### PR TITLE
Device Generic, In, Out: Add changes to the channel scanning system.

### DIFF
--- a/include/libm2k/analog/powersupply.hpp
+++ b/include/libm2k/analog/powersupply.hpp
@@ -34,8 +34,6 @@ public:
 		     std::string read_dev = "");
 	virtual ~PowerSupply();
 
-	void enableChannel(unsigned int chnidx, bool enable);
-
 private:
 	class PowerSupplyImpl;
 	std::unique_ptr<PowerSupplyImpl> m_pimpl;

--- a/include/libm2k/utils/channel.hpp
+++ b/include/libm2k/utils/channel.hpp
@@ -58,6 +58,10 @@ public:
 	std::string getStringValue(std::string attr);
 
 	void setLongValue(std::string attr, long long val);
+	long long getLongValue(std::string attr);
+
+	void setBoolValue(std::string attr, bool val);
+	bool getBoolValue(std::string attr);
 
 	void enableChannel(bool enable);
 	uintptr_t getFirst(struct iio_buffer* buffer);

--- a/include/libm2k/utils/devicegeneric.hpp
+++ b/include/libm2k/utils/devicegeneric.hpp
@@ -32,18 +32,29 @@ namespace utils {
 class Channel;
 class Buffer;
 
+/**
+ * The DeviceGeneric class is to be used in interacting with any IIO device (it should express a correspondent
+ * to the struct iio_device in underlying libiio. It provides basic functionality such as:
+ * - creating and initializing the iio_device and its corresponding channels;
+ * - channel handling is done in a generic way, scanning all the input and output channels;
+ * - all the mutators and accessors are as generic as possible, while providing a fairly simple usage scenario;
+ * these can be used for iio_device related attributes or for channel related attributes; in the latter case,
+ * the direction of the channels should be known and provided (input/output);
+ * - can be used to manage iio_devices with both input and output channels
+ * (can handle any channel type (whether it is voltage in, voltage out, altvoltage, temp, etc.);
+ */
 class DeviceGeneric
 {
 public:
-	DeviceGeneric(struct iio_context* context, std::string dev_name = "", bool input = false);
+	DeviceGeneric(struct iio_context* context, std::string dev_name = "");
 	virtual ~DeviceGeneric();
 
-	virtual Channel *getChannel(unsigned int chnIdx);
-	virtual Channel *getChannel(std::string id);
+	virtual Channel *getChannel(unsigned int chnIdx, bool output);
+	virtual Channel *getChannel(std::string id, bool output);
 	virtual bool isChannel(unsigned int chnIdx, bool output);
 
-	virtual void enableChannel(unsigned int chnIdx, bool enable);
-	virtual bool isChannelEnabled(unsigned int chnIdx);
+	virtual void enableChannel(unsigned int chnIdx, bool enable, bool output);
+	virtual bool isChannelEnabled(unsigned int chnIdx, bool output);
 
 	virtual std::string getName();
 	virtual double getDoubleValue(std::string attr);
@@ -72,10 +83,10 @@ public:
 	virtual void writeRegister(uint32_t address, uint32_t value);
 
 	virtual std::string getHardwareRevision();
-	virtual unsigned int getNbChannels();
+	virtual unsigned int getNbChannels(bool output);
 
-	virtual void convertChannelHostFormat(unsigned int chn_idx, int16_t *avg, int16_t *src);
-	virtual void convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src);
+	virtual void convertChannelHostFormat(unsigned int chn_idx, int16_t *avg, int16_t *src, bool output);
+	virtual void convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src, bool output);
 
 	virtual void setKernelBuffersCount(unsigned int count);
 	virtual bool isValidDmmChannel(unsigned int chnIdx);

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -38,7 +38,7 @@ class Buffer;
 class DeviceIn : public DeviceGeneric
 {
 public:
-	DeviceIn(struct iio_context* context, std::string dev_name = "", bool input = false);
+	DeviceIn(struct iio_context* context, std::string dev_name = "");
 	virtual ~DeviceIn();
 
 	virtual std::vector<unsigned short> getSamples(unsigned int nb_samples);

--- a/include/libm2k/utils/deviceout.hpp
+++ b/include/libm2k/utils/deviceout.hpp
@@ -38,7 +38,7 @@ class Buffer;
 class DeviceOut : public DeviceGeneric
 {
 public:
-	DeviceOut(struct iio_context* context, std::string dev_name = "", bool input = false);
+	DeviceOut(struct iio_context* context, std::string dev_name = "");
 	virtual ~DeviceOut();
 
 	virtual void push(std::vector<short> const &data, unsigned int channel,

--- a/include/libm2k/utils/utils.hpp
+++ b/include/libm2k/utils/utils.hpp
@@ -68,6 +68,7 @@ namespace utils {
 		static DEVICE_DIRECTION getIioDeviceDirection(iio_device *dev);
 		static std::vector<std::string> split(std::string, std::string);
 		static int compareVersions(std::string v1, std::string v2);
+		static bool compareNatural(const std::string &a, const std::string &b);
 	private:
 		static std::string parseIniSection(std::string line);
 		static std::pair<std::string, std::vector<std::string>>

--- a/src/analog/genericanalogout.cpp
+++ b/src/analog/genericanalogout.cpp
@@ -104,5 +104,5 @@ std::string GenericAnalogOut::getName()
 
 void GenericAnalogOut::enableChannel(unsigned int chnIdx, bool enable)
 {
-	m_pimpl->enableChannel(chnIdx, enable);
+	m_pimpl->enableChannel(chnIdx, enable, true);
 }

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -90,12 +90,12 @@ bool M2kAnalogIn::isChannelEnabled(unsigned int chnIdx)
 
 void M2kAnalogIn::convertChannelHostFormat(unsigned int chn_idx, int16_t *avg, int16_t *src)
 {
-	m_pimpl->convertChannelHostFormat(chn_idx, avg, src);
+	m_pimpl->convertChannelHostFormat(chn_idx, avg, src, false);
 }
 
 void M2kAnalogIn::convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src)
 {
-	m_pimpl->convertChannelHostFormat(chn_idx, avg, src);
+	m_pimpl->convertChannelHostFormat(chn_idx, avg, src, false);
 }
 
 double M2kAnalogIn::setCalibscale(unsigned int index, double calibscale)

--- a/src/analog/powersupply.cpp
+++ b/src/analog/powersupply.cpp
@@ -31,8 +31,4 @@ PowerSupply::~PowerSupply()
 {
 }
 
-void PowerSupply::enableChannel(unsigned int chnidx, bool enable)
-{
-	m_pimpl->enableChannel(chnidx, enable);
-}
 

--- a/src/analog/private/dmm_impl.cpp
+++ b/src/analog/private/dmm_impl.cpp
@@ -31,13 +31,14 @@ using namespace libm2k::utils;
 class DMM::DMMImpl : public DeviceIn  {
 public:
 	DMMImpl(struct iio_context *ctx, std::string dev, bool sync) :
-		DeviceIn (ctx, dev, true)
+		DeviceIn(ctx, dev)
 	{
 		m_dev_name = dev;
-		for (unsigned int i = 0; i < getNbChannels(); i++) {
+		bool output = false;
+		for (unsigned int i = 0; i < getNbChannels(output); i++) {
 			if (isValidDmmChannel(i)) {
 				m_channel_id_list.insert(std::pair<std::string, unsigned int>
-					(getChannel(i)->getId(), i));
+					(getChannel(i, output)->getId(), i));
 			}
 		}
 	}
@@ -78,10 +79,10 @@ public:
 		DMM_READING result;
 		double value = 0;
 		std::string key = "";
-		std::string id = getChannel(m_channel_id_list.at(chn_name))->getId();
-		std::string name = getChannel(m_channel_id_list.at(chn_name))->getName();
+		std::string id = getChannel(m_channel_id_list.at(chn_name), false)->getId();
+		std::string name = getChannel(m_channel_id_list.at(chn_name), false)->getName();
 		unsigned int index = m_channel_id_list.at(chn_name);
-		auto channel = getChannel(index);
+		auto channel = getChannel(index, false);
 		if (channel->hasAttribute("raw")) {
 			value = channel->getDoubleValue("raw");
 		} else if (channel->hasAttribute("processed")) {

--- a/src/analog/private/genericanalogin_impl.cpp
+++ b/src/analog/private/genericanalogin_impl.cpp
@@ -98,7 +98,7 @@ public:
 
 	void enableChannel(unsigned int index, bool enable)
 	{
-		DeviceGeneric::enableChannel(index, enable);
+		DeviceGeneric::enableChannel(index, enable, false);
 	}
 
 	void setKernelBuffersCount(unsigned int count)

--- a/src/analog/private/genericanalogout_impl.cpp
+++ b/src/analog/private/genericanalogout_impl.cpp
@@ -69,7 +69,7 @@ public:
 
 	void setCyclic(bool en)
 	{
-		for (unsigned int i = 0; i < getNbChannels(); i++) {
+		for (unsigned int i = 0; i < getNbChannels(true); i++) {
 			m_cyclic.at(i) = en;
 		}
 		DeviceGeneric::setCyclic(en);
@@ -77,7 +77,7 @@ public:
 
 	void setCyclic(unsigned int chn, bool en)
 	{
-		if (chn >= getNbChannels()) {
+		if (chn >= getNbChannels(true)) {
 			throw_exception(EXC_INVALID_PARAMETER, "Generic Analog Out: No such channel");
 		}
 		m_cyclic.at(chn) = en;
@@ -85,7 +85,7 @@ public:
 
 	bool getCyclic(unsigned int chn)
 	{
-		if (chn >= getNbChannels()) {
+		if (chn >= getNbChannels(true)) {
 			throw_exception(EXC_INVALID_PARAMETER, "Generic Analog Out: No such channel");
 		}
 		return m_cyclic.at(chn);

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -80,6 +80,21 @@ public:
 	{
 	}
 
+	void enableChannel(unsigned int chn_idx, bool enable)
+	{
+		DeviceGeneric::enableChannel(chn_idx, enable, false);
+	}
+
+	bool isChannelEnabled(unsigned int chn_idx)
+	{
+		return DeviceGeneric::isChannelEnabled(chn_idx, false);
+	}
+
+	unsigned int getNbChannels()
+	{
+		return DeviceGeneric::getNbChannels(false);
+	}
+
 	void init()
 	{
 		setOversamplingRatio(1);

--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -421,12 +421,12 @@ public:
 
 	void enableChannel(unsigned int chnIdx, bool enable)
 	{
-		getDacDevice(chnIdx)->enableChannel(0, enable);
+		getDacDevice(chnIdx)->enableChannel(0, enable, true);
 	}
 
 	bool isChannelEnabled(unsigned int chnIdx)
 	{
-		return getDacDevice(chnIdx)->isChannelEnabled(0);
+		return getDacDevice(chnIdx)->isChannelEnabled(0, true);
 	}
 
 	DeviceOut* getDacDevice(unsigned int chnIdx)

--- a/src/digital/private/genericdigital_impl.cpp
+++ b/src/digital/private/genericdigital_impl.cpp
@@ -37,9 +37,9 @@ public:
 	{
 		m_dev_name = logic_dev;
 
-		for (unsigned int i = 0; i < getNbChannels(); i++) {
+		for (unsigned int i = 0; i < getNbChannels(false); i++) {
 			std::string name = "voltage" + std::to_string(i);
-			Channel* channel = getChannel(name);
+			Channel* channel = getChannel(name, false);
 			if (channel) {
 				m_channel_list.push_back(channel);
 			}
@@ -75,8 +75,8 @@ public:
 
 	void enableChannel(unsigned int index, bool enable)
 	{
-		if (index < getNbChannels()) {
-			enableChannel(index, enable);
+		if (index < getNbChannels(false)) {
+			DeviceGeneric::enableChannel(index, enable, false);
 		} else {
 			throw_exception(EXC_OUT_OF_RANGE, "Cannot enable digital channel.");
 		}

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -81,20 +81,20 @@ public:
 
 	void syncDevice()
 	{
-		for (unsigned int i = 0; i < getNbChannels(); i++) {
+		for (unsigned int i = 0; i < getNbChannels(false); i++) {
 			/* Disable all the TX channels */
-			bool en = m_dev_write->isChannelEnabled(i);
+			bool en = m_dev_write->isChannelEnabled(i, true);
 			m_tx_channels_enabled.push_back(en);
 
 			/* Enable all the RX channels */
 			m_rx_channels_enabled.push_back(true);
-			m_dev_read->enableChannel(i, true);
+			m_dev_read->enableChannel(i, true, false);
 		}
 	}
 
 	void init()
 	{
-		for (unsigned int i = 0; i < getNbChannels(); i++) {
+		for (unsigned int i = 0; i < getNbChannels(false); i++) {
 			/* Disable all the TX channels */
 
 			m_tx_channels_enabled.push_back(false);
@@ -102,7 +102,7 @@ public:
 
 			/* Enable all the RX channels */
 			m_rx_channels_enabled.push_back(true);
-			m_dev_read->enableChannel(i, true);
+			m_dev_read->enableChannel(i, true, false);
 		}
 
 		setKernelBuffersCountIn(1);
@@ -118,7 +118,7 @@ public:
 		DIO_DIRECTION direction;
 		bool dir = false;
 		unsigned int index = 0;
-		while (mask != 0 || index < m_dev_write->getNbChannels()) {
+		while (mask != 0 || index < m_dev_write->getNbChannels(true)) {
 			dir = mask & 1;
 			mask >>= 1;
 			direction = static_cast<DIO_DIRECTION>(dir);
@@ -148,7 +148,7 @@ public:
 
 	void setDirection(DIO_CHANNEL index, DIO_DIRECTION dir)
 	{
-		if (index < getNbChannels()) {
+		if (index < getNbChannels(false)) {
 			std::string dir_str = "";
 			if (dir == 0) {
 				dir_str = "in";
@@ -164,7 +164,7 @@ public:
 
 	DIO_DIRECTION getDirection(DIO_CHANNEL index)
 	{
-		if (index >= getNbChannels()) {
+		if (index >= getNbChannels(false)) {
 			throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel");
 		}
 
@@ -177,7 +177,7 @@ public:
 
 	void setValueRaw(DIO_CHANNEL index, DIO_LEVEL level)
 	{
-		if (index >= getNbChannels()) {
+		if (index >= getNbChannels(false)) {
 			throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel");
 		}
 		long long val = static_cast<long long>(level);
@@ -192,7 +192,7 @@ public:
 
 	DIO_LEVEL getValueRaw(DIO_CHANNEL index)
 	{
-		if (index >= getNbChannels()) {
+		if (index >= getNbChannels(false)) {
 			throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel");
 		}
 		long long val;
@@ -272,8 +272,8 @@ public:
 
 	void enableChannel(unsigned int index, bool enable)
 	{
-		if (index < getNbChannels()) {
-			m_dev_write->enableChannel(index, enable);
+		if (index < getNbChannels(true)) {
+			m_dev_write->enableChannel(index, enable, true);
 			m_tx_channels_enabled.at(index) = enable;
 		} else {
 			throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: Cannot enable digital TX channel");
@@ -282,8 +282,8 @@ public:
 
 	void enableChannel(DIO_CHANNEL index, bool enable)
 	{
-		if (index < getNbChannels()) {
-			m_dev_write->enableChannel(index, enable);
+		if (index < getNbChannels(true)) {
+			m_dev_write->enableChannel(index, enable, true);
 			m_tx_channels_enabled.at(index) = enable;
 		} else {
 			throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: Cannot enable digital TX channel");
@@ -292,7 +292,7 @@ public:
 
 	void enableAllOut(bool enable)
 	{
-		for (unsigned int i = 0; i < m_dev_write->getNbChannels() - 2; i++) {
+		for (unsigned int i = 0; i < m_dev_write->getNbChannels(true) - 2; i++) {
 			DIO_CHANNEL idx = static_cast<DIO_CHANNEL>(i);
 			enableChannel(idx, enable);
 		}

--- a/src/private/m2k_impl.cpp
+++ b/src/private/m2k_impl.cpp
@@ -327,7 +327,7 @@ public:
 	void blinkLed(const double duration = 4, bool blocking = false)
 	{
 		std::shared_ptr<DeviceGeneric> m_m2k_fabric = make_shared<DeviceGeneric>(m_context, "m2k-fabric");
-		if (m_m2k_fabric->getChannel("voltage4")->hasAttribute("done_led_overwrite_powerdown")) {
+		if (m_m2k_fabric->getChannel("voltage4", true)->hasAttribute("done_led_overwrite_powerdown")) {
 			bool currentValue = m_m2k_fabric->getBoolValue(4, "done_led_overwrite_powerdown", true);
 
 			const double blinkInterval = 0.05;
@@ -355,7 +355,7 @@ public:
 	void setLed(bool on)
 	{
 		std::shared_ptr<DeviceGeneric> m_m2k_fabric = make_shared<DeviceGeneric>(m_context, "m2k-fabric");
-		if (m_m2k_fabric->getChannel("voltage4")->hasAttribute("done_led_overwrite_powerdown")) {
+		if (m_m2k_fabric->getChannel("voltage4", true)->hasAttribute("done_led_overwrite_powerdown")) {
 			m_m2k_fabric->setBoolValue(4, !on, "done_led_overwrite_powerdown", true);
 		}
 	}
@@ -364,7 +364,7 @@ public:
 	{
 		bool on = false;
 		std::shared_ptr<DeviceGeneric> m_m2k_fabric = make_shared<DeviceGeneric>(m_context, "m2k-fabric");
-		if (m_m2k_fabric->getChannel("voltage4")->hasAttribute("done_led_overwrite_powerdown")) {
+		if (m_m2k_fabric->getChannel("voltage4", true)->hasAttribute("done_led_overwrite_powerdown")) {
 			on = !m_m2k_fabric->getBoolValue(4, "done_led_overwrite_powerdown", true);
 		}
 		return on;

--- a/src/private/m2khardwaretrigger_impl.cpp
+++ b/src/private/m2khardwaretrigger_impl.cpp
@@ -86,8 +86,8 @@ public:
 		DeviceIn (ctx, "m2k-adc-trigger")
 	{
 		std::vector<std::pair<Channel*, std::string>> channels;
-		for (unsigned int i = 0; i < getNbChannels(); i++) {
-			Channel* ch = getChannel(i);
+		for (unsigned int i = 0; i < getNbChannels(false); i++) {
+			Channel* ch = getChannel(i, false);
 			if (ch->isOutput()) {
 				continue;
 			}
@@ -122,7 +122,7 @@ public:
 			}
 		}
 
-		m_delay_trigger = getChannel("trigger");
+		m_delay_trigger = getChannel("trigger", false);
 
 		m_num_channels = m_analog_channels.size();
 

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -135,6 +135,21 @@ void Channel::setLongValue(std::string attr, long long val)
 	m_pimpl->setLongValue(attr, val);
 }
 
+long long Channel::getLongValue(std::string attr)
+{
+	return m_pimpl->getLongValue(attr);
+}
+
+void Channel::setBoolValue(std::string attr, bool val)
+{
+	m_pimpl->setBoolValue(attr, val);
+}
+
+bool Channel::getBoolValue(std::string attr)
+{
+	return m_pimpl->getBoolValue(attr);
+}
+
 void Channel::setStringValue(std::string attr, std::string val)
 {
 	m_pimpl->setStringValue(attr, val);

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -26,8 +26,8 @@ using namespace libm2k::contexts;
 /*
  * Represents an iio_DeviceGeneric
  */
-DeviceGeneric::DeviceGeneric(struct iio_context* context, std::string dev_name, bool input) :
-	m_pimpl(std::unique_ptr<DeviceGenericImpl>(new DeviceGenericImpl(context, dev_name, input)))
+DeviceGeneric::DeviceGeneric(struct iio_context* context, std::string dev_name) :
+	m_pimpl(std::unique_ptr<DeviceGenericImpl>(new DeviceGenericImpl(context, dev_name)))
 {
 }
 
@@ -40,14 +40,14 @@ DeviceGeneric::~DeviceGeneric()
 {
 }
 
-Channel* DeviceGeneric::getChannel(unsigned int chnIdx)
+Channel* DeviceGeneric::getChannel(unsigned int chnIdx, bool output)
 {
-	return m_pimpl->getChannel(chnIdx);
+	return m_pimpl->getChannel(chnIdx, output);
 }
 
-Channel* DeviceGeneric::getChannel(std::string id)
+Channel* DeviceGeneric::getChannel(std::string id, bool output)
 {
-	return m_pimpl->getChannel(id);
+	return m_pimpl->getChannel(id, output);
 }
 
 bool DeviceGeneric::isChannel(unsigned int chnIdx, bool output)
@@ -55,14 +55,14 @@ bool DeviceGeneric::isChannel(unsigned int chnIdx, bool output)
 	return m_pimpl->isChannel(chnIdx, output);
 }
 
-void DeviceGeneric::enableChannel(unsigned int chnIdx, bool enable)
+void DeviceGeneric::enableChannel(unsigned int chnIdx, bool enable, bool output)
 {
-	m_pimpl->enableChannel(chnIdx, enable);
+	m_pimpl->enableChannel(chnIdx, enable, output);
 }
 
-bool DeviceGeneric::isChannelEnabled(unsigned int chnIdx)
+bool DeviceGeneric::isChannelEnabled(unsigned int chnIdx, bool output)
 {
-	return m_pimpl->isChannelEnabled(chnIdx);
+	return m_pimpl->isChannelEnabled(chnIdx, output);
 }
 
 string DeviceGeneric::getName()
@@ -165,19 +165,19 @@ std::string DeviceGeneric::getHardwareRevision()
 	return m_pimpl->getHardwareRevision();
 }
 
-unsigned int DeviceGeneric::getNbChannels()
+unsigned int DeviceGeneric::getNbChannels(bool output)
 {
-	return m_pimpl->getNbChannels();
+	return m_pimpl->getNbChannels(output);
 }
 
-void DeviceGeneric::convertChannelHostFormat(unsigned int chn_idx, int16_t *avg, int16_t *src)
+void DeviceGeneric::convertChannelHostFormat(unsigned int chn_idx, int16_t *avg, int16_t *src, bool output)
 {
-	m_pimpl->convertChannelHostFormat(chn_idx, avg, src);
+	m_pimpl->convertChannelHostFormat(chn_idx, avg, src, output);
 }
 
-void DeviceGeneric::convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src)
+void DeviceGeneric::convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src, bool output)
 {
-	m_pimpl->convertChannelHostFormat(chn_idx, avg, src);
+	m_pimpl->convertChannelHostFormat(chn_idx, avg, src, output);
 }
 
 void DeviceGeneric::setKernelBuffersCount(unsigned int count)

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -26,9 +26,9 @@ using namespace libm2k::contexts;
 /*
  * Represents an iio_device
  */
-DeviceIn::DeviceIn(struct iio_context* context, std::string dev_name, bool input) :
-	DeviceGeneric(context, dev_name, input),
-	m_pimpl(std::unique_ptr<DeviceInImpl>(new DeviceInImpl(context, dev_name, input)))
+DeviceIn::DeviceIn(struct iio_context* context, std::string dev_name) :
+	DeviceGeneric(context, dev_name),
+	m_pimpl(std::unique_ptr<DeviceInImpl>(new DeviceInImpl(context, dev_name)))
 {
 }
 

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -26,9 +26,9 @@ using namespace libm2k::contexts;
 /*
  * Represents an iio_device
  */
-DeviceOut::DeviceOut(struct iio_context* context, std::string dev_name, bool input) :
-	DeviceGeneric(context, dev_name, input),
-	m_pimpl(std::unique_ptr<DeviceOutImpl>(new DeviceOutImpl(context, dev_name, input)))
+DeviceOut::DeviceOut(struct iio_context* context, std::string dev_name) :
+	DeviceGeneric(context, dev_name),
+	m_pimpl(std::unique_ptr<DeviceOutImpl>(new DeviceOutImpl(context, dev_name)))
 {
 }
 

--- a/src/utils/private/channel_impl.cpp
+++ b/src/utils/private/channel_impl.cpp
@@ -265,6 +265,19 @@ public:
 		}
 	}
 
+	long long getLongValue(std::string attr)
+	{
+		if (!m_channel) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		}
+		long long value = 0;
+		int ret = iio_channel_attr_read_longlong(m_channel, attr.c_str(), &value);
+		if (ret < 0) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		}
+		return value;
+	}
+
 	void setStringValue(std::string attr, std::string val)
 	{
 		if (!m_channel) {
@@ -287,6 +300,30 @@ public:
 			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
 		}
 		return std::string(value);
+	}
+
+	void setBoolValue(std::string attr, bool val)
+	{
+		if (!m_channel) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		}
+		int ret = iio_channel_attr_write_bool(m_channel, attr.c_str(), val);
+		if (ret < 0) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		}
+	}
+
+	bool getBoolValue(std::string attr)
+	{
+		if (!m_channel) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		}
+		bool value;
+		int ret = iio_channel_attr_read_bool(m_channel, attr.c_str(), &value);
+		if (ret < 0) {
+			throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		}
+		return value;
 	}
 
 	bool isValid()

--- a/src/utils/private/deviceout_impl.cpp
+++ b/src/utils/private/deviceout_impl.cpp
@@ -41,7 +41,7 @@ public:
 	/*
 	 * Represents an iio_device
 	 */
-	DeviceOutImpl(struct iio_context* context, std::string dev_name = "", bool input = false)
+	DeviceOutImpl(struct iio_context* context, std::string dev_name = "")
 	{
 		m_context = context;
 		m_dev = nullptr;
@@ -61,37 +61,29 @@ public:
 				m_buffer = nullptr;
 			}
 
-			__try {
-				unsigned int nb_channels = iio_device_get_channels_count(m_dev);
-				for (unsigned int i = 0; i < nb_channels; i++) {
-					Channel *chn = nullptr;
-					if (input) {
-						chn = new Channel(m_dev, i);
-						if (chn->isOutput()) {
-							delete chn;
-							chn = nullptr;
-							continue;
-						}
-					} else {
-						std::string name = "voltage" + std::to_string(i);
+			unsigned int nb_channels = iio_device_get_channels_count(m_dev);
+			for (unsigned int i = 0; i < nb_channels; i++) {
+				Channel *chn = nullptr;
 
-						chn = new Channel(m_dev, name.c_str(), true);
-						if (!chn->isValid()) {
-							delete chn;
-							chn = nullptr;
-							chn = new Channel(m_dev, name.c_str(), false);
-						}
-					}
-					if (!chn->isValid()) {
-						delete chn;
-						chn = nullptr;
-						continue;
-					}
-					m_channel_list.push_back(chn);
+				chn = new Channel(m_dev, i);
+				if (!chn->isValid()) {
+					delete chn;
+					chn = nullptr;
+					continue;
 				}
-			} __catch (std::exception &e) {
 
+				if (chn->isOutput()) {
+					m_channel_list.push_back(chn);
+				} else {
+					delete chn;
+					chn = nullptr;
+					continue;
+				}
 			}
+			std::sort(m_channel_list.begin(), m_channel_list.end(), [](Channel* lchn, Channel* rchn)
+			{
+				return Utils::compareNatural(lchn->getId(), rchn->getId());
+			});
 		}
 	}
 

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -17,17 +17,18 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include "libm2k/m2kexceptions.hpp"
 #include "libm2k/utils/utils.hpp"
 #include <regex>
 #include <iostream>
 #include <fstream>
 #include <string>
 #include <algorithm>
-#include "libm2k/m2kexceptions.hpp"
-
 #include <thread>
 #include <chrono>
 #include <iostream>
+#include <cctype>
+#include <sstream>
 
 using namespace std;
 using namespace libm2k::utils;
@@ -287,4 +288,36 @@ int Utils::compareVersions(std::string v1, std::string v2)
 	}
 
 	return v1.compare(v2);
+}
+
+bool Utils::compareNatural(const std::string& a, const std::string& b){
+	if (a.empty()) {
+		return true;
+	} else if (b.empty()) {
+		return false;
+	} else if (std::isdigit(a[0]) && !std::isdigit(b[0])) {
+		return true;
+	} else if (!std::isdigit(a[0]) && std::isdigit(b[0])) {
+		return false;
+	} else if (!std::isdigit(a[0]) && !std::isdigit(b[0])) {
+		if (a[0] == b[0]) {
+			return compareNatural(a.substr(1), b.substr(1));
+		}
+		return (a < b);
+	}
+
+	std::istringstream string_stream_a(a);
+	std::istringstream string_stream_b(b);
+	int int_a, int_b;
+	std::string a_new, b_new;
+
+	string_stream_a >> int_a;
+	string_stream_b >> int_b;
+	if (int_a != int_b) {
+		return (int_a < int_b);
+	}
+
+	std::getline(string_stream_a, a_new);
+	std::getline(string_stream_b, b_new);
+	return (compareNatural(a_new, b_new));
 }


### PR DESCRIPTION
Previously, DeviceGeneric(the class which handles the iio_device interaction) scanned channels using their index (for DMMs) and using their name/ID for all the other devices (ADCs, DACs). It assumed that all the ADC or DAC channels are called "voltageX" which is not right.

In order to correctly use the channels, it scans them all based on the index. But this is not enough, the list of channels is separated in input and output channels and sorted based on the ID of each channel (could be improved) because the order in iio_device might change.

Related to issue #53 . 

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>