### PR TITLE
Rework Python exposed methods.

### DIFF
--- a/bindings/python/examples/analog_raw_bytes.py
+++ b/bindings/python/examples/analog_raw_bytes.py
@@ -1,0 +1,87 @@
+# This example assumes the following connections:
+# W1 -> 1+
+# W2 -> 2+
+# GND -> 1-
+# GND -> 2-
+#
+# The application will generate a sine and triangular wave on W1 and W2. The signal is fed back into the analog input
+# and the voltage values are displayed on the screen
+
+import libm2k
+import matplotlib.pyplot as plt
+import time
+import numpy as np
+import struct
+
+NB_OUT_SAMPLES = 1024
+
+ctx=libm2k.m2kOpen()
+if ctx is None:
+	print("Connection Error: No ADALM2000 device available/connected to your PC.")
+	exit(1)
+
+ctx.calibrateADC()
+ctx.calibrateDAC()
+
+ain=ctx.getAnalogIn()
+aout=ctx.getAnalogOut()
+trig=ain.getTrigger()
+
+ain.enableChannel(0,True)
+ain.enableChannel(1,True)
+ain.setSampleRate(100000)
+ain.setRange(0,-10,10)
+ain.setKernelBuffersCount(1)
+
+### uncomment the following block to enable triggering
+#trig.setAnalogSource(0) # Channel 0 as source
+#trig.setAnalogCondition(0,libm2k.RISING_EDGE_ANALOG)
+#trig.setAnalogLevel(0,0.5)  # Set trigger level at 0.5
+#trig.setAnalogDelay(0) # Trigger is centered
+#trig.setAnalogMode(1, libm2k.ANALOG)
+
+aout.setSampleRate(0, 750000)
+aout.setSampleRate(1, 750000)
+aout.enableChannel(0, True)
+aout.enableChannel(1, True)
+
+x=np.linspace(-np.pi, np.pi, NB_OUT_SAMPLES)
+buffer1=np.linspace(-3.0, 3.00, NB_OUT_SAMPLES)
+buffer2=np.sin(x)
+
+aout.setCyclic(True)
+
+# Convert every voltage sample from the signal to its raw value.
+# The library method expects a short* (C++), but in Python a bytearray is accepted.
+# Change the type of the array from 'int64' to 'int16'.
+buffer1_raw = np.array([aout.convertVoltsToRaw(0, item) for item in buffer1])
+buffer1_raw = buffer1_raw.astype('int16')
+buffer1_raw = bytearray(buffer1_raw)
+buffer2_raw = np.array([aout.convertVoltsToRaw(1, item) for item in buffer2])
+buffer2_raw = buffer2_raw.astype('int16')
+buffer2_raw = bytearray(buffer2_raw)
+
+aout.pushRawBytes(0, buffer1_raw, NB_OUT_SAMPLES)
+aout.pushRawBytes(1, buffer2_raw, NB_OUT_SAMPLES)
+
+for i in range(10):					# gets 10 triggered samples then quits
+	ain.flushBuffer()
+	data = ain.getSamplesRawInterleaved(1000)	# allows a memory view
+	data = data.tobytes()				# convert the memory view to a readable bytearray
+	count = int(len(data) / 2)
+
+	data = struct.unpack('h'*count, data)		# interpret the raw interleaved samples as shorts
+	data1 = data[0::2]
+	data2 = data[1::2]
+
+	# convert raw values to Volts for each channel
+	data1 = [ain.convertRawToVolts(0, item) for item in data1]
+	data2 = [ain.convertRawToVolts(1, item) for item in data2]
+	print(data1)
+
+	plt.plot(data1)
+	plt.plot(data2)
+	plt.show()
+	time.sleep(0.1)
+
+libm2k.contextClose(ctx)

--- a/examples/analog/sync_stream_diff_frequencies.cpp
+++ b/examples/analog/sync_stream_diff_frequencies.cpp
@@ -24,7 +24,7 @@ void
 pushNTimes(M2kAnalogOut *analogOut, unsigned int channelIndex, double *samples, unsigned int nbSamples, unsigned int n)
 {
 	for (int i = 0; i < n; i++) {
-		analogOut->push(channelIndex, samples, nbSamples);
+		analogOut->pushBytes(channelIndex, samples, nbSamples);
 	}
 }
 

