### PR TITLE
Digital and Analog In / Out: Return and push interleaved samples and drop std::vector

### DIFF
--- a/examples/analog/CMakeLists.txt
+++ b/examples/analog/CMakeLists.txt
@@ -8,5 +8,8 @@ include_directories(
 	${CMAKE_SOURCE_DIR}/include
 )
 add_executable(${PROJECT_NAME} "main.cpp")
+add_executable(getSamples "getSamples.cpp")
+
 target_link_libraries(${PROJECT_NAME} libm2k)
+target_link_libraries(getSamples libm2k)
 

--- a/examples/analog/getSamples.cpp
+++ b/examples/analog/getSamples.cpp
@@ -1,0 +1,133 @@
+#include <iostream>
+#include <chrono>
+
+#include <math.h>
+#include <libm2k/m2k.hpp>
+#include <libm2k/contextbuilder.hpp>
+#include <libm2k/analog/m2kpowersupply.hpp>
+#include <libm2k/analog/m2kanalogin.hpp>
+#include <libm2k/analog/m2kanalogout.hpp>
+
+using namespace std;
+using namespace libm2k;
+using namespace libm2k::analog;
+using namespace libm2k::devices;
+#define M_PI 3.14
+int main(int argc, char* argv[])
+{
+	M2k *ctx = m2kOpen();
+	ctx->calibrateADC();
+	ctx->calibrateDAC();
+
+	M2kAnalogIn *ain = ctx->getAnalogIn();
+	M2kAnalogOut *aout = ctx->getAnalogOut();
+	M2kHardwareTrigger *trig = ain->getTrigger();
+
+	// Setup analog in
+
+	// Play with enable/disable channels to see changes in all the getSamples methods.
+	ain->enableChannel(0, false);
+	ain->enableChannel(1, true);
+
+
+	ain->setSampleRate(100000);
+	ain->setRange((ANALOG_IN_CHANNEL)0,-10.0,10.0); // nu are idxchannel
+	ain->setRange((ANALOG_IN_CHANNEL)1,PLUS_MINUS_25V);
+
+	// setup analog trigger
+	trig->setAnalogSource(CHANNEL_1);
+	trig->setAnalogCondition(0,RISING_EDGE);
+	trig->setAnalogLevel(0, 0.5);
+	trig->setAnalogDelay(0);
+	trig->setAnalogMode(0,ALWAYS);
+
+	// setup analog output
+	aout->setSampleRate(0,750000);
+	aout->setSampleRate(1,750000);
+	aout->enableChannel(0, true);
+	aout->enableChannel(1, true);
+
+	// create output buffers
+	vector<double> ch1;
+	vector<double> ch2;
+
+	//  Push 3V constant on the first channel and 4V constant on the second one
+	for(int i=0;i<1024;i++)
+	{
+		ch1.push_back(3.0);
+		ch2.push_back(4.0);
+	}
+
+	aout->setCyclic(true);
+	aout->push({ch1, ch2});
+
+
+	auto d = ain->getSamples(10);
+
+	// Use all the provided methods to acquire samples for the analog side
+	// Compare the values and the time
+
+	auto t1 = std::chrono::high_resolution_clock::now();
+	// Get Voltage for all the enabled channels
+	std::vector<std::vector<double>> d1 = ain->getSamples(10);
+	auto t2 = std::chrono::high_resolution_clock::now();
+	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>( t2 - t1 ).count();
+	std::cout << "\nTime - get V - std vector: " << duration << "ms" <<  endl;
+
+
+	auto t3 = std::chrono::high_resolution_clock::now();
+	// Get Raw values for all the enabled channels
+	std::vector<std::vector<double>> d2 = ain->getSamplesRaw(10);
+	auto t4 = std::chrono::high_resolution_clock::now();
+	duration = std::chrono::duration_cast<std::chrono::milliseconds>( t4 - t3 ).count();
+	std::cout << "\nTime - get raw - std vector: " << duration << "ms" <<  endl;
+
+
+	auto t5 = std::chrono::high_resolution_clock::now();
+	// Get Voltage Interleaved for all the enabled channels
+	double *d3 = ain->getSamplesInterleaved(10);
+	auto t6 = std::chrono::high_resolution_clock::now();
+	duration = std::chrono::duration_cast<std::chrono::milliseconds>( t6 - t5 ).count();
+	std::cout << "\nTime - get V pointer: " << duration << "ms" <<  endl;
+
+
+	auto t7 = std::chrono::high_resolution_clock::now();
+	// Get Raw interleaved for ALL the channels
+	// This is the most efficient, it does not make any copies or processing
+	short *d4 = ain->getSamplesRawInterleaved(10);
+	auto t8 = std::chrono::high_resolution_clock::now();
+	duration = std::chrono::duration_cast<std::chrono::milliseconds>( t8 - t7 ).count();
+	std::cout << "\nTime - get raw pointer: " << duration << "ms" << endl;
+
+	cout << endl <<  "\nVoltage CHANNEL1" << endl;
+
+	for (int i = 0 ; i < 10; i++) {
+		double val = d1[0][i];
+		cout << val << " ";
+	}
+
+	cout << endl << "\nRaw CHANNEL1" << endl;
+
+	for (int i = 0 ; i < 10; i++) {
+		double val = d2[0][i];
+		cout << val << " ";
+	}
+
+	cout <<  endl << "\nVoltage CHANNEL1 and CHANNEL2 interleaved" << endl;
+
+	for (int i = 0 ; i < 10; i++) {
+		double val = d3[i];
+		cout << val << " ";
+	}
+
+	cout <<  endl << "\nRaw CHANNEL1 and CHANNEL2 interleaved" << endl;
+
+	for (int i = 0 ; i < 10; i++) {
+		short val = d4[i];
+		cout << val << " ";
+	}
+
+	aout->stop();
+	delete [] d3;
+	deviceClose(ctx);
+}

