### PR TITLE
M2kDigital: Fix TX enableChannel method

### DIFF
--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -272,7 +272,7 @@ public:
 
 	void enableChannel(unsigned int index, bool enable)
 	{
-		if (index < getNbChannels(true)) {
+		if (index < m_dev_write->getNbChannels(true)) {
 			m_dev_write->enableChannel(index, enable, true);
 			m_tx_channels_enabled.at(index) = enable;
 		} else {
@@ -282,7 +282,7 @@ public:
 
 	void enableChannel(DIO_CHANNEL index, bool enable)
 	{
-		if (index < getNbChannels(true)) {
+		if (index < m_dev_write->getNbChannels(true)) {
 			m_dev_write->enableChannel(index, enable, true);
 			m_tx_channels_enabled.at(index) = enable;
 		} else {


### PR DESCRIPTION
 After recent changes to the Device In/Out/Generic channels
scanning system, the enableChannel() method no longer works without
specifying the TX device for channel number checking. That is because
the GenericDevice(m2k-logic-analyzer) only has input channels.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>