--- a/include/libm2k/analog/genericanalogin.hpp
+++ b/include/libm2k/analog/genericanalogin.hpp
@@ -50,6 +50,8 @@ public:
 	void setKernelBuffersCount(unsigned int count);
 	std::string getDeviceName();
 
+	struct IIO_OBJECTS getIioObjects();
+
 private:
 	class GenericAnalogInImpl;
 	std::unique_ptr<GenericAnalogInImpl> m_pimpl;

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -109,15 +109,6 @@ public:
 	*/
 	const short* getSamplesRawInterleaved(unsigned int nb_samples);
 
-	/**
-	* @brief Convert the raw value of a sample into volts
-	*
-	* @param sample The raw value of a sample
-	* @param channel The index corresponding to the channel
-	* @return The value of a sample converted into volts
-	*/
-	double processSample(int16_t sample, unsigned int channel);
-
 
 	/**
 	* @brief Retrieve the average raw value of the given channel
@@ -404,19 +395,29 @@ public:
 	/**
 	 * @private
 	 */
-	double convertRawToVolts(int sample, double correctionGain = 1,
+	double convRawToVolts(int sample, double correctionGain = 1,
 		double hw_gain = 0.02,
 		double filterCompensation = 1,
-		double offset = 0);
+		double offset = 0) const;
 
 
 	/**
-	 * @private
+	 * @brief Convert the raw value of a sample into volts
+	 * @param raw: the raw value of a sample;
+	 * @param channel: The index corresponding to the channel;
+	 * @return The value of a sample converted into volts;
 	 */
-	int convertVoltsToRaw(double voltage, double correctionGain = 1,
-		double hw_gain = 0.02,
-		double filterCompensation = 1,
-		double offset = 0);
+	double convertRawToVolts(unsigned int channel, short raw);
+
+
+	/**
+	* @brief Convert the voltage value of a sample into raw
+	*
+	* @param voltage The voltage value of a sample;
+	* @param channel The index corresponding to the channel;
+	* @return The value of a sample converted into raw;
+	*/
+	short convertVoltsToRaw(unsigned int channel, double voltage);
 
 
 	/**

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -479,6 +479,13 @@ public:
 	*/
 	libm2k::M2kHardwareTrigger* getTrigger();
 
+	/**
+	 * @brief Get access to IIO channels, buffers, devices and context.
+	 * Can be used when debugging directly with libiio.
+	 * @return IIO_OBJECTS structure.
+	 */
+	struct IIO_OBJECTS getIioObjects();
+
 private:
 	class M2kAnalogInImpl;
 	std::unique_ptr<M2kAnalogInImpl> m_pimpl;

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -404,6 +404,14 @@ public:
 	 */
 	void setKernelBuffersCount(unsigned int chnIdx, unsigned int count);
 
+
+	/**
+	 * @brief Get access to IIO channels, buffers, devices and context.
+	 * @note Can be used when debugging directly with libiio.
+	 * @return IIO_OBJECTS structure.
+	 */
+	struct IIO_OBJECTS getIioObjects();
+
 private:
 	class M2kAnalogOutImpl;
 	std::unique_ptr<M2kAnalogOutImpl> m_pimpl;

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -240,7 +240,7 @@ public:
 	* @param filterCompensation The value of the filter compensation
 	* @return The raw value
 	*/