--- a/include/libm2k/analog/genericanalogin.hpp
+++ b/include/libm2k/analog/genericanalogin.hpp
@@ -35,6 +35,9 @@ public:
 	virtual std::vector<std::vector<double>> getSamples(unsigned int nb_samples);
 	virtual std::vector<std::vector<double>> getSamplesRaw(unsigned int nb_samples);
 
+	double* getSamplesInterleaved(unsigned int nb_samples);
+	short* getSamplesRawInterleaved(unsigned int nb_samples);
+
 	double getSampleRate();
 	double getSampleRate(unsigned int);
 	double setSampleRate(double sampleRate);

--- a/include/libm2k/analog/genericanalogout.hpp
+++ b/include/libm2k/analog/genericanalogout.hpp
@@ -46,8 +46,12 @@ public:
 	void setCyclic(unsigned int chn, bool en);
 	bool getCyclic(unsigned int chn);
 
-	void push(std::vector<double> const &data, unsigned int chn_idx = 0);
-	void push(std::vector<short> const &data, unsigned int chn_idx = 0);
+	void push(unsigned int chn_idx, std::vector<double> const &data);
+	void pushRaw(unsigned int chn_idx, std::vector<short> const &data);
+
+	void push(unsigned int chn_idx, double *data, unsigned int nb_samples);
+	void pushRaw(unsigned int chn_idx, short *data, unsigned int nb_samples);
+
 	void stop();
 
 	std::string getName();

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -39,6 +39,9 @@ public:
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples);
 	std::vector<std::vector<double>> getSamplesRaw(unsigned int nb_samples);
 
+	double* getSamplesInterleaved(unsigned int nb_samples);
+	short* getSamplesRawInterleaved(unsigned int nb_samples);
+
 	double processSample(int16_t sample, unsigned int channel);
 
 	short getVoltageRaw(unsigned int ch);
@@ -49,6 +52,9 @@ public:
 
 	std::vector<short> getVoltageRaw();
 	std::vector<double> getVoltage();
+
+	short *getVoltageRawP();
+	double *getVoltageP();
 
 	double getScalingFactor(libm2k::analog::ANALOG_IN_CHANNEL ch);
 

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -69,9 +69,15 @@ public:
 	void setDacCalibVlsb(unsigned int chn, double vlsb);
 
 	void push(unsigned int chnIdx, std::vector<double> const &data);
-	void push(unsigned int chnIdx, std::vector<short> const &data);
+	void pushRaw(unsigned int chnIdx, std::vector<short> const &data);
 	void push(std::vector<std::vector<double>> const &data);
-	void push(std::vector<std::vector<short>> const &data);
+	void pushRaw(std::vector<std::vector<short>> const &data);
+
+	void push(unsigned int chnIdx, double *data, unsigned int nb_samples);
+	void pushRaw(unsigned int chnIdx, short *data, unsigned int nb_samples);
+	void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples_per_channel);
+	void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples_per_channel);
+
 	void stop();
 	void stop(unsigned int chn);
 

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -51,9 +51,11 @@ public:
 	DIO_LEVEL getValueRaw(unsigned int index);
 
 	void push(std::vector<unsigned short> const &data);
+	void push(unsigned short *data, unsigned int nb_samples);
 	void stop();
 
 	std::vector<unsigned short> getSamples(unsigned int nb_samples);
