### PR TITLE
Examples: fix trigger notation usage

### DIFF
--- a/bindings/csharp/examples/analog.cs
+++ b/bindings/csharp/examples/analog.cs
@@ -40,12 +40,12 @@ namespace examples
             ain.setRange((ANALOG_IN_CHANNEL)0, -10.0, 10.0); // nu are idxchannel
             ain.setRange((ANALOG_IN_CHANNEL)1, M2K_RANGE.PLUS_MINUS_25V);
             
-            // Uncomment the following block to enable triggering
-            // trig.setAnalogSource(M2K_TRIGGER_SOURCE.CHANNEL_1);
-            // trig.setAnalogCondition(0, M2K_TRIGGER_CONDITION.RISING_EDGE);
+	    // Uncomment the following block to enable triggering
             // trig.setAnalogLevel(0, 0.5);
             // trig.setAnalogDelay(0);
             // trig.setAnalogMode(0, M2K_TRIGGER_MODE.ALWAYS);
+	    // trig.setAnalogSource(M2K_TRIGGER_SOURCE_ANALOG.CHANNEL_1);
+	    // trig.setAnalogCondition(0, M2K_TRIGGER_CONDITION_ANALOG.RISING_EDGE_ANALOG);
 
             // setup analog output
             aout.setSampleRate(0, 750000);

--- a/bindings/python/examples/analog.py
+++ b/bindings/python/examples/analog.py
@@ -31,7 +31,7 @@ ain.setRange(0,-10,10)
 
 ### uncomment the following block to enable triggering
 #trig.setAnalogSource(0) # Channel 0 as source
-#trig.setAnalogCondition(0,libm2k.RISING_EDGE)
+#trig.setAnalogCondition(0,libm2k.RISING_EDGE_ANALOG)
 #trig.setAnalogLevel(0,0.5)  # Set trigger level at 0.5
 #trig.setAnalogDelay(0) # Trigger is centered
 #trig.setAnalogMode(1, libm2k.ANALOG)

--- a/examples/analog/main.cpp
+++ b/examples/analog/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
 #ifdef TRIGGERING
 	// setup analog trigger
 	trig->setAnalogSource(CHANNEL_1);
-	trig->setAnalogCondition(0,RISING_EDGE);
+	trig->setAnalogCondition(0,RISING_EDGE_ANALOG);
 	trig->setAnalogLevel(0, 0.5);
 	trig->setAnalogDelay(0);
 	trig->setAnalogMode(0,ANALOG);


### PR DESCRIPTION
Update all the examples to use the latest M2K trigger notations (added in PR #54  )

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>