-	int convertVoltsToRaw(double voltage, double vlsb,
+	short convVoltsToRaw(double voltage, double vlsb,
 		double filterCompensation);
 
 	/**
@@ -403,6 +403,24 @@ public:
 	 * @param count the number of kernel buffers
 	 */
 	void setKernelBuffersCount(unsigned int chnIdx, unsigned int count);
+
+
+	/**
+	 * @brief Convert the volts value of a sample into raw
+	 * @param channel The index corresponding to the channel
+	 * @param voltage The volts value of a sample
+	 * @return The value of a sample converted into raw
+	 */
+	short convertVoltsToRaw(unsigned int channel, double voltage);
+
+
+	/**
+	 * @brief Convert the raw value of a sample into volts
+	 * @param channel The index corresponding to the channel
+	 * @param raw The raw value of a sample
+	 * @return The value of a sample converted into volts
+	 */
+	double convertRawToVolts(unsigned int channel, short raw);
 
 
 	/**

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -254,7 +254,7 @@ public:
 	* @note The given channel won't be synchronized with the other channel
 	* @throw EXC_OUT_OF_RANGE No such channel
 	*/
-	void push(unsigned int chnIdx, double *data, unsigned int nb_samples);
+	void pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples);
 
 
 	/**
@@ -268,7 +268,7 @@ public:
 	* @note The given channel won't be synchronized with the other channel
 	* @throw EXC_OUT_OF_RANGE No such channel
 	*/
-	void pushRaw(unsigned int chnIdx, short *data, unsigned int nb_samples);
+	void pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples);
 
 
 	/**

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -355,6 +355,14 @@ public:
 	 */
 	void setKernelBuffersCountIn(unsigned int count);
 
+
+	/**
+	 * @brief Get access to IIO channels, buffers, devices and context.
+	 * Can be used when debugging directly with libiio.
+	 * @return IIO_OBJECTS structure.
+	 */
+	struct IIO_OBJECTS getIioObjects();
+
 	/** @} */
 
 private:

--- a/include/libm2k/enums.hpp
+++ b/include/libm2k/enums.hpp
@@ -25,6 +25,12 @@
 #include <string>
 #include <vector>
 
+extern "C" {
+	struct iio_context;
+	struct iio_device;
+	struct iio_channel;
+	struct iio_buffer;
+}
 /**
  * @file libm2k/enums.hpp
  * @brief Generic M2K enumerations
@@ -162,6 +168,19 @@ namespace libm2k {
 		std::vector<M2K_TRIGGER_MODE> mode; ///<Triggering mode
 		M2K_TRIGGER_SOURCE_ANALOG trigger_source; ///< Triggering source
 		int delay; ///< Trigger's delay
+	};
+
+
+	/**
+	 * @private
+	 */
+	struct IIO_OBJECTS {
+		std::vector<iio_channel*> channels_in;
+		std::vector<iio_channel*> channels_out;
+		std::vector<iio_device*> devices;
+		std::vector<iio_buffer*> buffers_rx;
+		std::vector<iio_buffer*> buffers_tx;
+		iio_context* context;
 	};
 }
 

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -66,6 +66,8 @@ public:
 	void stop();
 	void setCyclic(bool enable);
 	void flushBuffer();
+
+	struct iio_buffer* getBuffer();
 private:
 
 	class BufferImpl;

--- a/include/libm2k/utils/channel.hpp
+++ b/include/libm2k/utils/channel.hpp
@@ -70,6 +70,7 @@ public:
 	void *getFirstVoid(iio_buffer *buffer);
 
 	bool isValid();
+	struct iio_channel* getChannel();
 private:
 	class ChannelImpl;
 	std::shared_ptr<ChannelImpl> m_pimpl;

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <libm2k/m2kglobal.hpp>
 #include <libm2k/utils/devicegeneric.hpp>
+#include <libm2k/enums.hpp>
 
 using namespace std;
 
@@ -53,6 +54,7 @@ public:
 	void* getSamplesRawInterleavedVoid(unsigned int nb_samples);
 
 	virtual void flushBuffer();
+	virtual struct IIO_OBJECTS getIioObjects();
 private:
 	class DeviceInImpl;
 	std::unique_ptr<DeviceInImpl> m_pimpl;

--- a/include/libm2k/utils/deviceout.hpp
+++ b/include/libm2k/utils/deviceout.hpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <libm2k/m2kglobal.hpp>
 #include <libm2k/utils/devicegeneric.hpp>
+#include <libm2k/enums.hpp>
 
 using namespace std;
 
@@ -55,6 +56,7 @@ public:
 	virtual void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
 	virtual void stop();
 	virtual void setKernelBuffersCount(unsigned int count);
