### PR TITLE
MATLAB requirements

### DIFF
--- a/include/libm2k/analog/genericanalogin.hpp
+++ b/include/libm2k/analog/genericanalogin.hpp
@@ -35,8 +35,8 @@ public:
 	virtual std::vector<std::vector<double>> getSamples(unsigned int nb_samples);
 	virtual std::vector<std::vector<double>> getSamplesRaw(unsigned int nb_samples);
 
-	double* getSamplesInterleaved(unsigned int nb_samples);
-	short* getSamplesRawInterleaved(unsigned int nb_samples);
+	const double* getSamplesInterleaved(unsigned int nb_samples);
+	const short* getSamplesRawInterleaved(unsigned int nb_samples);
 
 	double getSampleRate();
 	double getSampleRate(unsigned int);

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -96,7 +96,7 @@ public:
 	* @param nb_samples The number of samples that will be retrieved
 	* @return A pointer to the interleaved samples
 	*/
-	double* getSamplesInterleaved(unsigned int nb_samples);
+	const double* getSamplesInterleaved(unsigned int nb_samples);
 
 
 	/**
@@ -105,7 +105,7 @@ public:
 	* @param nb_samples The number of samples that will be retrieved
 	* @return A pointer to the interleaved raw samples
 	*/
-	short* getSamplesRawInterleaved(unsigned int nb_samples);
+	const short* getSamplesRawInterleaved(unsigned int nb_samples);
 
 	/**
 	* @brief Convert the raw value of a sample into volts
@@ -178,7 +178,7 @@ public:
 	*
 	* @return A pointer to the average raw value of both channels
 	*/
-	short *getVoltageRawP();
+	const short *getVoltageRawP();
 
 
 	/**
@@ -186,7 +186,7 @@ public:
 	*
 	* @return A pointer to the average voltage of both channels
 	*/
-	double *getVoltageP();
+	const double *getVoltageP();
 
 	/**
 	 * @brief Set the vertical offset, in Volts, of a specific channel

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -266,11 +266,11 @@ public:
 	*
 	* @param data A pointer to the interleaved data
 	* @param nb_channels the number of channels on which we want to push
-	* @param nb_samples_per_channel the number of samples per channel
+	* @param nb_samples the number of samples total (samples_per_channel * channels)
 	* @note Make sure the samples are interleaved
 	* @note Both DACs will be powered up
 	*/
-	void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples_per_channel);
+	void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples);
 
 
 	/**
@@ -278,11 +278,11 @@ public:
 	*
 	* @param data A pointer to the interleaved raw data
 	* @param nb_channels the number of channels on which we want to push
-	* @param nb_samples_per_channel the number of raw samples per channel
+	* @param nb_samples the number of samples total (samples_per_channel * channels)
 	* @note Make sure the raw samples are interleaved
 	* @note Both DACs will be powered up
 	*/
-	void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples_per_channel);
+	void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples);
 
 	/**
 	* @brief Set the calibration gain for the given channel

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -202,7 +202,7 @@ public:
 	 * @param nb_samples The number of samples that will be retrieved
 	 * @return A pointer to the data
 	 */
-	unsigned short *getSamplesP(unsigned int nb_samples);
+	const unsigned short *getSamplesP(unsigned int nb_samples);
 
 	/* Enable/disable TX channels only*/
 

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -51,13 +51,13 @@ public:
 
 	void setChannels(std::vector<Channel*> channels);
 	std::vector<unsigned short> getSamples(unsigned int nb_samples);
-	unsigned short* getSamplesP(unsigned int nb_samples);
+	const unsigned short* getSamplesP(unsigned int nb_samples);
 
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process);
-	double *getSamplesInterleaved(unsigned int nb_samples,
+	const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process);
-	short *getSamplesRawInterleaved(unsigned int nb_samples);
+	const short *getSamplesRawInterleaved(unsigned int nb_samples);
 	void stop();
 	void setCyclic(bool enable);
 	void flushBuffer();

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -48,7 +48,6 @@ public:
 	virtual const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double (int16_t, unsigned int)> process);
 	virtual const short *getSamplesRawInterleaved(unsigned int nb_samples);
-	virtual short *getSamplesRawInterleaved(unsigned int nb_samples);
 	virtual void flushBuffer();
 
 private:

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -42,11 +42,12 @@ public:
 	virtual ~DeviceIn();
 
 	virtual std::vector<unsigned short> getSamples(unsigned int nb_samples);
-	virtual unsigned short* getSamplesP(unsigned int nb_samples);
+	virtual const unsigned short* getSamplesP(unsigned int nb_samples);
 	virtual std::vector<std::vector<double> > getSamples(unsigned int nb_samples,
 					std::function<double (int16_t, unsigned int)> process);