+	unsigned short *getSamplesP(unsigned int nb_samples);
 
 	/* Enable/disable TX channels only*/
 	void enableChannel(unsigned int index, bool enable);

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -46,6 +46,9 @@ public:
 	std::vector<unsigned short> getSamples(unsigned int nb_samples);
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process);
+	double *getSamplesInterleaved(unsigned int nb_samples,
+					std::function<double(int16_t, unsigned int)> process);
+	short *getSamplesRawInterleaved(unsigned int nb_samples);
 	void stop();
 	void setCyclic(bool enable);
 private:

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -42,6 +42,10 @@ public:
 		bool cyclic = true, bool multiplex = false);
 	void push(std::vector<double> const &data, unsigned int channel = 0, bool cyclic = true);
 	void push(std::vector<std::vector<short>> const &data);
+
+	void push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
+	void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
+
 	void setChannels(std::vector<Channel*> channels);
 	std::vector<unsigned short> getSamples(unsigned int nb_samples);
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples,

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -36,10 +36,13 @@ class Buffer
 public:
 	Buffer(struct iio_device *dev);
 	~Buffer();
+
 	void push(std::vector<short> const &data, unsigned int channel = 0,
 		bool cyclic = true, bool multiplex = false);
 	void push(std::vector<unsigned short> const &data, unsigned int channel = 0,
 		bool cyclic = true, bool multiplex = false);
+	void push(unsigned short *data, unsigned int channel, unsigned int nb_samples,
+		  bool cyclic = true, bool multiplex = false);
 	void push(std::vector<double> const &data, unsigned int channel = 0, bool cyclic = true);
 	void push(std::vector<std::vector<short>> const &data);
 
@@ -48,6 +51,8 @@ public:
 
 	void setChannels(std::vector<Channel*> channels);
 	std::vector<unsigned short> getSamples(unsigned int nb_samples);
+	unsigned short* getSamplesP(unsigned int nb_samples);
+
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process);
 	double *getSamplesInterleaved(unsigned int nb_samples,

--- a/include/libm2k/utils/channel.hpp
+++ b/include/libm2k/utils/channel.hpp
@@ -44,6 +44,9 @@ public:
 	void write(struct iio_buffer* buffer, std::vector<short> const &data);
 	void write(struct iio_buffer* buffer, std::vector<unsigned short> const &data);
 	void write(struct iio_buffer* buffer, std::vector<double> const &data);
+	void write(struct iio_buffer* buffer, double *data, unsigned int nb_samples);
+	void write(struct iio_buffer* buffer, short *data, unsigned int nb_samples);
+
 	void convert(int16_t *avg, int16_t *src);
 	void convert(double *avg, int16_t *src);
 

--- a/include/libm2k/utils/channel.hpp
+++ b/include/libm2k/utils/channel.hpp
@@ -46,6 +46,7 @@ public:
 	void write(struct iio_buffer* buffer, std::vector<double> const &data);
 	void write(struct iio_buffer* buffer, double *data, unsigned int nb_samples);
 	void write(struct iio_buffer* buffer, short *data, unsigned int nb_samples);
+	void write(struct iio_buffer* buffer, unsigned short *data, unsigned int nb_samples);
 
 	void convert(int16_t *avg, int16_t *src);
 	void convert(double *avg, int16_t *src);

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -44,6 +44,9 @@ public:
 	virtual std::vector<unsigned short> getSamples(unsigned int nb_samples);
 	virtual std::vector<std::vector<double> > getSamples(unsigned int nb_samples,
 					std::function<double (int16_t, unsigned int)> process);
+	virtual double *getSamplesInterleaved(unsigned int nb_samples,
+					std::function<double (int16_t, unsigned int)> process);
+	virtual short *getSamplesRawInterleaved(unsigned int nb_samples);
 
 private:
 	class DeviceInImpl;

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -42,6 +42,7 @@ public:
 	virtual ~DeviceIn();
 
 	virtual std::vector<unsigned short> getSamples(unsigned int nb_samples);
+	virtual unsigned short* getSamplesP(unsigned int nb_samples);
 	virtual std::vector<std::vector<double> > getSamples(unsigned int nb_samples,
 					std::function<double (int16_t, unsigned int)> process);
 	virtual double *getSamplesInterleaved(unsigned int nb_samples,

--- a/include/libm2k/utils/deviceout.hpp
+++ b/include/libm2k/utils/deviceout.hpp
@@ -46,6 +46,8 @@ public:
 	virtual void push(std::vector<unsigned short> const &data, unsigned int channel,
 		bool cyclic = true, bool multiplex = false);
 	virtual void push(std::vector<double> const &data, unsigned int channel, bool cyclic = true);
+	virtual void push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
+	virtual void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
 	virtual void stop();
 
 private:

--- a/include/libm2k/utils/deviceout.hpp
+++ b/include/libm2k/utils/deviceout.hpp
@@ -45,6 +45,8 @@ public:
 		bool cyclic = true, bool multiplex = false);
 	virtual void push(std::vector<unsigned short> const &data, unsigned int channel,
 		bool cyclic = true, bool multiplex = false);
+	virtual void push(unsigned short *data, unsigned int channel, unsigned int nb_samples,
+		  bool cyclic = true, bool multiplex = false);
 	virtual void push(std::vector<double> const &data, unsigned int channel, bool cyclic = true);
 	virtual void push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
 	virtual void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);