+	virtual struct IIO_OBJECTS getIioObjects();
 
 private:
 	class DeviceOutImpl;

--- a/src/analog/genericanalogin.cpp
+++ b/src/analog/genericanalogin.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "private/genericanalogin_impl.cpp"
+#include "libm2k/enums.hpp"
 
 using namespace libm2k::utils;
 using namespace libm2k::analog;
@@ -82,6 +83,11 @@ std::vector<double> GenericAnalogIn::getAvailableSampleRates()
 string GenericAnalogIn::getDeviceName()
 {
 	return m_pimpl->getDeviceName();
+}
+
+libm2k::IIO_OBJECTS GenericAnalogIn::getIioObjects()
+{
+	return m_pimpl->getIioObjects();
 }
 
 void GenericAnalogIn::enableChannel(unsigned int index, bool enable)

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -115,6 +115,11 @@ libm2k::M2kHardwareTrigger *M2kAnalogIn::getTrigger()
 	return m_pimpl->getTrigger();
 }
 
+libm2k::IIO_OBJECTS M2kAnalogIn::getIioObjects()
+{
+	return m_pimpl->getIioObjects();
+}
+
 void M2kAnalogIn::flushBuffer()
 {
 	m_pimpl->flushBuffer();

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -56,17 +56,10 @@ void M2kAnalogIn::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset)
 	m_pimpl->setAdcCalibOffset(channel, calib_offset);
 }
 
-double M2kAnalogIn::convertRawToVolts(int sample, double correctionGain,
-		double hw_gain, double filterCompensation, double offset)
+double M2kAnalogIn::convRawToVolts(int sample, double correctionGain,
+		double hw_gain, double filterCompensation, double offset) const
 {
-	return m_pimpl->convertRawToVolts(sample, correctionGain,
-					  hw_gain, filterCompensation, offset);
-}
-
-int M2kAnalogIn::convertVoltsToRaw(double voltage, double correctionGain,
-		double hw_gain, double filterCompensation, double offset)
-{
-	return m_pimpl->convertVoltsToRaw(voltage, correctionGain,
+	return m_pimpl->convRawToVolts(sample, correctionGain,
 					  hw_gain, filterCompensation, offset);
 }
 
@@ -145,9 +138,14 @@ const short *M2kAnalogIn::getSamplesRawInterleaved(unsigned int nb_samples)
 	return m_pimpl->getSamplesRawInterleaved(nb_samples);
 }
 
-double M2kAnalogIn::processSample(int16_t sample, unsigned int channel)
+short M2kAnalogIn::convertVoltsToRaw(unsigned int channel, double voltage)
 {
-	return m_pimpl->processSample(sample, channel);
+	return m_pimpl->convertVoltsToRaw(channel, voltage);
+}
+
+double M2kAnalogIn::convertRawToVolts(unsigned int channel, short raw)
+{
+	return m_pimpl->convertRawToVolts(channel, raw);
 }
 
 short M2kAnalogIn::getVoltageRaw(unsigned int ch)

--- a/src/analog/m2kanalogout.cpp
+++ b/src/analog/m2kanalogout.cpp
@@ -21,6 +21,7 @@
 
 #include "private/m2kanalogout_impl.cpp"
 
+using namespace libm2k;
 using namespace libm2k::analog;
 using namespace libm2k::utils;
 using namespace std;
@@ -215,4 +216,9 @@ bool M2kAnalogOut::isChannelEnabled(unsigned int chnIdx)
 void M2kAnalogOut::setKernelBuffersCount(unsigned int chnIdx, unsigned int count)
 {
 	return m_pimpl->setKernelBuffersCount(chnIdx, count);
+}
+
+IIO_OBJECTS M2kAnalogOut::getIioObjects()
+{
+	return m_pimpl->getIioObjects();
 }

--- a/src/analog/m2kanalogout.cpp
+++ b/src/analog/m2kanalogout.cpp
@@ -131,10 +131,10 @@ double M2kAnalogOut::getCalibscale(unsigned int index)
 	return m_pimpl->getCalibscale(index);
 }
 
