### PR TITLE
CMakeLists.txt: Fix SWIG detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,13 +42,8 @@ if (ENABLE_DOC)
     add_subdirectory(doc)
 endif()
 
-FIND_PACKAGE(SWIG)
-if (NOT SWIG_FOUND)
-	set(ENABLE_PYTHON OFF)
-endif()
-
-if (NOT SWIG_FOUND)
-	set(ENABLE_CSHARP OFF)
+if (ENABLE_PYTHON OR ENABLE_CSHARP)
+	FIND_PACKAGE(SWIG REQUIRED)
 endif()
 
 # build with LIBM2K_EXPORTS defined in order to export everything that is marked with LIBM2K_API.


### PR DESCRIPTION
Make sure the Configure/Generate step of CMake fails if SWIG is not found for Python or C# bindings.

The previous version disabled Python/C# if SWIG was not found. With this
changes, we make sure that if some bindings were required, those will be
built, not just ignored if SWIG is not found.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>