--- a/src/analog/genericanalogin.cpp
+++ b/src/analog/genericanalogin.cpp
@@ -37,6 +37,16 @@ std::vector<std::vector<double> > GenericAnalogIn::getSamplesRaw(unsigned int nb
 	return m_pimpl->getSamples(nb_samples, false);
 }
 
+double *GenericAnalogIn::getSamplesInterleaved(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesInterleaved(nb_samples, true);
+}
+
+short *GenericAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesRawInterleaved(nb_samples);
+}
+
 std::vector<std::vector<double>> GenericAnalogIn::getSamples(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples, true);

--- a/src/analog/genericanalogout.cpp
+++ b/src/analog/genericanalogout.cpp
@@ -72,14 +72,24 @@ bool GenericAnalogOut::getCyclic(unsigned int chn)
 	return m_pimpl->getCyclic(chn);
 }
 
-void GenericAnalogOut::push(std::vector<short> const &data, unsigned int chn_idx)
+void GenericAnalogOut::pushRaw(unsigned int chn_idx, std::vector<short> const &data)
 {
 	m_pimpl->push(data, chn_idx);
 }
 
-void GenericAnalogOut::push(std::vector<double> const &data, unsigned int chn_idx)
+void GenericAnalogOut::push(unsigned int chn_idx, std::vector<double> const &data)
 {
 	m_pimpl->push(data, chn_idx);
+}
+
+void GenericAnalogOut::push(unsigned int chn_idx, double *data, unsigned int nb_samples)
+{
+	m_pimpl->push(data, chn_idx, nb_samples);
+}
+
+void GenericAnalogOut::pushRaw(unsigned int chn_idx, short *data, unsigned int nb_samples)
+{
+	m_pimpl->push(data, chn_idx, nb_samples);
 }
 
 void GenericAnalogOut::stop()

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -123,6 +123,16 @@ std::vector<std::vector<double> > M2kAnalogIn::getSamplesRaw(unsigned int nb_sam
 	return m_pimpl->getSamples(nb_samples, false);
 }
 
+double *M2kAnalogIn::getSamplesInterleaved(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesInterleaved(nb_samples, true);
+}
+
+short *M2kAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesRawInterleaved(nb_samples);
+}
+
 double M2kAnalogIn::processSample(int16_t sample, unsigned int channel)
 {
 	return m_pimpl->processSample(sample, channel);
@@ -156,6 +166,16 @@ double M2kAnalogIn::getVoltage(ANALOG_IN_CHANNEL ch)
 std::vector<double> M2kAnalogIn::getVoltage()
 {
 	return m_pimpl->getVoltage();
+}
+
+short *M2kAnalogIn::getVoltageRawP()
+{
+	return m_pimpl->getVoltageRawP();
+}
+
+double *M2kAnalogIn::getVoltageP()
+{
+	return m_pimpl->getVoltageP();
 }
 
 double M2kAnalogIn::getScalingFactor(ANALOG_IN_CHANNEL ch)

--- a/src/analog/m2kanalogout.cpp
+++ b/src/analog/m2kanalogout.cpp
@@ -124,9 +124,9 @@ void M2kAnalogOut::setDacCalibVlsb(unsigned int chn_idx, double vlsb)
 	m_pimpl->setDacCalibVlsb(chn_idx, vlsb);
 }
 
-void M2kAnalogOut::push(unsigned int chnIdx, std::vector<short> const &data)
+void M2kAnalogOut::pushRaw(unsigned int chnIdx, std::vector<short> const &data)
 {
-	m_pimpl->push(data, chnIdx);
+	m_pimpl->pushRaw(data, chnIdx);
 }
 
 void M2kAnalogOut::push(unsigned int chnIdx, std::vector<double> const &data)
@@ -134,9 +134,29 @@ void M2kAnalogOut::push(unsigned int chnIdx, std::vector<double> const &data)
 	m_pimpl->push(data, chnIdx);
 }
 