-int M2kAnalogOut::convertVoltsToRaw(double voltage, double vlsb,
+short M2kAnalogOut::convVoltsToRaw(double voltage, double vlsb,
 				       double filterCompensation)
 {
-	return m_pimpl->convertVoltsToRaw(voltage, vlsb, filterCompensation);
+	return m_pimpl->convVoltsToRaw(voltage, vlsb, filterCompensation);
 }
 
 
@@ -216,6 +216,16 @@ bool M2kAnalogOut::isChannelEnabled(unsigned int chnIdx)
 void M2kAnalogOut::setKernelBuffersCount(unsigned int chnIdx, unsigned int count)
 {
 	return m_pimpl->setKernelBuffersCount(chnIdx, count);
+}
+
+short M2kAnalogOut::convertVoltsToRaw(unsigned int channel, double voltage)
+{
+	return m_pimpl->convertVoltsToRaw(channel, voltage);
+}
+
+double M2kAnalogOut::convertRawToVolts(unsigned int channel, short raw)
+{
+	return m_pimpl->convertRawToVolts(channel, raw);
 }
 
 IIO_OBJECTS M2kAnalogOut::getIioObjects()

--- a/src/analog/m2kanalogout.cpp
+++ b/src/analog/m2kanalogout.cpp
@@ -158,24 +158,24 @@ void M2kAnalogOut::pushRaw(std::vector<std::vector<short>> const &data)
 	m_pimpl->pushRaw(data);
 }
 
-void M2kAnalogOut::push(unsigned int chnIdx, double *data, unsigned int nb_samples)
+void M2kAnalogOut::pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples)
 {
-	m_pimpl->push(chnIdx, data, nb_samples);
+	m_pimpl->pushBytes(chnIdx, data, nb_samples);
 }
 
-void M2kAnalogOut::pushRaw(unsigned int chnIdx, short *data, unsigned int nb_samples)
+void M2kAnalogOut::pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples)
 {
-	m_pimpl->pushRaw(chnIdx, data, nb_samples);
+	m_pimpl->pushRawBytes(chnIdx, data, nb_samples);
 }
 
-void M2kAnalogOut::pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples_per_channel)
+void M2kAnalogOut::pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples)
 {
-	m_pimpl->push(data, nb_channels, nb_samples_per_channel);
+	m_pimpl->pushInterleaved(data, nb_channels, nb_samples);
 }
 
-void M2kAnalogOut::pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples_per_channel)
+void M2kAnalogOut::pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples)
 {
-	m_pimpl->pushRaw(data, nb_channels, nb_samples_per_channel);
+	m_pimpl->pushRawInterleaved(data, nb_channels, nb_samples);
 }
 
 void M2kAnalogOut::push(std::vector<std::vector<double>> const &data)

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -145,7 +145,7 @@ public:
 		getVerticalOffset(channel);
 	}
 
-	double convertRawToVolts(int sample, double correctionGain,
+	double convRawToVolts(short sample, double correctionGain,
 					      double hw_gain, double filterCompensation, double offset)
 	{
 		// TO DO: explain this formula
@@ -153,12 +153,30 @@ public:
 			correctionGain * filterCompensation) + offset;
 	}
 
