### PR TITLE
M2kAnalogOut: Fix cyclic mode for M2kAnalogOut.

### DIFF
--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -205,7 +205,10 @@ public:
 
 	bool getCyclic(unsigned int chn)
 	{
-		return getDacDevice(chn);
+		if (chn >= m_dac_devices.size()) {
+			throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		}
+		return m_cyclic.at(chn);
 	}
 
 	int convertVoltsToRaw(double voltage, double vlsb,


### PR DESCRIPTION
This fixes a mistake added in one of the previous commits. The cyclic mode attribute was no longer taken into consideration because of the wrong getter.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>