-void M2kAnalogOut::push(std::vector<std::vector<short>> const &data)
+void M2kAnalogOut::pushRaw(std::vector<std::vector<short>> const &data)
 {
-	m_pimpl->push(data);
+	m_pimpl->pushRaw(data);
+}
+
+void M2kAnalogOut::push(unsigned int chnIdx, double *data, unsigned int nb_samples)
+{
+	m_pimpl->push(chnIdx, data, nb_samples);
+}
+
+void M2kAnalogOut::pushRaw(unsigned int chnIdx, short *data, unsigned int nb_samples)
+{
+	m_pimpl->pushRaw(chnIdx, data, nb_samples);
+}
+
+void M2kAnalogOut::pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples_per_channel)
+{
+	m_pimpl->push(data, nb_channels, nb_samples_per_channel);
+}
+
+void M2kAnalogOut::pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples_per_channel)
+{
+	m_pimpl->pushRaw(data, nb_channels, nb_samples_per_channel);
 }
 
 void M2kAnalogOut::push(std::vector<std::vector<double>> const &data)

--- a/src/analog/private/genericanalogin_impl.cpp
+++ b/src/analog/private/genericanalogin_impl.cpp
@@ -54,6 +54,17 @@ public:
 		return DeviceIn::getSamples(nb_samples, processSample);
 	}
 
+	double *getSamplesInterleaved(unsigned int nb_samples,
+						bool processed = false)
+	{
+		return DeviceIn::getSamplesInterleaved(nb_samples, processSample);
+	}
+
+	short *getSamplesRawInterleaved(unsigned int nb_samples)
+	{
+		return DeviceIn::getSamplesRawInterleaved(nb_samples);
+	}
+
 	double getSampleRate()
 	{
 		return getDoubleValue("sampling_frequency");

--- a/src/analog/private/genericanalogout_impl.cpp
+++ b/src/analog/private/genericanalogout_impl.cpp
@@ -101,6 +101,16 @@ public:
 		DeviceOut::push(data, chn_idx, getCyclic(chn_idx));
 	}
 
+	void push(short *data, unsigned int chn_idx, unsigned int nb_samples)
+	{
+		DeviceOut::push(data, chn_idx, nb_samples, getCyclic(chn_idx));
+	}
+
+	void push(double *data, unsigned int chn_idx, unsigned int nb_samples)
+	{
+		DeviceOut::push(data, chn_idx, nb_samples, getCyclic(chn_idx));
+	}
+
 	void stop()
 	{
 		DeviceOut::stop();

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -177,6 +177,27 @@ public:
 		return samps;
 	}
 
+	double *getSamplesInterleaved(unsigned int nb_samples,
+						bool processed = false)
+	{
+		if (processed) {
+			m_need_processing = true;
+		}
+		m_samplerate = getSampleRate();
+		auto fp = std::bind(&M2kAnalogInImpl::processSample, this, _1, _2);
+		auto samps = DeviceIn::getSamplesInterleaved(nb_samples, fp);
+		if (processed) {
+			m_need_processing = false;
+		}
+		return samps;
+	}
+
+	short *getSamplesRawInterleaved(unsigned int nb_samples)
+	{
+		m_samplerate = getSampleRate();
+		return DeviceIn::getSamplesRawInterleaved(nb_samples);
+	}
+
 	double processSample(int16_t sample, unsigned int channel)
 	{
 		if (m_need_processing) {
@@ -243,6 +264,12 @@ public:
 		return avgs;
 	}
 
+	short *getVoltageRawP()
+	{
+		std::vector<short> avgs = getVoltageRaw();
+		return avgs.data();
+	}
+
 	double getVoltage(unsigned int ch)
 	{
 		ANALOG_IN_CHANNEL chn = static_cast<ANALOG_IN_CHANNEL>(ch);
@@ -292,6 +319,12 @@ public:
 			enableChannel(i, enabled.at(i));
 		}
 		return avgs;
+	}
+
+	double *getVoltageP()
+	{
+		std::vector<double> avgs = getVoltage();
+		return avgs.data();
 	}
 
 	double getScalingFactor(ANALOG_IN_CHANNEL ch)

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -95,9 +95,14 @@ DIO_LEVEL M2kDigital::getValueRaw(unsigned int index)
 	return m_pimpl->getValueRaw(index);
 }
 
-void M2kDigital::push(std::vector<unsigned short> const &data)
+void M2kDigital::push(const std::vector<unsigned short> &data)
 {
 	m_pimpl->push(data);
+}
+
+void M2kDigital::push(unsigned short *data, unsigned int nb_samples)
+{
+	m_pimpl->push(data, nb_samples);
 }
 
 void M2kDigital::stop()