-	int convertVoltsToRaw(double voltage, double correctionGain,
+	double convertRawToVolts(unsigned int channel, short sample)
+	{
+		return convRawToVolts(sample,
+					 m_adc_calib_gain.at(channel),
+					 getValueForRange(m_input_range.at(channel)),
+					 getFilterCompensation(m_samplerate),
+					 -m_adc_hw_vert_offset.at(channel));
+	}
+
+	short convVoltsToRaw(double voltage, double correctionGain,
 					   double hw_gain, double filterCompensation, double offset)
 	{
 		// TO DO: explain this formula
-		return ((voltage - offset) / (correctionGain * filterCompensation) *
-			(2048 * 1.3 * hw_gain) / 0.78);
+		return (short)(((voltage - offset) / (correctionGain * filterCompensation) *
+				(2048 * 1.3 * hw_gain) / 0.78));
+	}
+
+	short convertVoltsToRaw(unsigned int channel, double voltage)
+	{
+		return convVoltsToRaw(voltage,
+					 m_adc_calib_gain.at(channel),
+					 getValueForRange(m_input_range.at(channel)),
+					 getFilterCompensation(m_samplerate),
+					 -m_adc_hw_vert_offset.at(channel));
 	}
 
 	double getCalibscale(unsigned int index)
@@ -260,7 +278,7 @@ public:
 	double processSample(int16_t sample, unsigned int channel)
 	{
 		if (m_need_processing) {
-			return convertRawToVolts(sample,
+			return convRawToVolts(sample,
 						 m_adc_calib_gain.at(channel),
 						 getValueForRange(m_input_range.at(channel)),
 						 getFilterCompensation(m_samplerate),

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -570,6 +570,11 @@ public:
 		}
 	}
 
+	struct IIO_OBJECTS getIioObjects()
+	{
+		return DeviceIn::getIioObjects();
+	}
+
 private:
 	std::shared_ptr<DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<DeviceGeneric> m_m2k_fabric;

--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -562,6 +562,16 @@ public:
 		m_nb_kernel_buffers[chnIdx] = count;
 	}
 
+	struct IIO_OBJECTS getIioObjects()
+	{
+		auto dev_a_iio = getDacDevice(0)->getIioObjects();
+		auto dev_b_iio = getDacDevice(1)->getIioObjects();
+		dev_a_iio.buffers_tx.insert(dev_a_iio.buffers_tx.end(), dev_b_iio.buffers_tx.begin(), dev_b_iio.buffers_tx.end());
+		dev_a_iio.channels_out.insert(dev_a_iio.channels_out.end(), dev_b_iio.channels_out.begin(), dev_b_iio.channels_out.end());
+		dev_a_iio.devices.insert(dev_a_iio.devices.end(), dev_b_iio.devices.begin(), dev_b_iio.devices.end());
+		return dev_a_iio;
+	}
+
 private:
 	std::shared_ptr<DeviceGeneric> m_m2k_fabric;
 	std::vector<double> m_calib_vlsb;

--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -291,18 +291,18 @@ public:
 	void pushRaw(std::vector<short> const &data, unsigned int chnIdx)
 	{
 		short *ptr = (short*)data.data();
-		pushRaw(chnIdx, ptr, data.size());
+		pushRawBytes(chnIdx, ptr, data.size());
 	}
 
-	void pushRaw(unsigned int chnIdx, short *data, unsigned int nb_samples)
+	void pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples)
 	{
 		if (chnIdx >= m_dac_devices.size()) {
 			throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
 		}
 
-		std::vector<short> raw_data_buffer(data, data + nb_samples);
+		m_dac_devices.at(chnIdx)->push(data, 0, nb_samples, getCyclic(chnIdx));
 
-		m_dac_devices.at(chnIdx)->push(raw_data_buffer, 0, getCyclic(chnIdx));
+		setSyncedDma(false, chnIdx);
 	}
 
 
@@ -312,10 +312,10 @@ public:
 	void push(std::vector<double> const &data, unsigned int chnIdx)
 	{
 		double *ptr = (double*)data.data();
-		push(chnIdx, ptr, data.size());
+		pushBytes(chnIdx, ptr, data.size());
 	}
 
-	void push(unsigned int chnIdx, double *data, unsigned int nb_samples)
+	void pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples)
 	{
 		if (chnIdx >= m_dac_devices.size()) {
 			throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
@@ -373,7 +373,7 @@ public:
 		}
 	}
 
-	void pushRaw(short *data, unsigned int nb_channels, unsigned int nb_samples)
+	void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples)
 	{
 		if ((nb_samples % nb_channels) !=0) {
                         throw_exception(EXC_INVALID_PARAMETER, "Analog Out: Input array length must be multiple of channels");
@@ -468,7 +468,7 @@ public:
 		}
 	}
 
