### PR TITLE
General: Change "devices" to "contexts"

### DIFF
--- a/bindings/csharp/examples/analog.cs
+++ b/bindings/csharp/examples/analog.cs
@@ -75,7 +75,7 @@ namespace examples
             }
 
             aout.stop();
-            libm2k.deviceClose(ctx);
+	    libm2k.contextClose(ctx);
         }
     }
 }

--- a/bindings/csharp/examples/digital.cs
+++ b/bindings/csharp/examples/digital.cs
@@ -45,7 +45,7 @@ namespace examples
                 Console.Write(val + " \n");
             }
             dig.stop();
-            libm2k.deviceClose(ctx);
+	    libm2k.contextClose(ctx);
         }
     }
 }

--- a/bindings/csharp/examples/powersupply.cs
+++ b/bindings/csharp/examples/powersupply.cs
@@ -30,7 +30,7 @@ namespace examples
 
             double voltage = ain.getVoltage(ANALOG_IN_CHANNEL.ANALOG_IN_CHANNEL_1);
             Console.WriteLine(voltage);
-            libm2k.deviceClose(ctx);
+	    libm2k.contextClose(ctx);
         }
     }
 }

--- a/bindings/csharp/examples/voltmeter.cs
+++ b/bindings/csharp/examples/voltmeter.cs
@@ -26,7 +26,7 @@ namespace examples
             double voltage = ain.getVoltage(ANALOG_IN_CHANNEL.ANALOG_IN_CHANNEL_1);
 
             Console.WriteLine(voltage);
-            libm2k.deviceClose(ctx);
+	    libm2k.contextClose(ctx);
         }
     }
 }

--- a/bindings/python/examples/analog.py
+++ b/bindings/python/examples/analog.py
@@ -47,4 +47,4 @@ for i in range(10): # gets 10 triggered samples then quits
     plt.show()
     time.sleep(0.1)
 
-libm2k.deviceClose(ctx)
+libm2k.contextClose(ctx)

--- a/bindings/python/examples/powersupply.py
+++ b/bindings/python/examples/powersupply.py
@@ -13,4 +13,4 @@ ain=ctx.getAnalogIn()
 ain.enableChannel(0,True)
 print(ain.getVoltage()[0])
 
-libm2k.deviceClose(ctx)
+libm2k.contextClose(ctx)

--- a/bindings/python/examples/voltmeter.py
+++ b/bindings/python/examples/voltmeter.py
@@ -13,4 +13,4 @@ ain.enableChannel(channel,True)
 print(ain.getVoltage()[channel])
 
 
-l.deviceClose(ctx)
+l.contextClose(ctx)

--- a/examples/analog/main.cpp
+++ b/examples/analog/main.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 using namespace libm2k;
 using namespace libm2k::analog;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 #define M_PI 3.14
 int main(int argc, char* argv[])
 {

--- a/examples/analog/main.cpp
+++ b/examples/analog/main.cpp
@@ -75,5 +75,5 @@ int main(int argc, char* argv[])
 	}
 	cout <<"end";
 	aout->stop();
-	deviceClose(ctx);
+	contextClose(ctx);
 }

--- a/examples/digital/main.cpp
+++ b/examples/digital/main.cpp
@@ -47,7 +47,7 @@ int main()
 		cout<<bitset<16>(val)<<endl;
 	}
 	dig->stop();
-	deviceClose(ctx);
+	contextClose(ctx);
 
 	return 0;
 }

--- a/examples/digital/main.cpp
+++ b/examples/digital/main.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace libm2k;
 using namespace libm2k::digital;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 #define N_BITS (4)
 

--- a/examples/powersupply/main.cpp
+++ b/examples/powersupply/main.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace libm2k;
 using namespace libm2k::analog;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 #define PS_CHANNEL (0)
 #define PS_VOLTAGE (1.7)