@@ -108,6 +113,11 @@ void M2kDigital::stop()
 std::vector<unsigned short> M2kDigital::getSamples(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples);
+}
+
+unsigned short *M2kDigital::getSamplesP(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesP(nb_samples);
 }
 
 void M2kDigital::enableChannel(unsigned int index, bool enable)

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -209,6 +209,14 @@ public:
 		m_dev_write->push(data, 0, getCyclic(), true);
 	}
 
+	void push(unsigned short *data, unsigned int nb_samples)
+	{
+		if (!anyChannelEnabled(DIO_OUTPUT)) {
+			throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No TX channel enabled.");
+		}
+		m_dev_write->push(data, 0, nb_samples, getCyclic(), true);
+	}
+
 	void stop()
 	{
 		m_dev_write->stop();
@@ -227,6 +235,25 @@ public:
 			 * nearest multiple.*/
 			nb_samples = ((nb_samples + 3) / 4) * 4;
 			return m_dev_read->getSamples(nb_samples);
+
+		} __catch (exception_type &e) {
+			throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: " + string(e.what()));
+		}
+	}
+
+	unsigned short* getSamplesP(int nb_samples)
+	{
+		__try {
+			if (!anyChannelEnabled(DIO_INPUT)) {
+				throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No RX channel enabled.");
+
+			}
+
+			/* There is a restriction in the HDL that the buffer size must
+			 * be a multiple of 8 bytes (4x 16-bit samples). Round up to the
+			 * nearest multiple.*/
+			nb_samples = ((nb_samples + 3) / 4) * 4;
+			return m_dev_read->getSamplesP(nb_samples);
 
 		} __catch (exception_type &e) {
 			throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: " + string(e.what()));

--- a/src/private/m2kcalibration_impl.cpp
+++ b/src/private/m2kcalibration_impl.cpp
@@ -486,7 +486,7 @@ out_cleanup:
 			m_m2k_dac->enableChannel(1, true);
 
 			m_m2k_dac->setCyclic(true);
-			m_m2k_dac->push(vec_data_all);
+			m_m2k_dac->pushRaw(vec_data_all);
 
 			m_m2k_dac->setSyncedDma(false);
 			m_m2k_fabric->setBoolValue(0, false, "powerdown", true);
@@ -569,7 +569,7 @@ out_cleanup:
 			m_m2k_dac->enableChannel(1, true);
 
 			m_m2k_dac->setCyclic(true);
-			m_m2k_dac->push(vec_data_all);
+			m_m2k_dac->pushRaw(vec_data_all);
 
 			m_m2k_dac->setSyncedDma(false);
 			m_m2k_fabric->setBoolValue(0, false, "powerdown", true);

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -56,6 +56,12 @@ void Buffer::push(std::vector<short> const &data, unsigned int channel,
     m_pimpl->push(data, channel, cyclic, multiplex);
 }
 
+void Buffer::push(unsigned short *data, unsigned int channel, unsigned int nb_samples,
+		  bool cyclic, bool multiplex)
+{
+	m_pimpl->push(data, channel, nb_samples, cyclic, multiplex);
+}
+
 void Buffer::push(std::vector<double> const &data, unsigned int channel, bool cyclic)
 {
 	m_pimpl->push(data, channel, cyclic);
@@ -74,6 +80,11 @@ void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bo
 std::vector<unsigned short> Buffer::getSamples(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples);
+}
+
+unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesP(nb_samples);
 }
 
 std::vector<std::vector<double>> Buffer::getSamples(unsigned int nb_samples,

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -61,6 +61,16 @@ void Buffer::push(std::vector<double> const &data, unsigned int channel, bool cy
 	m_pimpl->push(data, channel, cyclic);
 }
 
+void Buffer::push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+{
+	m_pimpl->push(data, channel, nb_samples, cyclic);
+}
+
+void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+{
+	m_pimpl->push(data, channel, nb_samples, cyclic);
+}
+
 std::vector<unsigned short> Buffer::getSamples(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples);

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -72,6 +72,16 @@ std::vector<std::vector<double>> Buffer::getSamples(unsigned int nb_samples,
 	return m_pimpl->getSamples(nb_samples, process);
 }
 
+double *Buffer::getSamplesInterleaved(unsigned int nb_samples, std::function<double (int16_t, unsigned int)> process)
+{
+	return m_pimpl->getSamplesInterleaved(nb_samples, process);
+}
+
+short *Buffer::getSamplesRawInterleaved(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesRawInterleaved(nb_samples);
+}
+
 void Buffer::stop()
 {
 	m_pimpl->stop();

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -95,6 +95,16 @@ void Channel::write(struct iio_buffer* buffer, std::vector<double> const &data)
 	m_pimpl->write(buffer, data);
 }
 
+void Channel::write(struct iio_buffer* buffer, double *data, unsigned int nb_samples)
+{
+	m_pimpl->write(buffer, data, nb_samples);
+}
+
+void Channel::write(struct iio_buffer* buffer, short *data, unsigned int nb_samples)
+{
+	m_pimpl->write(buffer, data, nb_samples);
+}
+
 void Channel::convert(int16_t *avg, int16_t *src)
 {
 	m_pimpl->convert(avg, src);

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -105,6 +105,11 @@ void Channel::write(struct iio_buffer* buffer, short *data, unsigned int nb_samp
 	m_pimpl->write(buffer, data, nb_samples);
 }
 
+void Channel::write(struct iio_buffer* buffer, unsigned short *data, unsigned int nb_samples)
+{
+	m_pimpl->write(buffer, data, nb_samples);
+}
+
 void Channel::convert(int16_t *avg, int16_t *src)
 {
 	m_pimpl->convert(avg, src);

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -41,6 +41,11 @@ std::vector<unsigned short> DeviceIn::getSamples(unsigned int nb_samples)
 	return m_pimpl->getSamples(nb_samples);
 }
 
+unsigned short *DeviceIn::getSamplesP(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesP(nb_samples);
+}
+
 std::vector<std::vector<double> > DeviceIn::getSamples(unsigned int nb_samples,
 				std::function<double(int16_t, unsigned int)> process)
 {

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -46,3 +46,14 @@ std::vector<std::vector<double> > DeviceIn::getSamples(unsigned int nb_samples,
 {
 	return m_pimpl->getSamples(nb_samples, process);
 }
+
+double *DeviceIn::getSamplesInterleaved(unsigned int nb_samples,
+				std::function<double(int16_t, unsigned int)> process)
+{
+	return m_pimpl->getSamplesInterleaved(nb_samples, process);
+}
+
+short *DeviceIn::getSamplesRawInterleaved(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesRawInterleaved(nb_samples);
+}

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -53,6 +53,16 @@ void DeviceOut::push(std::vector<double> const &data, unsigned int channel, bool
 	m_pimpl->push(data, channel, cyclic);
 }
 
+void DeviceOut::push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+{
+	m_pimpl->push(data, channel, nb_samples, cyclic);
+}
+
+void DeviceOut::push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+{
+	m_pimpl->push(data, channel, nb_samples, cyclic);
+}
+
 void DeviceOut::stop()
 {
 	m_pimpl->stop();

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -48,6 +48,12 @@ void DeviceOut::push(std::vector<unsigned short> const &data, unsigned int chann
 	m_pimpl->push(data, channel, cyclic, multiplex);
 }
 
+void DeviceOut::push(unsigned short *data, unsigned int channel, unsigned int nb_samples,
+		  bool cyclic, bool multiplex)
+{
+	m_pimpl->push(data, channel, nb_samples, cyclic, multiplex);
+}
+
 void DeviceOut::push(std::vector<double> const &data, unsigned int channel, bool cyclic)
 {
 	m_pimpl->push(data, channel, cyclic);

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -89,11 +89,11 @@ public:
 			if (!multiplex) {
 					m_channel_list.at(channel)->write(m_buffer, data, nb_samples);
 			} else {
-				int *p_dat;
+				short *p_dat;
 				int i = 0;
 
-				for (p_dat = (int *)iio_buffer_start(m_buffer); (p_dat < iio_buffer_end(m_buffer));
-				     (unsigned int*)p_dat++, i++) {
+				for (p_dat = (short *)iio_buffer_start(m_buffer); (p_dat < iio_buffer_end(m_buffer));
+				     (unsigned short*)p_dat++, i++) {
 					*p_dat = data[i];
 				}
 

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -193,6 +193,64 @@ public:
 		}
 	}
 
+	void push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+	{
+		if (Utils::getIioDeviceDirection(m_dev) == INPUT) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		}
+
+		destroy();
+
+		/* If the data vector is empty, then it means we want
+		 * to remove what was pushed earlier to the device, so
+		 * we destroy the buffer */
+		if (nb_samples == 0) {
+			return;
+		}
+
+		m_buffer = iio_device_create_buffer(m_dev, nb_samples, cyclic);
+
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Can't create the TX buffer");
+		}
+
+		if (channel < m_channel_list.size() ) {
+			m_channel_list.at(channel)->write(m_buffer, data, nb_samples);
+			iio_buffer_push(m_buffer);
+		} else {
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		}
+	}
+
+	void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+	{
+		if (Utils::getIioDeviceDirection(m_dev) == INPUT) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		}
+
+		destroy();
+
+		/* If the data vector is empty, then it means we want
+		 * to remove what was pushed earlier to the device, so
+		 * we destroy the buffer */
+		if (nb_samples == 0) {
+			return;
+		}
+
+		m_buffer = iio_device_create_buffer(m_dev, nb_samples, cyclic);
+
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Can't create the TX buffer");
+		}
+
+		if (channel < m_channel_list.size() ) {
+			m_channel_list.at(channel)->write(m_buffer, data, nb_samples);
+			iio_buffer_push(m_buffer);
+		} else {
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		}
+	}
+
 	std::vector<unsigned short> getSamples(int nb_samples)
 	{
 		if (Utils::getIioDeviceDirection(m_dev) == OUTPUT) {

--- a/src/utils/private/channel_impl.cpp
+++ b/src/utils/private/channel_impl.cpp
@@ -172,6 +172,34 @@ public:
 		}
 	}
 
+	void write(struct iio_buffer* buffer, double *data, unsigned int nb_samples)
+	{
+		if (!m_channel) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Can not find associated channel");
+		}
+
+		size_t ret = iio_channel_write(m_channel, buffer, data,
+					       nb_samples * sizeof(double));
+
+		if (ret == 0) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: could not write; result is 0 bytes");
+		}
+	}
+
+	void write(struct iio_buffer* buffer, short *data, unsigned int nb_samples)
+	{
+		if (!m_channel) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Can not find associated channel");
+		}
+
+		size_t ret = iio_channel_write(m_channel, buffer, data,
+					       nb_samples * sizeof(short));
+
+		if (ret == 0) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: could not write; result is 0 bytes");
+		}
+	}
+
 	void convert(int16_t *avg, int16_t *src)
 	{
 		if (!m_channel) {

--- a/src/utils/private/channel_impl.cpp
+++ b/src/utils/private/channel_impl.cpp
@@ -200,6 +200,20 @@ public:
 		}
 	}
 