-	void push(double *data, unsigned int nb_channels, unsigned int nb_samples)
+	void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples)
 	{
 		if ((nb_samples % nb_channels) !=0) {
                         throw_exception(EXC_INVALID_PARAMETER, "Analog Out: Input array length must be multiple of channels");

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -157,6 +157,11 @@ void M2kDigital::setKernelBuffersCountIn(unsigned int count)
 	m_pimpl->setKernelBuffersCountIn(count);
 }
 
+IIO_OBJECTS M2kDigital::getIioObjects()
+{
+	return m_pimpl->getIioObjects();
+}
+
 void M2kDigital::setOutputMode(DIO_CHANNEL chn, DIO_MODE mode)
 {
 	m_pimpl->setOutputMode(chn, mode);

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -386,6 +386,16 @@ public:
 		m_dev_write->setCyclic(cyclic);
 	}
 
+	struct IIO_OBJECTS getIioObjects()
+	{
+		auto tx_iio = m_dev_write->getIioObjects();
+		auto rx_iio = m_dev_read->getIioObjects();
+		rx_iio.buffers_tx.insert(rx_iio.buffers_tx.end(), tx_iio.buffers_tx.begin(), tx_iio.buffers_tx.end());
+		rx_iio.channels_out.insert(rx_iio.channels_out.end(), tx_iio.channels_out.begin(), tx_iio.channels_out.end());
+		rx_iio.devices.insert(rx_iio.devices.end(), tx_iio.devices.begin(), tx_iio.devices.end());
+		return rx_iio;
+	}
+
 
 private:
 	bool m_cyclic;

--- a/src/private/m2kcalibration_impl.cpp
+++ b/src/private/m2kcalibration_impl.cpp
@@ -242,8 +242,8 @@ public:
 		tmp = ch1_avg;
 		m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_2, &ch1_avg, &tmp);
 
-		voltage0 = m_m2k_adc->convertRawToVolts(ch0_avg, 1, 1);
-		voltage1 = m_m2k_adc->convertRawToVolts(ch1_avg, 1, 1);
+		voltage0 = m_m2k_adc->convRawToVolts(ch0_avg, 1, 1);
+		voltage1 = m_m2k_adc->convRawToVolts(ch1_avg, 1, 1);
 
 		m_adc_ch0_offset = (int)(2048 - ((voltage0 * 4096 * gain) / range));
 		m_adc_ch1_offset = (int)(2048 - ((voltage1 * 4096 * gain) / range));
@@ -288,8 +288,8 @@ public:
 		tmp = avg1;
 		m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_2, &avg1, &tmp);
 
-		avg0 = m_m2k_adc->convertRawToVolts(avg0, 1, 1);
-		avg1 = m_m2k_adc->convertRawToVolts(avg1, 1, 1);
+		avg0 = m_m2k_adc->convRawToVolts(avg0, 1, 1);
+		avg1 = m_m2k_adc->convRawToVolts(avg1, 1, 1);
 
 		m_adc_ch0_gain = vref1 / avg0;
 		m_adc_ch1_gain = vref1 / avg1;
@@ -527,9 +527,9 @@ out_cleanup:
 		tmp = ch1_avg;
 		m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_2, &ch1_avg, &tmp);
 
