### PR TITLE
M2kHardwareTriggerImpl: Fix MSVC undefined behaviour.

### DIFF
--- a/src/private/m2khardwaretrigger_impl.cpp
+++ b/src/private/m2khardwaretrigger_impl.cpp
@@ -200,31 +200,31 @@ public:
 
 	virtual void setAnalogExternalOutSelect(M2K_TRIGGER_OUT_SELECT out_select)
 	{
-		throw_exception(EXC_INVALID_PARAMETER, "M2kHardwareTrigger: "
-						       "the analog external output is not configurable on "
-						       "the current board; Check the firmware version.");
+		throw std::runtime_error("M2kHardwareTrigger: "
+					 "the analog external output is not configurable on "
+					 "the current board; Check the firmware version.");
 	}
 
 	virtual M2K_TRIGGER_OUT_SELECT getAnalogExternalOutSelect()
 	{
-		throw_exception(EXC_INVALID_PARAMETER, "M2kHardwareTrigger: "
-						       "the analog external output is not available on "
-						       "the current board; Check the firmware version.");
+		throw std::runtime_error("M2kHardwareTrigger: "
+					 "the analog external output is not available on "
+					 "the current board; Check the firmware version.");
 	}
 
 
 	virtual void setDigitalSource(M2K_TRIGGER_SOURCE_DIGITAL external_src)
 	{
-		throw_exception(EXC_INVALID_PARAMETER, "M2kHardwareTrigger: "
-						       "the digital external source is not configurable on "
-						       "the current board; Check the firmware version.");
+		throw std::runtime_error("M2kHardwareTrigger: "
+					 "the digital external source is not configurable on "
+					 "the current board; Check the firmware version.");
 	}
 
 	virtual M2K_TRIGGER_SOURCE_DIGITAL getDigitalSource()
 	{
-		throw_exception(EXC_INVALID_PARAMETER, "M2kHardwareTrigger: "
-						       "the digital external source is not available on "
-						       "the current board; Check the firmware version.");
+		throw std::runtime_error("M2kHardwareTrigger: "
+					 "the digital external source is not available on "
+					 "the current board; Check the firmware version.");
 	}
 
 	M2K_TRIGGER_CONDITION_DIGITAL getDigitalExternalCondition()


### PR DESCRIPTION
MSVC displays warnings as errors in this case, where the methods only throw an exception instead of returning.

These methods in particular only throw an exception to the user, letting
him know that the operation is not possible. When building with CMake-GUI
and Microsoft Visual Studio on Windows, the compiler complains about the
missing return value. To ensure that these throw we call "throw" directly,
without using our own "throw" wrapper.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>