### PR TITLE
M2kAnalogIn: correctly set/reset calib offset & vertical offset

### DIFF
--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -125,6 +125,9 @@ public:
 			ANALOG_IN_CHANNEL ch = static_cast<ANALOG_IN_CHANNEL>(i);
 			auto range = getRangeDevice(ch);
 			m_input_range[i] = range;
+
+			// load calib_offset from the register - assuming it was deinitialized correctly
+			m_adc_calib_offset[i] = m_ad5625_dev->getLongValue(2 + i, "raw", true);
 			getVerticalOffset(ch);
 
 			m_trigger->setCalibParameters(i, getScalingFactor(i), m_adc_hw_vert_offset.at(i));

--- a/src/private/m2k_impl.cpp
+++ b/src/private/m2k_impl.cpp
@@ -94,6 +94,22 @@ public:
 			}
 		}
 
+		// The vertical offset register in the device has dual purpose:
+		// 1. use as ADC offset for calibration
+		// 2. use as ADC vertical offset for measurement
+		// This can cause some confusion when initializing the board
+		// because it is not clear whether the value in the register is
+		// the calibration value or the calibration+vertical offset value
+		// This workaround will always set the vertical offset to 0 on deinitialization
+		// and upon initialization the offset will be loaded from the register
+		// (when no calibration is done)
+		//
+		// The correct fix would be adding a separate caliboffset register in the firmware
+		// which will clear up the confusion
+
+		getAnalogIn()->setVerticalOffset(ANALOG_IN_CHANNEL_1,0);
+		getAnalogIn()->setVerticalOffset(ANALOG_IN_CHANNEL_2,0);
+
 		delete m_calibration;
 
 		if (m_trigger) {


### PR DESCRIPTION
The vertical offset register in the device has dual purpose:
1. use as ADC offset for calibration
2. use as ADC vertical offset for measurement
This can cause some confusion when initializing the board
because it is not clear whether the value in the register is
the calibration value or the calibration+vertical offset value
This workaround will always set the vertical offset to 0 on deinitialization
and upon initialization the offset will be loaded from the register
(when no calibration is done)

The correct fix would be adding a separate caliboffset register in the firmware
which will clear up the confusion

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>