### PR TITLE
M2kCalibration: Fix index in the ADC offset calibration.

### DIFF
--- a/src/private/m2kcalibration_impl.cpp
+++ b/src/private/m2kcalibration_impl.cpp
@@ -232,7 +232,7 @@ public:
 		}
 
 		int16_t ch0_avg = Utils::average(ch_data.at(0).data(), num_samples);
-		int16_t ch1_avg = Utils::average(ch_data.at(0).data(), num_samples);
+		int16_t ch1_avg = Utils::average(ch_data.at(1).data(), num_samples);
 
 		// Convert from raw format to signed raw
 		int16_t tmp;


### PR DESCRIPTION
This mistake was visible only on some boards, where the difference
between the 2 ADC channel offsets was bigger and it influenced the
captured values.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>