### PR TITLE
ContextBuilder: define API functions as inline in order to avoid multiple definition error.

### DIFF
--- a/include/libm2k/contextbuilder.hpp
+++ b/include/libm2k/contextbuilder.hpp
@@ -110,28 +110,19 @@ private:
 /**
 * @private
 */
-LIBM2K_API Context* deviceOpen()
-{
-	return ContextBuilder::deviceOpen();
-}
+LIBM2K_API Context* deviceOpen();
 
 
 /**
  * @private
  */
-LIBM2K_API Context* deviceOpen(const char* uri)
-{
-	return ContextBuilder::deviceOpen(uri);
-}
+LIBM2K_API Context* deviceOpen(const char* uri);
 
 
 /**
  * @private
  */
-LIBM2K_API Context* deviceOpen(struct iio_context* ctx, const char* uri)
-{
-	return ContextBuilder::deviceOpen(ctx, uri);
-}
+LIBM2K_API Context* deviceOpen(struct iio_context* ctx, const char* uri);
 
 
 /**
@@ -139,10 +130,7 @@ LIBM2K_API Context* deviceOpen(struct iio_context* ctx, const char* uri)
  * @param uri Describe the location of the context
  * @return M2k object
  */
-LIBM2K_API M2k* m2kOpen(const char* uri)
-{
-	return ContextBuilder::m2kOpen(uri);
-}
+LIBM2K_API M2k* m2kOpen(const char* uri);
 
 
 /**
@@ -151,30 +139,21 @@ LIBM2K_API M2k* m2kOpen(const char* uri)
  * @param uri Describe the location of the context
  * @return M2k object
  */
-LIBM2K_API M2k* m2kOpen(struct iio_context* ctx, const char* uri)
-{
-	return ContextBuilder::m2kOpen(ctx, uri);
-}
+LIBM2K_API M2k* m2kOpen(struct iio_context* ctx, const char* uri);
 
 
 /**
  *@brief Open a device based on its USB uri
  * @return  M2k object
  */
-LIBM2K_API M2k* m2kOpen()
-{
-	return ContextBuilder::m2kOpen();
-}
+LIBM2K_API M2k* m2kOpen();
 
 
 /**
  * @brief List all available devices
  * @return A list containing the available devices
  */
-LIBM2K_API std::vector<std::string> listDevices()
-{
-	return ContextBuilder::listDevices();
-}
+LIBM2K_API std::vector<std::string> listDevices();
 
 
 /**
@@ -182,19 +161,13 @@ LIBM2K_API std::vector<std::string> listDevices()
  * @param ctx The context to be destroyed
  * @param deinit If deinit is set to false, running contexts won't be affected
  */
-LIBM2K_API void deviceClose(Context* ctx, bool deinit = true)
-{
-	ContextBuilder::deviceClose(ctx, deinit);
-}
+LIBM2K_API void deviceClose(Context* ctx, bool deinit = true);
 
 
 /**
  * @brief Close all the devices
  */
-LIBM2K_API void deviceCloseAll()
-{
-	ContextBuilder::deviceCloseAll();
-}
+LIBM2K_API void deviceCloseAll();
 
 /**
  * @}

--- a/src/contextbuilder.cpp
+++ b/src/contextbuilder.cpp
@@ -222,3 +222,48 @@ DeviceTypes ContextBuilder::identifyDevice(iio_context *ctx)
 	}
 	return type;
 }
+
+Context *libm2k::devices::deviceOpen()
+{
+	return ContextBuilder::deviceOpen();
+}
+
+Context *libm2k::devices::deviceOpen(const char *uri)
+{
+	return ContextBuilder::deviceOpen(uri);
+}
+
+Context *libm2k::devices::deviceOpen(struct iio_context *ctx, const char *uri)
+{
+	return ContextBuilder::deviceOpen(ctx, uri);
+}
+
+M2k *libm2k::devices::m2kOpen(const char *uri)
+{
+	return ContextBuilder::m2kOpen(uri);
+}
+
+M2k *libm2k::devices::m2kOpen(struct iio_context *ctx, const char *uri)
+{
+	return ContextBuilder::m2kOpen(ctx, uri);
+}
+
+M2k *libm2k::devices::m2kOpen()
+{
+	return ContextBuilder::m2kOpen();
+}
+
+std::vector<std::string> libm2k::devices::listDevices()
+{
+	return ContextBuilder::listDevices();
+}
+
+void libm2k::devices::deviceClose(Context *ctx, bool deinit)
+{
+	ContextBuilder::deviceClose(ctx, deinit);
+}
+
+void libm2k::devices::deviceCloseAll()
+{
+	ContextBuilder::deviceCloseAll();
+}


### PR DESCRIPTION
In order to avoid multiple definition error, move ContextBuilder API implementation to source file.

Signed-off-by: Teo Perisanu <Teo.Perisanu@analog.com>