### PR TITLE
libm2k.i: Generate Python documentation 

### DIFF
--- a/bindings/libm2k.i
+++ b/bindings/libm2k.i
@@ -9,7 +9,7 @@
 %include "std_vector.i"
 %include "exception.i"
 %allowexception;
-
+%feature("autodoc", "3");
 namespace std {
 	%template(VectorI) vector<int>;
 	%template(VectorS) vector<short>;


### PR DESCRIPTION
libm2k.i: Generate Python documentation based on the documented classes and methods in C++.

When using libm2k in Python it is useful to be able to check what parameters are needed and also their type.

We can call **help** on any libm2k element in a python3 console and check the parameters. 

A simple example: 
**help(libm2k.M2kHardwareTrigger.setAnalogCondition)**
```
Help on function setAnalogCondition in module libm2k:

setAnalogCondition(self, chnIdx, cond)
    setAnalogCondition(M2kHardwareTrigger self, unsigned int chnIdx, libm2k::M2K_TRIGGER_CONDITION_ANALOG cond)
    
    Parameters
    ----------
    chnIdx: unsigned int
    cond: enum libm2k::M2K_TRIGGER_CONDITION_ANALOG
```


Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>