### PR TITLE
Travis CI:  Fix Python installation on OSX

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -2,7 +2,7 @@
 
 . CI/travis/lib.sh
 
-brew_install_or_upgrade cmake doxygen libusb libxml2 swig curl python
+brew_install_if_not_exists cmake doxygen libusb libxml2 swig curl python
 
 wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg
 sudo installer -pkg ${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg -target /


### PR DESCRIPTION
Drop the upgrade step for brew packages.
Upgrading to the latest version of some packages can result in undefined behaviour so it's better if we install the package if it does not exist.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>