### PR TITLE
M2kDigital: Set kernel buffers count for the output of the M2k Digital.

### DIFF
--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -350,10 +350,17 @@ public:
 
 
 	/**
-	 * @brief Set the kernel buffers to a specific value
+	 * @brief Set the kernel buffers for input to a specific value
 	 * @param count the number of kernel buffers
 	 */
 	void setKernelBuffersCountIn(unsigned int count);
+
+
+	/**
+	 * @brief Set the kernel buffers for output to a specific value
+	 * @param count the number of kernel buffers
+	 */
+	void setKernelBuffersCountOut(unsigned int count);
 
 
 	/**

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -157,6 +157,11 @@ void M2kDigital::setKernelBuffersCountIn(unsigned int count)
 	m_pimpl->setKernelBuffersCountIn(count);
 }
 
+void libm2k::digital::M2kDigital::setKernelBuffersCountOut(unsigned int count)
+{
+	m_pimpl->setKernelBuffersCountOut(count);
+}
+
 IIO_OBJECTS M2kDigital::getIioObjects()
 {
 	return m_pimpl->getIioObjects();

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -115,6 +115,11 @@ public:
 		m_dev_read->setKernelBuffersCount(count);
 	}
 
+	void setKernelBuffersCountOut(unsigned int count)
+	{
+		m_dev_write->setKernelBuffersCount(count);
+	}
+
 	void setDirection(unsigned short mask)
 	{
 		DIO_DIRECTION direction;


### PR DESCRIPTION
Setting multiple kernel buffer on the output of the M2k Digital is possible in libiio so we also need to provide this possibility.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>