### PR TITLE
CI/travis/before_install_linux: Update Doxygen link on Travis-CI.

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -33,7 +33,7 @@ handle_default() {
 
 handle_doxygen() {
 	# Install a recent version of doxygen
-	DOXYGEN_URL="wget doxygen.nl/files/doxygen-1.8.15.src.tar.gz"
+	DOXYGEN_URL="wget https://sourceforge.net/projects/doxygen/files/rel-1.8.15/doxygen-1.8.15.src.tar.gz"
 	cd ${DEPS_DIR}
 	[ -d "doxygen" ] || {
 		mkdir doxygen && wget --quiet -O - ${DOXYGEN_URL} | tar --strip-components=1 -xz -C doxygen


### PR DESCRIPTION
Travis fails on the Doxygen job because of a broken link.
Update the link to one that is working.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>