+	void write(struct iio_buffer* buffer, unsigned short *data, unsigned int nb_samples)
+	{
+		if (!m_channel) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Can not find associated channel");
+		}
+
+		size_t ret = iio_channel_write(m_channel, buffer, data,
+					       nb_samples * sizeof(unsigned short));
+
+		if (ret == 0) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: could not write; result is 0 bytes");
+		}
+	}
+
 	void convert(int16_t *avg, int16_t *src)
 	{
 		if (!m_channel) {

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -117,6 +117,16 @@ public:
 
 	}
 
+	unsigned short* getSamplesP(unsigned int nb_samples)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		return m_buffer->getSamplesP(nb_samples);
+
+	}
+
 	std::vector<std::vector<double> > getSamples(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process)
 	{

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -127,6 +127,25 @@ public:
 		return m_buffer->getSamples(nb_samples, process);
 	}
 
+	double *getSamplesInterleaved(unsigned int nb_samples,
+					std::function<double(int16_t, unsigned int)> process)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		return m_buffer->getSamplesInterleaved(nb_samples, process);
+	}
+
+	short *getSamplesRawInterleaved(unsigned int nb_samples)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		return m_buffer->getSamplesRawInterleaved(nb_samples);
+	}
+
 private:
 	struct iio_context *m_context;
 	struct iio_device *m_dev;

