### PR TITLE
M2kPowerSupply: Fix the behaviour of M2kPowerSupply at startup.

### DIFF
--- a/src/analog/private/m2kpowersupply_impl.cpp
+++ b/src/analog/private/m2kpowersupply_impl.cpp
@@ -96,12 +96,7 @@ public:
 			m_individual_powerdown = true;
 		}
 
-		powerDownDacs(true);
 		loadCalibrationCoefficients();
-
-		for (unsigned int i : m_write_channel_idx) {
-			m_dev_write->setDoubleValue(i, 0.0, "raw", true);
-		}
 
 		m_write_coefficients.push_back(4095.0 / (5.02 * 1.2 ));
 		m_write_coefficients.push_back(4095.0 / (-5.1 * 1.2 ));
@@ -120,12 +115,13 @@ public:
 
 	void syncDevice()
 	{
-		m_channels_enabled.at(0) = m_dev_write->getBoolValue(m_write_channel_idx.at(0), "powerdown", true);
-		m_channels_enabled.at(1) = m_dev_write->getBoolValue(m_write_channel_idx.at(1), "powerdown", true);
+		m_channels_enabled.at(0) = !m_dev_write->getBoolValue(m_write_channel_idx.at(0), "powerdown", true);
+		m_channels_enabled.at(1) = !m_dev_write->getBoolValue(m_write_channel_idx.at(1), "powerdown", true);
 	}
 
 	void init()
 	{
+		powerDownDacs(true);
 		for (unsigned int i : m_write_channel_idx) {
 			m_dev_write->setDoubleValue(i, 0.0, "raw", true);
 		}

--- a/src/private/m2k_impl.cpp
+++ b/src/private/m2k_impl.cpp
@@ -79,6 +79,9 @@ public:
 
 				/* ADF4360 global clock power down */
 				m_m2k_fabric->setBoolValue(true, "clk_powerdown");
+				for (auto ps : m_instancesPowerSupply) {
+					ps->powerDownDacs(true);
+				}
 			}
 		}
 


### PR DESCRIPTION
If the previous libm2k context is closed without deinit, the M2kPowerSupply should continue to be functional (should not be reset to 0).
The M2K context will power down the DACs when it is closed.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>