-	virtual double *getSamplesInterleaved(unsigned int nb_samples,
+	virtual const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double (int16_t, unsigned int)> process);
+	virtual const short *getSamplesRawInterleaved(unsigned int nb_samples);
 	virtual short *getSamplesRawInterleaved(unsigned int nb_samples);
 	virtual void flushBuffer();
 

--- a/src/analog/genericanalogin.cpp
+++ b/src/analog/genericanalogin.cpp
@@ -37,12 +37,12 @@ std::vector<std::vector<double> > GenericAnalogIn::getSamplesRaw(unsigned int nb
 	return m_pimpl->getSamples(nb_samples, false);
 }
 
-double *GenericAnalogIn::getSamplesInterleaved(unsigned int nb_samples)
+const double *GenericAnalogIn::getSamplesInterleaved(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesInterleaved(nb_samples, true);
 }
 
-short *GenericAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
+const short *GenericAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -128,12 +128,12 @@ std::vector<std::vector<double> > M2kAnalogIn::getSamplesRaw(unsigned int nb_sam
 	return m_pimpl->getSamples(nb_samples, false);
 }
 
-double *M2kAnalogIn::getSamplesInterleaved(unsigned int nb_samples)
+const double *M2kAnalogIn::getSamplesInterleaved(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesInterleaved(nb_samples, true);
 }
 
-short *M2kAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
+const short *M2kAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }
@@ -173,12 +173,12 @@ std::vector<double> M2kAnalogIn::getVoltage()
 	return m_pimpl->getVoltage();
 }
 
-short *M2kAnalogIn::getVoltageRawP()
+const short *M2kAnalogIn::getVoltageRawP()
 {
 	return m_pimpl->getVoltageRawP();
 }
 
-double *M2kAnalogIn::getVoltageP()
+const double *M2kAnalogIn::getVoltageP()
 {
 	return m_pimpl->getVoltageP();
 }

--- a/src/analog/private/genericanalogin_impl.cpp
+++ b/src/analog/private/genericanalogin_impl.cpp
@@ -54,13 +54,13 @@ public:
 		return DeviceIn::getSamples(nb_samples, processSample);
 	}
 
-	double *getSamplesInterleaved(unsigned int nb_samples,
+	const double *getSamplesInterleaved(unsigned int nb_samples,
 						bool processed = false)
 	{
 		return DeviceIn::getSamplesInterleaved(nb_samples, processSample);
 	}
 
-	short *getSamplesRawInterleaved(unsigned int nb_samples)
+	const short *getSamplesRawInterleaved(unsigned int nb_samples)
 	{
 		return DeviceIn::getSamplesRawInterleaved(nb_samples);
 	}

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -182,7 +182,7 @@ public:
 		return samps;
 	}
 