--- a/examples/voltmeter/main.cpp
+++ b/examples/voltmeter/main.cpp
@@ -7,7 +7,7 @@
 using namespace std;
 using namespace libm2k;
 using namespace libm2k::analog;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 int main(int argc, char* argv[])
 {

--- a/include/libm2k/context.hpp
+++ b/include/libm2k/context.hpp
@@ -43,7 +43,7 @@ namespace digital {
 	class GenericDigital;
 }
 
-namespace devices {
+namespace contexts {
 class M2k;
 
 class LIBM2K_API Context {
@@ -77,7 +77,7 @@ public:
 	std::string getSerialNumber();
 	std::unordered_set<std::string> getAllDevices();
 
-	libm2k::devices::M2k* toM2k();
+	libm2k::contexts::M2k* toM2k();
 
 	static bool iioChannelHasAttribute(iio_channel *chn, const std::string &attr);
 	static bool iioDevHasAttribute(iio_device *dev, const std::string &attr);

--- a/include/libm2k/contextbuilder.hpp
+++ b/include/libm2k/contextbuilder.hpp
@@ -27,9 +27,9 @@
 #include <unordered_set>
 #include <map>
 
-enum DeviceTypes {
-	DevFMCOMMS,
-	DevM2K,
+enum ContextTypes {
+	CtxFMCOMMS,
+	CtxM2K,
 	Other
 };
 
@@ -55,19 +55,19 @@ public:
 	/**
 	* @private
 	*/
-	static std::vector<std::string> listDevices();
+	static std::vector<std::string> getAllContexts();
 	/**
 	 * @private
 	 */
-	static Context* deviceOpen(const char*);
+	static Context* contextOpen(const char*);
 	/**
 	* @private
 	*/
-	static Context* deviceOpen(struct iio_context*, const char*);
+	static Context* contextOpen(struct iio_context*, const char*);
 	/**
 	* @private
 	*/
-	static Context* deviceOpen();
+	static Context* contextOpen();
 	/**
 	* @private
 	*/
@@ -83,15 +83,15 @@ public:
 	/**
 	* @private
 	*/
-	static void deviceClose(Context*, bool deinit = true);
+	static void contextClose(Context*, bool deinit = true);
 
-	static void deviceCloseAll();
+	static void contextCloseAll();
 private:
-	static std::map<DeviceTypes, std::vector<std::string>> m_dev_map;
-	static std::map<DeviceTypes, std::string> m_dev_name_map;
+	static std::map<ContextTypes, std::vector<std::string>> m_dev_map;
+	static std::map<ContextTypes, std::string> m_dev_name_map;
 	//                std::shared_ptr<M2KImpl> m_pimpl;
-	static DeviceTypes identifyDevice(iio_context *ctx);
-	static Context* buildDevice(DeviceTypes type,
+	static ContextTypes identifyContext(iio_context *ctx);
+	static Context* buildContext(ContextTypes type,
 		std::string uri,
 		struct iio_context *ctx,
 		bool sync);
@@ -110,19 +110,19 @@ private:
 /**
 * @private
 */
-LIBM2K_API Context* deviceOpen();
+LIBM2K_API Context* contextOpen();
 
 
 /**
  * @private
  */
-LIBM2K_API Context* deviceOpen(const char* uri);
+LIBM2K_API Context* contextOpen(const char* uri);
 
 
 /**
  * @private
  */
-LIBM2K_API Context* deviceOpen(struct iio_context* ctx, const char* uri);
+LIBM2K_API Context* contextOpen(struct iio_context* ctx, const char* uri);
 
 
 /**
@@ -158,10 +158,10 @@ LIBM2K_API M2k* m2kOpen();
 
 
 /**
- * @brief List all available devices
- * @return A list containing the available devices
+ * @brief List all available contexts
+ * @return A list containing the available contexts
  */
-LIBM2K_API std::vector<std::string> listDevices();
+LIBM2K_API std::vector<std::string> getAllContexts();
 
 
 /**
@@ -169,13 +169,13 @@ LIBM2K_API std::vector<std::string> listDevices();
  * @param ctx The context to be destroyed
  * @param deinit If deinit is set to false, running contexts won't be affected
  */
-LIBM2K_API void deviceClose(Context* ctx, bool deinit = true);
+LIBM2K_API void contextClose(Context* ctx, bool deinit = true);
 
 
 /**
  * @brief Close all the devices
  */
-LIBM2K_API void deviceCloseAll();
+LIBM2K_API void contextCloseAll();
 
 /**
  * @}

--- a/include/libm2k/contextbuilder.hpp
+++ b/include/libm2k/contextbuilder.hpp
@@ -36,7 +36,7 @@ enum DeviceTypes {
 namespace libm2k {
 
 
-namespace devices {
+namespace contexts {
 
     /**
      * @private

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -41,7 +41,7 @@ class M2kCalibration;
  * @brief Contains the representation of the M2K
  * @{
  */
-namespace devices {
+namespace contexts {
 
 /**
 * @defgroup m2k M2k

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -21,7 +21,7 @@
 
 using namespace libm2k::analog;
 using namespace libm2k::digital;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 using namespace libm2k::utils;
 
 Context::Context(std::string uri, struct iio_context *ctx, std::string name, bool sync) :
@@ -144,12 +144,12 @@ std::string Context::getUri()
 	return m_pimpl->getUri();
 }
 
-void libm2k::devices::Context::scanAllPowerSupply()
+void libm2k::contexts::Context::scanAllPowerSupply()
 {
 	m_pimpl->scanAllPowerSupply();
 }
 
-void libm2k::devices::Context::scanAllDigital()
+void libm2k::contexts::Context::scanAllDigital()
 {
 	m_pimpl->scanAllDigital();
 }

--- a/src/contextbuilder.cpp
+++ b/src/contextbuilder.cpp
@@ -28,7 +28,7 @@
 #include <memory>
 
 
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 using namespace libm2k::utils;
 
 std::vector<Context*> ContextBuilder::s_connectedDevices = {};
@@ -238,17 +238,17 @@ Context *libm2k::devices::deviceOpen(struct iio_context *ctx, const char *uri)
 	return ContextBuilder::deviceOpen(ctx, uri);
 }
 
-M2k *libm2k::devices::m2kOpen(const char *uri)
+M2k *libm2k::contexts::m2kOpen(const char *uri)
 {
 	return ContextBuilder::m2kOpen(uri);
 }
 
-M2k *libm2k::devices::m2kOpen(struct iio_context *ctx, const char *uri)
+M2k *libm2k::contexts::m2kOpen(struct iio_context *ctx, const char *uri)
 {
 	return ContextBuilder::m2kOpen(ctx, uri);
 }
 
-M2k *libm2k::devices::m2kOpen()
+M2k *libm2k::contexts::m2kOpen()
 {
 	return ContextBuilder::m2kOpen();
 }

--- a/src/devices/FMCOMMS/fmcomms.ini
+++ b/src/devices/FMCOMMS/fmcomms.ini
@@ -1,2 +1,0 @@
-[FMCOMMS]
-compatible-devices=cf-ad9361-lpc,cf-ad9361-dds-core-lpc,ad9361-phy

--- a/src/devices/M2K/m2k.ini
+++ b/src/devices/M2K/m2k.ini
@@ -1,2 +1,0 @@
-[M2K]
-compatibe-devices=m2k-adc,m2k-dac-a,m2k-dac-b,m2k-logic-analyzer-rx,m2k-logic-analyzer-tx,m2k-logic-analyzer

--- a/src/m2k.cpp
+++ b/src/m2k.cpp
@@ -20,7 +20,7 @@
 #include "private/m2k_impl.cpp"
 
 using namespace std;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 using namespace libm2k::analog;
 using namespace libm2k::digital;
 using namespace libm2k::utils;

--- a/src/private/context_impl.cpp
+++ b/src/private/context_impl.cpp
@@ -31,7 +31,7 @@
 
 using namespace libm2k::analog;
 using namespace libm2k::digital;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 using namespace libm2k::utils;
 
 class Context::ContextImpl {
@@ -383,7 +383,7 @@ public:
 
 	M2k* toM2k(Context *parent)
 	{
-		libm2k::devices::M2k* dev = dynamic_cast<M2k*>(parent);
+		libm2k::contexts::M2k* dev = dynamic_cast<M2k*>(parent);
 		if(dev) {
 			return dev;
 		} else {

--- a/src/private/m2k_impl.cpp
+++ b/src/private/m2k_impl.cpp
@@ -34,7 +34,7 @@
 #include <thread>
 
 using namespace std;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 using namespace libm2k::analog;
 using namespace libm2k::digital;
 using namespace libm2k::utils;

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -21,7 +21,7 @@
 
 using namespace std;
 using namespace libm2k::utils;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 /*
  * Represents an iio_DeviceGeneric

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -21,7 +21,7 @@
 
 using namespace std;
 using namespace libm2k::utils;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 /*
  * Represents an iio_device

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -21,7 +21,7 @@
 
 using namespace std;
 using namespace libm2k::utils;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 /*
  * Represents an iio_device

--- a/src/utils/private/devicegeneric_impl.cpp
+++ b/src/utils/private/devicegeneric_impl.cpp
@@ -33,7 +33,7 @@ extern "C" {
 
 using namespace std;
 using namespace libm2k::utils;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 class DeviceGeneric::DeviceGenericImpl {
 public:

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -33,7 +33,7 @@ extern "C" {
 
 using namespace std;
 using namespace libm2k::utils;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 class DeviceIn::DeviceInImpl {
 public:

--- a/src/utils/private/deviceout_impl.cpp
+++ b/src/utils/private/deviceout_impl.cpp
@@ -33,7 +33,7 @@ extern "C" {
 
 using namespace std;
 using namespace libm2k::utils;
-using namespace libm2k::devices;
+using namespace libm2k::contexts;
 
 class DeviceOut::DeviceOutImpl {
 public:

--- a/tools/m2kcli/commands/command.cpp
+++ b/tools/m2kcli/commands/command.cpp
@@ -35,10 +35,10 @@ Command::Command(int argc, char **argv)
 			help = true;
 			break;
 		} else if (std::string(argv[i]) == "auto") {
-			context = libm2k::devices::m2kOpen();
+			context = libm2k::contexts::m2kOpen();
 			break;
 		} else if (Validator::validateUri(argv[i])) {
-			context = libm2k::devices::m2kOpen(argv[i]);
+			context = libm2k::contexts::m2kOpen(argv[i]);
 			break;
 		}
 	}
@@ -47,7 +47,7 @@ Command::Command(int argc, char **argv)
 	}
 }
 
-libm2k::devices::M2k *Command::getContext()
+libm2k::contexts::M2k *Command::getContext()
 {
 	return context;
 }

--- a/tools/m2kcli/commands/command.h
+++ b/tools/m2kcli/commands/command.h
@@ -32,10 +32,10 @@ public:
 
 	virtual bool parseArguments(std::vector<std::pair<std::string, std::string>> &output) = 0;
 
-	libm2k::devices::M2k *getContext();
+	libm2k::contexts::M2k *getContext();
 
 protected:
-	libm2k::devices::M2k *context;
+	libm2k::contexts::M2k *context;
 	int argc;
 	char **argv;
 

--- a/tools/m2kcli/commands/command_out.h
+++ b/tools/m2kcli/commands/command_out.h
@@ -21,7 +21,7 @@
 namespace libm2k {
 namespace cli {
 
-class CommandOut : virtual public Command { ;
+class CommandOut : virtual public Command {
 protected:
 
 	static void getSamplesCsvFormat(std::string &file, std::vector<uint16_t> &samples);

--- a/tools/m2kcli/main.cpp
+++ b/tools/m2kcli/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 		}
 	}
 	if (command->getContext() != nullptr) {
-		libm2k::devices::deviceClose(command->getContext(), true);
+		libm2k::contexts::contextClose(command->getContext(), true);
 	}
 	return 0;
 }

--- a/tools/python/sine_gen.py
+++ b/tools/python/sine_gen.py
@@ -89,6 +89,6 @@ def main():
     input( " Press any key to stop generation ")
 
     siggen.stop()
-    libm2k.deviceClose(ctx)
+    libm2k.contextClose(ctx)
 
 main()


### PR DESCRIPTION
Mixing "devices" and "contexts" may become confusing, so we rename everything that is related to Contexts.

Related to #30.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>