-		double voltage0 = m_m2k_adc->convertRawToVolts(
+		double voltage0 = m_m2k_adc->convRawToVolts(
 					ch0_avg, m_adc_ch0_gain, 1);
-		double voltage1 = m_m2k_adc->convertRawToVolts(
+		double voltage1 = m_m2k_adc->convRawToVolts(
 					ch1_avg, m_adc_ch1_gain, 1);
 
 		m_dac_a_ch_offset = (int)(2048 - ((voltage0 * 9.06 ) / 0.002658));
@@ -609,9 +609,9 @@ out_cleanup:
 		tmp = ch1_avg;
 		m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_2, &ch1_avg, &tmp);
 
-		double voltage0 = m_m2k_adc->convertRawToVolts(
+		double voltage0 = m_m2k_adc->convRawToVolts(
 					ch0_avg, m_adc_ch0_gain, 1);
-		double voltage1 = m_m2k_adc->convertRawToVolts(
+		double voltage1 = m_m2k_adc->convRawToVolts(
 					ch1_avg, m_adc_ch1_gain, 1);
 
 		// Taking into account the voltage divider on the loopback path

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -130,3 +130,8 @@ void Buffer::flushBuffer()
 {
 	m_pimpl->flushBuffer();
 }
+
+iio_buffer *Buffer::getBuffer()
+{
+	return m_pimpl->getBuffer();
+}

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -87,6 +87,11 @@ bool Channel::isValid()
 	return m_pimpl->isValid();
 }
 
+iio_channel *Channel::getChannel()
+{
+	return m_pimpl->getChannel();
+}
+
 void Channel::write(struct iio_buffer* buffer, std::vector<short> const &data)
 {
     m_pimpl->write(buffer, data);

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -22,6 +22,7 @@
 #include "private/devicein_impl.cpp"
 
 using namespace std;
+using namespace libm2k;
 using namespace libm2k::utils;
 using namespace libm2k::contexts;
 
@@ -73,4 +74,9 @@ void* DeviceIn::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 void DeviceIn::flushBuffer()
 {
 	m_pimpl->flushBuffer();
+}
+
+IIO_OBJECTS DeviceIn::getIioObjects()
+{
+	return m_pimpl->getIioObjects();
 }

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -22,6 +22,7 @@
 #include "private/deviceout_impl.cpp"
 
 using namespace std;
+using namespace libm2k;
 using namespace libm2k::utils;
 using namespace libm2k::contexts;
 
@@ -84,4 +85,9 @@ void DeviceOut::stop()
 void DeviceOut::setKernelBuffersCount(unsigned int count)
 {
 	m_pimpl->setKernelBuffersCount(count);
+}
+
+IIO_OBJECTS DeviceOut::getIioObjects()
+{
+	return m_pimpl->getIioObjects();
 }

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -502,6 +502,11 @@ public:
 		m_cyclic = enable;
 	}
 
+	struct iio_buffer* getBuffer()
+	{
+		return m_buffer;
+	}
+
 private:
 	struct iio_device* m_dev;
 	struct iio_buffer* m_buffer;

--- a/src/utils/private/channel_impl.cpp
+++ b/src/utils/private/channel_impl.cpp
@@ -339,6 +339,11 @@ public:
 		return !!m_channel;
 	}
 
+	struct iio_channel *getChannel()
+	{
+		return m_channel;
+	}
+
 private:
 	struct iio_device *m_device;
 	struct iio_channel *m_channel;

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -168,6 +168,19 @@ public:
 		m_buffer->flushBuffer();
 	}
 
+	struct IIO_OBJECTS getIioObjects()
+	{
+		IIO_OBJECTS iio_object = {};
+		iio_object.buffers_rx.push_back(m_buffer->getBuffer());
+
+		for (auto chn : m_channel_list) {
+			iio_object.channels_in.push_back(chn->getChannel());
+		}
+		iio_object.devices.push_back(m_dev);
+		iio_object.context = m_context;
+		return iio_object;
+	}
+
 private:
 	struct iio_context *m_context;
 	struct iio_device *m_dev;

--- a/src/utils/private/deviceout_impl.cpp
+++ b/src/utils/private/deviceout_impl.cpp
@@ -183,6 +183,19 @@ public:
 		}
 	}
 
+	struct IIO_OBJECTS getIioObjects()
+	{
+		IIO_OBJECTS iio_object = {};
+		iio_object.buffers_tx.push_back(m_buffer->getBuffer());
+
+		for (auto chn : m_channel_list) {
+			iio_object.channels_out.push_back(chn->getChannel());
+		}
+		iio_object.devices.push_back(m_dev);
+		iio_object.context = m_context;
+		return iio_object;
+	}
+
 private:
 	struct iio_context *m_context;
 	struct iio_device *m_dev;


### PR DESCRIPTION
Rework Python exposed methods for both Analog and Digital. Previously, users were not able to access in Python elements of objects like double*/short* because SWIG can't expose them by default.
In order to fix this, we added some typemaps and made use of memory view and buffer protocol in Python. 

In this PR we also expose conversion methods (for Analog In and Analog Out, from/to volts to/from raw).

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>