### PR TITLE
General: Add multiple fixes.

### DIFF
--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -264,7 +264,7 @@ public:
 		m_samplerate.at(1) = getSampleRate(1);
 
 		for (unsigned int i = 0; i < nb_samples; i++) {
-			raw_data_buffer.push_back(processSample(data[i], chnIdx, true));
+			raw_data_buffer.push_back(data[i]);
 		}
 		m_dac_devices.at(chnIdx)->push(raw_data_buffer, 0, getCyclic(chnIdx));
 
@@ -295,7 +295,7 @@ public:
 		m_samplerate.at(1) = getSampleRate(1);
 
 		for (unsigned int i = 0; i < nb_samples; i++) {
-			raw_data_buffer.push_back(processSample(data[i], chnIdx, false));
+			raw_data_buffer.push_back(processSample(data[i], chnIdx));
 		}
 		m_dac_devices.at(chnIdx)->push(raw_data_buffer, 0, getCyclic(chnIdx));
 
@@ -320,7 +320,7 @@ public:
 			size_t size = data.at(chn).size();
 			std::vector<short> raw_data_buffer = {};
 			for (unsigned int i = 0; i < size; i++) {
-				raw_data_buffer.push_back(processSample(data[chn][i], chn, true));
+				raw_data_buffer.push_back(data[chn][i]);
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 		}
@@ -341,7 +341,7 @@ public:
 		for (unsigned int chn = 0; chn < nb_channels; chn++) {
 			std::vector<short> raw_data_buffer = {};
 			for (unsigned int i = 0; i < nb_samples; i++) {
-				raw_data_buffer.push_back(processSample(data[chn + nb_channels * i], chn, true));
+				raw_data_buffer.push_back(data[chn + nb_channels * i]);
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 		}
@@ -367,7 +367,7 @@ public:
 			size_t size = data.at(chn).size();
 			std::vector<short> raw_data_buffer = {};
 			for (unsigned int i = 0; i < size; i++) {
-				raw_data_buffer.push_back(processSample(data[chn][i], chn, false));
+				raw_data_buffer.push_back(processSample(data[chn][i], chn));
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 			data_buffers.push_back(raw_data_buffer);
@@ -389,7 +389,7 @@ public:
 		for (unsigned int chn = 0; chn < nb_channels; chn++) {
 			std::vector<short> raw_data_buffer = {};
 			for (unsigned int i = 0; i < nb_samples; i++) {
-				raw_data_buffer.push_back(processSample(data[chn + nb_channels * i], chn, false));
+				raw_data_buffer.push_back(processSample(data[chn + nb_channels * i], chn));
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 			data_buffers.push_back(raw_data_buffer);
@@ -431,20 +431,11 @@ public:
 		m_dac_devices.at(chn)->stop();
 	}
 
-	short processSample(double value, unsigned int channel, bool raw)
+	short processSample(double value, unsigned int channel)
 	{
-		if (raw) {
-			short raw_value = value;
-			raw_value = (-raw_value) << 4;
-
-			// This should go away once channel type gets
-			// changed from 'le:S16/16>>0' to 'le:S12/16>>4'
-			return raw_value;
-		} else {
-			return convertVoltsToRaw(value, m_calib_vlsb.at(channel),
-						 getFilterCompensation(
-							 m_samplerate.at(channel)));
-		}
+		return convertVoltsToRaw(value, m_calib_vlsb.at(channel),
+					 getFilterCompensation(
+						 m_samplerate.at(channel)));
 	}
 
 	void enableChannel(unsigned int chnIdx, bool enable)

--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -258,14 +258,11 @@ public:
 		m_m2k_fabric->setBoolValue(chnIdx, false, "powerdown", true);
 		setSyncedDma(true, chnIdx);
 
-		std::vector<short> raw_data_buffer = {};
-
 		m_samplerate.at(0) = getSampleRate(0);
 		m_samplerate.at(1) = getSampleRate(1);
 
-		for (unsigned int i = 0; i < nb_samples; i++) {
-			raw_data_buffer.push_back(data[i]);
-		}
+		std::vector<short> raw_data_buffer(data, data + nb_samples);
+
 		m_dac_devices.at(chnIdx)->push(raw_data_buffer, 0, getCyclic(chnIdx));
 
 		setSyncedDma(false, chnIdx);
@@ -318,10 +315,7 @@ public:
 
 		for (unsigned int chn = 0; chn < data.size(); chn++) {
 			size_t size = data.at(chn).size();
-			std::vector<short> raw_data_buffer = {};
-			for (unsigned int i = 0; i < size; i++) {
-				raw_data_buffer.push_back(data[chn][i]);
-			}
+			std::vector<short> raw_data_buffer(data.at(chn).data(), data.at(chn).data() + size);
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 		}
 
@@ -340,8 +334,8 @@ public:
 
 		for (unsigned int chn = 0; chn < nb_channels; chn++) {
 			std::vector<short> raw_data_buffer = {};
-			for (unsigned int i = 0; i < nb_samples; i++) {
-				raw_data_buffer.push_back(data[chn + nb_channels * i]);
+			for (unsigned int i = 0, off = 0; i < nb_samples; i++, off += nb_channels) {
+				raw_data_buffer.push_back(data[chn + off]);
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 		}
@@ -388,8 +382,8 @@ public:
 
 		for (unsigned int chn = 0; chn < nb_channels; chn++) {
 			std::vector<short> raw_data_buffer = {};
-			for (unsigned int i = 0; i < nb_samples; i++) {
-				raw_data_buffer.push_back(processSample(data[chn + nb_channels * i], chn));
+			for (unsigned int i = 0, off = 0; i < nb_samples; i++, off += nb_channels) {
+				raw_data_buffer.push_back(processSample(data[chn + off], chn));
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
 			data_buffers.push_back(raw_data_buffer);

--- a/src/analog/private/m2khardwaretrigger_impl.cpp
+++ b/src/analog/private/m2khardwaretrigger_impl.cpp
@@ -272,7 +272,7 @@ public:
 		m_analog_channels[chnIdx]->setLongValue("trigger_level", static_cast<long long>(level));
 	}
 
-	int getAnalogLevel(unsigned int chnIdx)
+	double getAnalogLevel(unsigned int chnIdx)
 	{
 		if (chnIdx >= m_num_channels) {
 			throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -77,6 +77,10 @@ public:
 
 	~M2kDigitalImpl()
 	{
+		if (m_trigger) {
+			delete m_trigger;
+			m_trigger = NULL;
+		}
 	}
 
 	void syncDevice()


### PR DESCRIPTION
This PR introduces 3 fixes throughout the library:

- For the M2K Analog Out : The raw samples should not be altered at all before being pushed to the device. They should be pushed in the same state they were provided (only applies to raw values & pushRaw() methods) ( Related to issue #24 )
- M2K Digital : Delete the trigger object.
- M2K Hardware Trigger: Change the return type for the analog trigger level from int to double.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>