--- a/src/utils/private/deviceout_impl.cpp
+++ b/src/utils/private/deviceout_impl.cpp
@@ -127,6 +127,17 @@ public:
 		m_buffer->push(data, channel, cyclic, multiplex);
 	}
 
+
+	void push(unsigned short *data, unsigned int channel, unsigned int nb_samples,
+			  bool cyclic, bool multiplex)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_RUNTIME_ERROR, "Device: Can not push; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		m_buffer->push(data, channel, nb_samples, cyclic, multiplex);
+	}
+
 	void push(std::vector<double> const &data, unsigned int channel, bool cyclic = true)
 	{
 		if (!m_buffer) {

--- a/src/utils/private/deviceout_impl.cpp
+++ b/src/utils/private/deviceout_impl.cpp
@@ -136,6 +136,24 @@ public:
 		m_buffer->push(data, channel, cyclic);
 	}
 
+	void push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_RUNTIME_ERROR, "Device: Can not push; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		m_buffer->push(data, channel, nb_samples, cyclic);
+	}
+
+	void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_RUNTIME_ERROR, "Device: Can not push; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		m_buffer->push(data, channel, nb_samples, cyclic);
+	}
+
 	void stop()
 	{
 		if (m_buffer) {


### PR DESCRIPTION
-Add methods for push and getSamples which accept raw pointers. 
This is useful in scenarios where std libraries are not available.

-Add methods which send and get interleaved data. 

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>