### PR TITLE
M2kDigital: Manage kernel buffers count and flush buffers

### DIFF
--- a/examples/digital/main.cpp
+++ b/examples/digital/main.cpp
@@ -49,7 +49,7 @@ int main()
 	{
 		cout<<bitset<16>(val)<<endl;
 	}
-	dig->stop();
+	dig->stopBufferOut();
 	contextClose(ctx);
 
 	return 0;

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -186,7 +186,13 @@ public:
 	/**
 	* @brief Stop all digital channels from sending the signals
 	*/
-	void stop();
+	void stopBufferOut();
+
+
+	/**
+	 * @brief Destroy the buffer
+	 */
+	void flushBufferIn();
 
 
 	/**

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -340,6 +340,13 @@ public:
 	*/
 	libm2k::analog::M2kHardwareTrigger* getTrigger();
 
+
+	/**
+	 * @brief Set the kernel buffers to a specific value
+	 * @param count the number of kernel buffers
+	 */
+	void setKernelBuffersCountIn(unsigned int count);
+
 	/** @} */
 
 private:

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -102,6 +102,7 @@ public:
 			m_adc_hw_vert_offset_raw.at(i) = 2048;
 			m_trigger->setCalibParameters(i, getScalingFactor(i), m_adc_hw_vert_offset.at(i));
 		}
+		setKernelBuffersCount(1);
 	}
 
 	void syncDevice()

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -105,9 +105,14 @@ void M2kDigital::push(unsigned short *data, unsigned int nb_samples)
 	m_pimpl->push(data, nb_samples);
 }
 
-void M2kDigital::stop()
+void M2kDigital::stopBufferOut()
 {
-	m_pimpl->stop();
+	m_pimpl->stopBufferOut();
+}
+
+void M2kDigital::flushBufferIn()
+{
+	m_pimpl->flushBufferIn();
 }
 
 std::vector<unsigned short> M2kDigital::getSamples(unsigned int nb_samples)

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -145,6 +145,11 @@ M2kHardwareTrigger *M2kDigital::getTrigger()
 	return m_pimpl->getTrigger();
 }
 
+void M2kDigital::setKernelBuffersCountIn(unsigned int count)
+{
+	m_pimpl->setKernelBuffersCountIn(count);
+}
+
 void M2kDigital::setOutputMode(DIO_CHANNEL chn, DIO_MODE mode)
 {
 	m_pimpl->setOutputMode(chn, mode);

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -112,6 +112,11 @@ public:
 		m_dev_read->setKernelBuffersCount(25);
 	}
 
+	void setKernelBuffersCountIn(unsigned int count)
+	{
+		m_dev_read->setKernelBuffersCount(count);
+	}
+
 	void setDirection(unsigned short mask)
 	{
 		DIO_DIRECTION direction;

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -109,7 +109,7 @@ public:
 			m_dev_read->enableChannel(i, true);
 		}
 
-		m_dev_read->setKernelBuffersCount(25);
+		setKernelBuffersCountIn(1);
 	}
 
 	void setKernelBuffersCountIn(unsigned int count)

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -226,9 +226,14 @@ public:
 		m_dev_write->push(data, 0, nb_samples, getCyclic(), true);
 	}
 
-	void stop()
+	void stopBufferOut()
 	{
 		m_dev_write->stop();
+	}
+
+	void flushBufferIn()
+	{
+		m_dev_read->flushBuffer();
 	}
 
 	std::vector<unsigned short> getSamples(int nb_samples)

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -481,6 +481,7 @@ public:
 		if (m_buffer) {
 			iio_buffer_cancel(m_buffer);
 		}
+		destroy();
 	}
 
 	void destroy()

--- a/tools/m2kcli/commands/digital/digital.cpp
+++ b/tools/m2kcli/commands/digital/digital.cpp
@@ -142,7 +142,7 @@ void Digital::handleGenerate()
 	std::cout << "Press ENTER to stop the generation... ";
 	std::cin.clear();
 	std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-	digital->stop();
+	digital->stopBufferOut();
 }
 
 void Digital::handleGet(std::vector<std::pair<std::string, std::string>> &output)


### PR DESCRIPTION
1. Kernel buffers count can also be modified for the digital device. 
2. Allow the user to stop the digital output.
3. Allow the user to flush the input buffers. This drops all the old data from the buffers. Similar to the method provided for the analog devices.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>