-	double *getSamplesInterleaved(unsigned int nb_samples,
+	const double *getSamplesInterleaved(unsigned int nb_samples,
 						bool processed = false)
 	{
 		if (processed) {
@@ -190,14 +190,14 @@ public:
 		}
 		m_samplerate = getSampleRate();
 		auto fp = std::bind(&M2kAnalogInImpl::processSample, this, _1, _2);
-		auto samps = DeviceIn::getSamplesInterleaved(nb_samples, fp);
+		auto samps = (const double *)DeviceIn::getSamplesInterleaved(nb_samples, fp);
 		if (processed) {
 			m_need_processing = false;
 		}
 		return samps;
 	}
 
-	short *getSamplesRawInterleaved(unsigned int nb_samples)
+	const short *getSamplesRawInterleaved(unsigned int nb_samples)
 	{
 		m_samplerate = getSampleRate();
 		return DeviceIn::getSamplesRawInterleaved(nb_samples);

--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -308,6 +308,9 @@ public:
 
 	void pushRaw(short *data, unsigned int nb_channels, unsigned int nb_samples)
 	{
+		if ((nb_samples % nb_channels) !=0) {
+                        throw_exception(EXC_INVALID_PARAMETER, "Analog Out: Input array length must be multiple of channels");
+                }
 		std::vector<std::vector<short>> data_buffers;
 		m_m2k_fabric->setBoolValue(0, false, "powerdown", true);
 		m_m2k_fabric->setBoolValue(1, false, "powerdown", true);
@@ -318,7 +321,7 @@ public:
 
 		for (unsigned int chn = 0; chn < nb_channels; chn++) {
 			std::vector<short> raw_data_buffer = {};
-			for (unsigned int i = 0, off = 0; i < nb_samples; i++, off += nb_channels) {
+			for (unsigned int i = 0, off = 0; i < (nb_samples/nb_channels); i++, off += nb_channels) {
 				raw_data_buffer.push_back(data[chn + off]);
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));
@@ -356,6 +359,9 @@ public:
 
 	void push(double *data, unsigned int nb_channels, unsigned int nb_samples)
 	{
+		if ((nb_samples % nb_channels) !=0) {
+                        throw_exception(EXC_INVALID_PARAMETER, "Analog Out: Input array length must be multiple of channels");
+                }
 		std::vector<std::vector<short>> data_buffers;
 		m_m2k_fabric->setBoolValue(0, false, "powerdown", true);
 		m_m2k_fabric->setBoolValue(1, false, "powerdown", true);
@@ -366,7 +372,7 @@ public:
 
 		for (unsigned int chn = 0; chn < nb_channels; chn++) {
 			std::vector<short> raw_data_buffer = {};
-			for (unsigned int i = 0, off = 0; i < nb_samples; i++, off += nb_channels) {
+			for (unsigned int i = 0, off = 0; i < (nb_samples/nb_channels); i++, off += nb_channels) {
 				raw_data_buffer.push_back(processSample(data[chn + off], chn));
 			}
 			m_dac_devices.at(chn)->push(raw_data_buffer, 0, getCyclic(chn));

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -115,7 +115,7 @@ std::vector<unsigned short> M2kDigital::getSamples(unsigned int nb_samples)
 	return m_pimpl->getSamples(nb_samples);
 }
 
-unsigned short *M2kDigital::getSamplesP(unsigned int nb_samples)
+const unsigned short *M2kDigital::getSamplesP(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesP(nb_samples);
 }

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -245,7 +245,7 @@ public:
 		}
 	}
 
-	unsigned short* getSamplesP(int nb_samples)
+	const unsigned short* getSamplesP(int nb_samples)
 	{
 		__try {
 			if (!anyChannelEnabled(DIO_INPUT)) {

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -82,7 +82,7 @@ std::vector<unsigned short> Buffer::getSamples(unsigned int nb_samples)
 	return m_pimpl->getSamples(nb_samples);
 }
 
-unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
+const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesP(nb_samples);
 }
@@ -93,12 +93,12 @@ std::vector<std::vector<double>> Buffer::getSamples(unsigned int nb_samples,
 	return m_pimpl->getSamples(nb_samples, process);
 }
 
-double *Buffer::getSamplesInterleaved(unsigned int nb_samples, std::function<double (int16_t, unsigned int)> process)
+const double *Buffer::getSamplesInterleaved(unsigned int nb_samples, std::function<double (int16_t, unsigned int)> process)
 {
 	return m_pimpl->getSamplesInterleaved(nb_samples, process);
 }
 
-short *Buffer::getSamplesRawInterleaved(unsigned int nb_samples)
+const short *Buffer::getSamplesRawInterleaved(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -41,7 +41,7 @@ std::vector<unsigned short> DeviceIn::getSamples(unsigned int nb_samples)
 	return m_pimpl->getSamples(nb_samples);
 }
 
-unsigned short *DeviceIn::getSamplesP(unsigned int nb_samples)
+const unsigned short *DeviceIn::getSamplesP(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesP(nb_samples);
 }
@@ -52,13 +52,13 @@ std::vector<std::vector<double> > DeviceIn::getSamples(unsigned int nb_samples,
 	return m_pimpl->getSamples(nb_samples, process);
 }
 
-double *DeviceIn::getSamplesInterleaved(unsigned int nb_samples,
+const double *DeviceIn::getSamplesInterleaved(unsigned int nb_samples,
 				std::function<double(int16_t, unsigned int)> process)
 {
 	return m_pimpl->getSamplesInterleaved(nb_samples, process);
 }
 
-short *DeviceIn::getSamplesRawInterleaved(unsigned int nb_samples)
+const short *DeviceIn::getSamplesRawInterleaved(unsigned int nb_samples)
 {
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -333,7 +333,7 @@ public:
 		return m_data_short;
 	}
 
-	unsigned short *getSamplesP(int nb_samples)
+	const unsigned short *getSamplesP(int nb_samples)
 	{
 		if (Utils::getIioDeviceDirection(m_dev) == OUTPUT) {
 			throw_exception(EXC_RUNTIME_ERROR, "Device not input-buffer capable, so no buffer was created");
@@ -358,12 +358,12 @@ public:
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 		}
 
-		unsigned short* data = (unsigned short*)iio_buffer_start(m_buffer);
+		const unsigned short* data = (const unsigned short*)iio_buffer_start(m_buffer);
 		return data;
 	}
 
 
-	short* getSamplesRawInterleaved(int nb_samples)
+	const short* getSamplesRawInterleaved(int nb_samples)
 	{
 		bool anyChannelEnabled = false;
 		std::vector<bool> channels_enabled;
@@ -403,7 +403,7 @@ public:
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 		}
 
-		short* p_dat = (short*) m_channel_list.at(0)->getFirst(m_buffer);
+		const short* p_dat = (const short*) m_channel_list.at(0)->getFirst(m_buffer);
 
 		for (unsigned int i = 0; i < m_channel_list.size(); i++) {
 			m_channel_list.at(i)->enableChannel(channels_enabled.at(i));
@@ -411,10 +411,10 @@ public:
 		return p_dat;
 	}
 
-	double* getSamplesInterleaved(int nb_samples,
+	const double* getSamplesInterleaved(int nb_samples,
 				      std::function<double(int16_t, unsigned int)> process)
 	{
-		short* data_p = getSamplesRawInterleaved(nb_samples);
+		const short* data_p = getSamplesRawInterleaved(nb_samples);
 
 		std::vector<bool> channels_enabled;
 
@@ -437,13 +437,13 @@ public:
 			}
 		}
 
-		return data_p_d;
+		return (const double *)data_p_d;
 	}
 
 	std::vector<std::vector<double>> getSamples(int nb_samples,
 					std::function<double(int16_t, unsigned int)> process)
 	{
-		short* data_p = getSamplesRawInterleaved(nb_samples);
+		short* data_p = (short *) getSamplesRawInterleaved(nb_samples);
 
 		std::vector<bool> channels_enabled;
 		m_data.clear();

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -117,7 +117,7 @@ public:
 
 	}
 
-	unsigned short* getSamplesP(unsigned int nb_samples)
+	const unsigned short* getSamplesP(unsigned int nb_samples)
 	{
 		if (!m_buffer) {
 			throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
@@ -137,7 +137,7 @@ public:
 		return m_buffer->getSamples(nb_samples, process);
 	}
 
-	double *getSamplesInterleaved(unsigned int nb_samples,
+	const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process)
 	{
 		if (!m_buffer) {
@@ -147,7 +147,7 @@ public:
 		return m_buffer->getSamplesInterleaved(nb_samples, process);
 	}
 
-	short *getSamplesRawInterleaved(unsigned int nb_samples)
+	const short *getSamplesRawInterleaved(unsigned int nb_samples)
 	{
 		if (!m_buffer) {
 			throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");

--- a/tools/m2kcli/commands/analog/analog_in.cpp
+++ b/tools/m2kcli/commands/analog/analog_in.cpp
@@ -137,11 +137,11 @@ void AnalogIn::handleCapture()
 	if (!format.empty() && format == "binary") {
 
 		if (raw) {
-			short *tempSamples = analogIn->getSamplesRawInterleaved(bufferSize);
+			short *tempSamples = (short*) analogIn->getSamplesRawInterleaved(bufferSize);
 			std::vector<uint16_t> samples(tempSamples, tempSamples + bufferSize);
 			printSamplesBinaryFormat(samples);
 		} else {
-			double *tempSamples = analogIn->getSamplesInterleaved(bufferSize);
+			double *tempSamples = (double*) analogIn->getSamplesInterleaved(bufferSize);
 			std::vector<double> samples(tempSamples, tempSamples + bufferSize);
 			printSamplesBinaryFormat(samples);
 		}

--- a/tools/m2kcli/commands/analog/analog_out.cpp
+++ b/tools/m2kcli/commands/analog/analog_out.cpp
@@ -114,7 +114,7 @@ void AnalogOut::handleGenerate()
 				analogOut->pushRaw(channels[0], samplesChannel);
 			} else {
 				analogOut->pushRawInterleaved(reinterpret_cast<short *>(samples.data()),
-							      channels.size(), samples.size() / channels.size());
+							      channels.size(), samples.size());
 			}
 		} else {
 			std::vector<double> samples;
@@ -124,7 +124,7 @@ void AnalogOut::handleGenerate()
 				analogOut->push(channels[0], samplesChannel);
 			} else {
 				analogOut->pushInterleaved(reinterpret_cast<double *>(samples.data()), channels.size(),
-							   samples.size() / channels.size());
+							   samples.size());
 			}
 		}
 


### PR DESCRIPTION
This PR updates some APIs to allow MATLAB binding creation. MATLAB requires const output pointers for output data arrays, and any provided (pushed) data must supply the number of samples in the array explicitly.
- [MATLAB Requirements](https://www.mathworks.com/help/matlab/matlab_external/define-matlab-interface-for-c-library.html) as documented by MathWorks

- The MATLAB binding are [built externally](https://github.com/analogdevicesinc/libm2k-matlab) based off these changes.