### PR TITLE
Device In: Handle all types of data sizes.

### DIFF
--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -58,6 +58,8 @@ public:
 	const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process);
 	const short *getSamplesRawInterleaved(unsigned int nb_samples);
+	void* getSamplesRawInterleavedVoid(int nb_samples);
+
 	void stop();
 	void setCyclic(bool enable);
 	void flushBuffer();

--- a/include/libm2k/utils/channel.hpp
+++ b/include/libm2k/utils/channel.hpp
@@ -65,6 +65,7 @@ public:
 
 	void enableChannel(bool enable);
 	uintptr_t getFirst(struct iio_buffer* buffer);
+	void *getFirstVoid(iio_buffer *buffer);
 
 	bool isValid();
 private:

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -48,8 +48,9 @@ public:
 	virtual const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double (int16_t, unsigned int)> process);
 	virtual const short *getSamplesRawInterleaved(unsigned int nb_samples);
-	virtual void flushBuffer();
+	void* getSamplesRawInterleavedVoid(unsigned int nb_samples);
 
+	virtual void flushBuffer();
 private:
 	class DeviceInImpl;
 	std::unique_ptr<DeviceInImpl> m_pimpl;

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -103,6 +103,11 @@ const short *Buffer::getSamplesRawInterleaved(unsigned int nb_samples)
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }
 
+void* Buffer::getSamplesRawInterleavedVoid(int nb_samples)
+{
+	return m_pimpl->getSamplesRawInterleavedVoid(nb_samples);
+}
+
 void Buffer::stop()
 {
 	m_pimpl->stop();

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -75,6 +75,11 @@ uintptr_t Channel::getFirst(iio_buffer *buffer)
 	return m_pimpl->getFirst(buffer);
 }
 
+void *Channel::getFirstVoid(iio_buffer *buffer)
+{
+	return m_pimpl->getFirstVoid(buffer);
+}
+
 bool Channel::isValid()
 {
 	return m_pimpl->isValid();

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -63,6 +63,11 @@ const short *DeviceIn::getSamplesRawInterleaved(unsigned int nb_samples)
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }
 
+void* DeviceIn::getSamplesRawInterleavedVoid(unsigned int nb_samples)
+{
+	return m_pimpl->getSamplesRawInterleavedVoid(nb_samples);
+}
+
 void DeviceIn::flushBuffer()
 {
 	m_pimpl->flushBuffer();

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -365,6 +365,11 @@ public:
 
 	const short* getSamplesRawInterleaved(int nb_samples)
 	{
+		return static_cast<const short*>(getSamplesRawInterleavedVoid(nb_samples));
+	}
+
+	void *getSamplesRawInterleavedVoid(int nb_samples)
+	{
 		bool anyChannelEnabled = false;
 		if (Utils::getIioDeviceDirection(m_dev) != INPUT) {
 			throw_exception(EXC_INVALID_PARAMETER, "Device not found, so no buffer was created");
@@ -391,14 +396,12 @@ public:
 		}
 
 		ssize_t ret = iio_buffer_refill(m_buffer);
-
 		if (ret < 0) {
 			destroy();
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 		}
 
-		const short* p_dat = (const short*) m_channel_list.at(0)->getFirst(m_buffer);
-		return p_dat;
+		return m_channel_list.at(0)->getFirstVoid(m_buffer);
 	}
 
 	const double* getSamplesInterleaved(int nb_samples,

--- a/src/utils/private/channel_impl.cpp
+++ b/src/utils/private/channel_impl.cpp
@@ -124,7 +124,13 @@ public:
 
 	uintptr_t getFirst(iio_buffer *buffer)
 	{
-		return (uintptr_t)iio_buffer_first(buffer, m_channel);
+		return reinterpret_cast<uintptr_t>(getFirstVoid(buffer));
+	}
+
+
+	void *getFirstVoid(iio_buffer *buffer)
+	{
+		return iio_buffer_first(buffer, m_channel);
 	}
 
 	void write(struct iio_buffer* buffer, std::vector<short> const &data)

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -130,6 +130,15 @@ public:
 		return m_buffer->getSamples(nb_samples, process);
 	}
 
+	void* getSamplesRawInterleavedVoid(unsigned int nb_samples)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		return m_buffer->getSamplesRawInterleavedVoid(nb_samples);
+	}
+
 	const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process)
 	{


### PR DESCRIPTION
Allow libm2k to handle data acquisition on devices with data sizes different from data size on "m2k-adc" in ADALM2000.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>