### PR TITLE
Travis: Deploy packages to Github release page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,11 @@ env:
 matrix:
   include:
     - os: linux
+      dist: bionic
+      python: 3.6
       env:
-        - OS_TYPE=ubuntu_docker
-        - OS_VERSION=bionic
+        - PYTHON=python PIP=pip
+        - OS_TYPE=ubuntu
     - os: linux
       dist: xenial
       env:
@@ -52,4 +54,30 @@ before_install:
 script:
   - if [[ -z "$ARCH" && "$TRAVIS_OS_NAME" == "linux" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_linux libm2k "$OS_TYPE" "$OS_VERSION" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_darwin; fi
+before_deploy:
+  - ". ${TRAVIS_BUILD_DIR}/CI/travis/before_deploy"
 
+deploy:
+  - provider: releases
+    api_key:
+      secure: O6mk05weBrhXR4DJ9cYkZ0MP4DQa0NLylvOAGW5mxpwcJBciQEe7JQg1NYxugemZ2d8EcyRaNqqSDK+PBnWqQpl+G+eGQny40BcbLCxOo6nR/XX2Zodrwqd/VEWxm7y/gb1prF4zSvYKCZQ5PZJHqvdU6jtn9EuiFpEM1WV+1Sy96o/6k6jxBQKZgQx3YIdXs1kLXh+UBVWgyGX3cN+W1Hv9eeRfr0skm2t16RNODIV1CNEeRsOI2Xv7LGoC0T3kux3SefgE5oTnvaBqO3FEZFUp0Ssrv0nU4E3E+l27x4veT5v5sBVDDBkyEJlIPaUPxEMq708WScCiOEsenBI1dJqYy5bmzwTh9tC+ZlVVIdLGsnGdU1Mzf+i21Wf/G3u65dIbMYYxyZpFknrd8dRjeDh3GG/1ARi9hEr0Y2WGRT32d31ReLsMv2lQtju28vxOzLN4TuzweTxBnTxj5lItW71C30r7NQXY1/2gAT9KyIyKOZFZljypC/whNPtbaRffbtcqZB4fyge39g7kB81fse2BOvYURIAe4IYlUPaupHOnXax9TpRoOXBCPW04+suUoieVxhqruMdmYNIRtozsuM29qqJUuvnzJAJ3IwRmQqIXYxs3wc5I50Yh/2r43G2PQMZoTmYF9q3d3PSypfhW+d2ntMzJeAljxVKQ2I4D9G4=
+    file:
+      - "${RELEASE_PKG_FILE_DEB}"
+      - "${RELEASE_PY_FILE_DEB}"
+      - "${RELEASE_PKG_FILE_TGZ}"
+    skip_cleanup: true
+    on:
+      repo: analogdevicesinc/libm2k
+      tags: true
+      condition: "($TRAVIS_OS_NAME = linux)"
+  - provider: releases
+    api_key:
+      secure: O6mk05weBrhXR4DJ9cYkZ0MP4DQa0NLylvOAGW5mxpwcJBciQEe7JQg1NYxugemZ2d8EcyRaNqqSDK+PBnWqQpl+G+eGQny40BcbLCxOo6nR/XX2Zodrwqd/VEWxm7y/gb1prF4zSvYKCZQ5PZJHqvdU6jtn9EuiFpEM1WV+1Sy96o/6k6jxBQKZgQx3YIdXs1kLXh+UBVWgyGX3cN+W1Hv9eeRfr0skm2t16RNODIV1CNEeRsOI2Xv7LGoC0T3kux3SefgE5oTnvaBqO3FEZFUp0Ssrv0nU4E3E+l27x4veT5v5sBVDDBkyEJlIPaUPxEMq708WScCiOEsenBI1dJqYy5bmzwTh9tC+ZlVVIdLGsnGdU1Mzf+i21Wf/G3u65dIbMYYxyZpFknrd8dRjeDh3GG/1ARi9hEr0Y2WGRT32d31ReLsMv2lQtju28vxOzLN4TuzweTxBnTxj5lItW71C30r7NQXY1/2gAT9KyIyKOZFZljypC/whNPtbaRffbtcqZB4fyge39g7kB81fse2BOvYURIAe4IYlUPaupHOnXax9TpRoOXBCPW04+suUoieVxhqruMdmYNIRtozsuM29qqJUuvnzJAJ3IwRmQqIXYxs3wc5I50Yh/2r43G2PQMZoTmYF9q3d3PSypfhW+d2ntMzJeAljxVKQ2I4D9G4=
+    file:
+      - "${RELEASE_PKG_FILE_PKG}"
+      - "${RELEASE_PKG_FILE_TGZ}"
+    skip_cleanup: true
+    on:
+      repo: analogdevicesinc/libm2k
+      tags: true
+      condition: "$TRAVIS_OS_NAME = osx"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
       python: 3.6
       env:
         - PYTHON=python PIP=pip
-        - OS_TYPE=ubuntu
     - os: linux
       dist: xenial
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ matrix:
         - PYTHON=python PIP=pip
     - os: linux
       dist: xenial
+      python: 3.6
+      env:
+        - PYTHON=python PIP=pip
+    - os: linux
+      dist: xenial
       env:
         - OS_TYPE=doxygen
       addons: { apt: { packages: ["cmake", "graphviz"] } }

--- a/53-adi-m2k-usb.rules
+++ b/53-adi-m2k-usb.rules
@@ -1,0 +1,6 @@
+# allow "plugdev" group read/write access to ADI M2K devices
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b672", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b675", MODE="0664", GROUP="plugdev"
+# tell the ModemManager (part of the NetworkManager suite) that the device is not a modem, 
+# and don't send AT commands to it
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b672", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -1,23 +1,96 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
-. CI/travis/lib.sh
+. "$TRAVIS_BUILD_DIR"/CI/travis/lib.sh
+
+# Don't prepare a deploy on a Coverity build
+if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
+
+deploy=0
+if [ -z "$TRAVIS_BUILD_DIR" ] ; then
+	t=$(find ./ -name CMakeCache.txt|head -1)
+	if [ -n "${t}" ] ; then
+		cd $(dirname $(dirname ${t}))
+		TRAVIS_BUILD_DIR=$(pwd)
+	else
+		echo "I am confused - can't find CMakeCache.txt"
+		exit
+	fi
+else
+	cd $TRAVIS_BUILD_DIR
+fi
+pwd
+
+if [ -z "${LDIST}" -a -f "build/.LDIST" ] ; then
+	export LDIST="-$(cat build/.LDIST)"
+fi
+if [ -z "${LDIST}" ] ; then
+	export LDIST="-$(get_ldist)"
+fi
 
 check_file()
 {
-temp=$(find ./build* -maxdepth 1 -name "*.$1")
-if [ "$(echo ${temp} | wc -w)" -gt "1"  ] ; then
-	echo "I am confused - more than 2 $1 files"
-	echo $temp
-	exit
+NAME=${2:-libm2k}
+temp=""
+for i in $(find ./ -name CMakeCache.txt)
+do
+hit=$(find $(dirname ${i}) -maxdepth 1 -name "${NAME}*.$1" -a ! -name "*${LDIST}*")
+if [ "$(echo ${hit} | wc -w)" -gt "1"  ] ; then
+	echo "I am confused - more than 2 $1 files!"
+	echo $hit
+	exit 1
+else
+	if [ "$(echo ${hit} | wc -w)" -eq "1" ] ; then
+		if [ -z "${temp}" ] ; then
+			temp=$hit
+		else
+			echo "I am confused - more than 2 $1 files"
+			echo $temp
+			echo $hit
+			exit 1
+		fi
+	fi
 fi
+done
 }
 
+
+check_file deb python3
+if [ -n "${temp}" ] ; then
+	deploy=$(expr ${deploy} + 1)
+	if [ -z "${TARGET_DEB}" ] ; then
+		export TARGET_DEB=$(echo ${temp} | \
+			sed -e 's:^./.*/::' -e 's:.deb$::')${LDIST}.deb
+	fi
+	echo "deploying ${temp} to nightly $TARGET_DEB"
+	if [ -z "${RELEASE_PY_FILE_DEB}" ] ; then
+		export RELEASE_PY_FILE_DEB=$(dirname ${temp})/${TARGET_DEB}
+		cp ${temp} ${RELEASE_PY_FILE_DEB}
+	fi
+	echo ${TARGET_DEB}
+	ls -lh ${temp}
+	echo ${RELEASE_PY_FILE_DEB}
+	ls -lh ${RELEASE_PY_FILE_DEB}
+else
+	echo "Skipping deployment of debian package"
+fi
+
+temp=""
+TARGET_DEB=""
 check_file deb
 if [ -n "${temp}" ] ; then
-	export RELEASE_PKG_FILE_DEB=${temp}
-	export TARGET_DEB=$(echo ${RELEASE_PKG_FILE_DEB} | \
-		sed -e 's:^./.*/::' -e 's:.deb$::')${LDIST}.deb
-	echo "deploying $RELEASE_PKG_FILE_DEB to nightly $TARGET_DEB"
+	deploy=$(expr ${deploy} + 1)
+	if [ -z "${TARGET_DEB}" ] ; then
+		export TARGET_DEB=$(echo ${temp} | \
+			sed -e 's:^./.*/::' -e 's:-Linux::' -e 's:.deb$::')${LDIST}.deb
+	fi
+	echo "deploying ${temp} to nightly $TARGET_DEB"
+	if [ -z "${RELEASE_PKG_FILE_DEB}" ] ; then
+		export RELEASE_PKG_FILE_DEB=$(dirname ${temp})/${TARGET_DEB}
+		cp ${temp} ${RELEASE_PKG_FILE_DEB}
+	fi
+	echo ${TARGET_DEB}
+	ls -lh ${temp}
+	echo ${RELEASE_PKG_FILE_DEB}
 	ls -lh ${RELEASE_PKG_FILE_DEB}
 else
 	echo "Skipping deployment of debian package"
@@ -25,10 +98,19 @@ fi
 
 check_file rpm
 if [ -n "${temp}" ] ; then
-	export RELEASE_PKG_FILE_RPM=${temp}
-	export TARGET_RPM=$(echo ${RELEASE_PKG_FILE_RPM} | \
-		sed -e 's:^./.*/::' -e 's:.rpm$::')${LDIST}.rpm
-	echo "deploying $RELEASE_PKG_FILE_RPM to nightly $TARGET_RPM"
+	deploy=$(expr ${deploy} + 1)
+	if [ -z "${TARGET_RPM}" ] ; then
+		export TARGET_RPM=$(echo ${temp} | \
+			sed -e 's:^./.*/::' -e 's:-Linux::' -e 's:.rpm$::')${LDIST}.rpm
+	fi
+	echo "deploying ${temp} to nightly $TARGET_RPM"
+	if [ -z "${RELEASE_PKG_FILE_RPM}" ] ; then
+		export RELEASE_PKG_FILE_RPM=$(dirname ${temp})/${TARGET_RPM}
+		cp ${temp}  ${RELEASE_PKG_FILE_RPM}
+	fi
+	echo ${TARGET_RPM}
+	ls -lh ${temp}
+	echo ${RELEASE_PKG_FILE_RPM}
 	ls -lh ${RELEASE_PKG_FILE_RPM}
 else
 	echo "Skipping deployment of rpm package"
@@ -36,10 +118,19 @@ fi
 
 check_file tar.gz
 if [  -n "${temp}"  ] ; then
-	export RELEASE_PKG_FILE_TGZ=${temp}
-	export TARGET_TGZ=$(echo ${RELEASE_PKG_FILE_TGZ} | \
-		sed -e 's:^./.*/::' -e 's:.tar.gz$::')${LDIST}.tar.gz;
-	echo "deploying $RELEASE_PKG_FILE_TGZ to $TARGET_TGZ"
+	deploy=$(expr ${deploy} + 1)
+	if [ -z "${TARGET_TGZ}" ] ; then
+		export TARGET_TGZ=$(echo ${temp} | \
+			sed -e 's:^./.*/::' -e 's:-Linux::' -e 's:-Darwin::' -e 's:.tar.gz$::')${LDIST}.tar.gz;
+	fi
+	echo "deploying ${temp} to $TARGET_TGZ"
+	if [ -z "${RELEASE_PKG_FILE_TGZ}" ] ; then
+		export RELEASE_PKG_FILE_TGZ=$(dirname ${temp})/${TARGET_TGZ}
+		cp ${temp} ${RELEASE_PKG_FILE_TGZ}
+	fi
+	echo ${TARGET_TGZ}
+	ls -lh ${temp}
+	echo ${RELEASE_PKG_FILE_TGZ}
 	ls -lh ${RELEASE_PKG_FILE_TGZ}
 else
 	echo "Skipping deployment of tarball"
@@ -47,13 +138,25 @@ fi
 
 check_file pkg
 if [ -n "${temp}" ] ; then
-	export RELEASE_PKG_FILE_PKG=${temp}
-	export TARGET_PKG=$(echo ${RELEASE_PKG_FILE_PKG} | \
-		sed -e 's:^./.*/::' -e 's:.pkg$::')${LDIST}.pkg
-	echo "deploying $RELEASE_PKG_FILE_PKG to nightly $TARGET_PKG"
+	deploy=$(expr ${deploy} + 1)
+	if [ -z "${TARGET_PKG}" ] ; then
+		export TARGET_PKG=$(echo ${temp} | \
+			sed -e 's:^./.*/::' -e 's:.pkg$::')${LDIST}.pkg
+	fi
+	echo "deploying ${temp} to nightly $TARGET_PKG"
+	if [ -z "${RELEASE_PKG_FILE_PKG}" ] ; then
+		export RELEASE_PKG_FILE_PKG=$(dirname ${temp})/${TARGET_PKG}
+		cp ${temp} ${RELEASE_PKG_FILE_PKG}
+	fi
+	echo ${TARGET_PKG}
+	ls -lh ${temp}
+	echo ${RELEASE_PKG_FILE_PKG}
 	ls -lh ${RELEASE_PKG_FILE_PKG}
 else
 	echo "Skipping deployment of OS X package"
 fi
 
-
+if [ "${deploy}" -eq "0" ] ; then
+	echo did not deploy any files
+	exit 1
+fi

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -22,13 +22,15 @@ handle_ubuntu_docker() {
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y cmake doxygen graphviz libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git curl swig python3-dev python3-setuptools
+	sudo apt-get install -y cmake doxygen graphviz libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git curl swig python3-dev python3-setuptools python3-pip python3-all debhelper devscripts fakeroot
 	if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
 		sudo apt-get install -y libserialport-dev
 	fi
 
 	wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
 	sudo dpkg -i ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
+
+	sudo pip3 install --upgrade pip stdeb argparse
 }
 
 handle_doxygen() {

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -7,16 +7,27 @@ if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 handle_default() {
 	mkdir -p build
 	cd build
-	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
+
+	#create deb for bindings
+	cmake -DENABLE_PYTHON=ON -DENABLE_TOOLS=ON -DENABLE_CSHARP=OFF .. && make
+	sudo python3 setup.py --command-packages=stdeb.command sdist_dsc
+	cd "$(find . -type d -name "debian" | head -n 1)"
+	sudo env DEB_BUILD_OPTIONS=nocheck debuild -us -uc
+	cp ../../*.deb ${TRAVIS_BUILD_DIR}/build/
+	cd ${TRAVIS_BUILD_DIR}/build/
+	#remove the tar.gz for bindings
+	sudo rm *.tar.gz
+
+	#create simple .deb without Python bindings
+	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON -DENABLE_PYTHON=OFF -DENABLE_CSHARP=ON -DENABLE_TOOLS=ON -DCMAKE_INSTALL_PREFIX=/usr ..
 	make && make package
 	ls
-	cd ..
 }
 
 handle_centos() {
 	mkdir -p build
 	cd build
-	cmake -DENABLE_PACKAGING=ON ..
+	cmake -DENABLE_PACKAGING=ON -DENABLE_PYTHON=OFF -DENABLE_CSHARP=ON -DENABLE_TOOLS=ON -DCMAKE_INSTALL_PREFIX=/usr ..
 	make && make package
 	cd ..
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if(OSX_PACKAGE)
 	add_custom_command(OUTPUT ${LIBM2K_PKG}
 		COMMAND ${PKGBUILD_EXECUTABLE}
 			--component ${LIBM2K_FRAMEWORK_DIR}
-			--identifier com.adi.m2k --version ${PROJECT_VERSION}
+			--identifier libm2k --version ${PROJECT_VERSION}
 			--install-location ${OSX_INSTALL_FRAMEWORKSDIR} ${LIBM2K_TEMP_PKG}
 		COMMAND ${PRODUCTBUILD_EXECUTABLE}
 			--distribution ${LIBM2K_DISTRIBUTION_XML} ${LIBM2K_PKG}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(ENABLE_EXCEPTIONS "Build with exception handling support" ON)
 option(ENABLE_PYTHON "Build Python bindings" ON)
 option(ENABLE_CSHARP "Build C# bindings" ON)
 option(ENABLE_TOOLS "Build the tools" OFF)
+option(INSTALL_UDEV_RULES "Install udev rules for the M2K" ON)
 
 if (ENABLE_DOC)
     add_subdirectory(doc)
@@ -167,6 +168,13 @@ add_subdirectory(src)
 set(LIBM2K_PC ${CMAKE_CURRENT_BINARY_DIR}/libm2k.pc)
 configure_file(libm2k.pc.cmakein ${LIBM2K_PC} @ONLY)
 install(FILES ${LIBM2K_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+
+# install udev rules on Linux
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux" AND INSTALL_UDEV_RULES)
+	set(LIBSMU_UDEV_RULES "${CMAKE_CURRENT_SOURCE_DIR}/53-adi-m2k-usb.rules")
+	set(UDEV_RULES_PATH "/etc/udev/rules.d" CACHE STRING "Target directory for udev rule installation.")
+	install(FILES ${LIBSMU_UDEV_RULES} DESTINATION ${UDEV_RULES_PATH})
+endif()
 
 configure_file(libm2k.iss.cmakein ${CMAKE_CURRENT_BINARY_DIR}/libm2k.iss @ONLY)
 

--- a/bindings/python/setup.py.cmakein
+++ b/bindings/python/setup.py.cmakein
@@ -2,8 +2,10 @@ from setuptools import setup, os, Extension
 
 setup (name = '${PROJECT_NAME}',
        version = '${PROJECT_VERSION}',
-       author = "Analog Devices, Inc",
+       maintainer = "Analog Devices, Inc",
+       maintainer_email = "Alexandra.Trifan@analog.com",
        description = """Install Python bindings from original C/C++ libm2k""",
+       url='https://github.com/analogdevicesinc/libm2k',
        py_modules = ["${PROJECT_NAME}"],
        packages=[''],
        package_data={'': ['_${PROJECT_NAME}.so', '_${PROJECT_NAME}.pyd']},

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1.3)
 
+option(OSX_PACKAGE "Create OSX package" OFF)
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
 
 if(APPLE)
@@ -56,7 +57,6 @@ target_link_libraries(${PROJECT_NAME}
 set_target_properties(${PROJECT_NAME} PROPERTIES
         VERSION ${PROJECT_VERSION}
 	SOVERSION ${PROJECT_VERSION}
-	FRAMEWORK TRUE
 )
 
 if (MSVC)
@@ -64,14 +64,15 @@ if (MSVC)
 endif()
 
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	option(OSX_PACKAGE "Create a OSX package" ON)
-
-	set(OSX_INSTALL_FRAMEWORKSDIR "/Library/Frameworks" CACHE STRING "Installation directory for frameworks")
-	get_filename_component(OSX_INSTALL_FRAMEWORKSDIR "${OSX_INSTALL_FRAMEWORKSDIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
-
+if (APPLE)
+	set_target_properties(${PROJECT_NAME} PROPERTIES FRAMEWORK FALSE)
 	set(CMAKE_MACOSX_RPATH ON)
-	set(SKIP_INSTALL_ALL ${OSX_PACKAGE})
+	if (OSX_PACKAGE)
+		set_target_properties(${PROJECT_NAME} PROPERTIES FRAMEWORK TRUE)
+		set(OSX_INSTALL_FRAMEWORKSDIR "/Library/Frameworks" CACHE STRING "Installation directory for frameworks")
+		get_filename_component(OSX_INSTALL_FRAMEWORKSDIR "${OSX_INSTALL_FRAMEWORKSDIR}" REALPATH BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+		set(SKIP_INSTALL_ALL ${OSX_PACKAGE})
+	endif()
 endif()
 
 install(TARGETS ${PROJECT_NAME}


### PR DESCRIPTION
- This PR fixes some issues related to the OSX build (we don't want to build a framework by default). 
Some small changes were needed in order to create the .pkg and .tar.gz correctly.
- On Linux, we are building a .deb (for the base library) and a python .deb (only with python bindings) for every distribution on Travis-CI.
- Add code to deploy packages on the github release page for every newly created tag.
(2 .deb files and .tar.gz for Linux, and 2 .pkgs and 2 .tar.gz for OSX).


Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>