### PR TITLE
Update the Doxygen documentation to use Contexts

### DIFF
--- a/include/libm2k/contextbuilder.hpp
+++ b/include/libm2k/contextbuilder.hpp
@@ -99,7 +99,7 @@ private:
 };
 
 /**
- * @addtogroup devices
+ * @addtogroup contexts
  * @{
  * @defgroup context ContextBuilder
  * @brief Creates/destroys the context

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -37,7 +37,7 @@ class M2kDigital;
 
 class M2kCalibration;
 
-/** @defgroup devices Devices
+/** @defgroup contexts Contexts
  * @brief Contains the representation of the M2K
  * @{
  */


### PR DESCRIPTION
Doxygen Documentation: Update the Doxygen documentation to use Contexts instead of devices.
Forgot to add this in PR #41.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>