### PR TITLE
M2kHardwareTrigger.cpp: Fix comparison result for firmware versions.

### DIFF
--- a/src/m2khardwaretrigger.cpp
+++ b/src/m2khardwaretrigger.cpp
@@ -29,7 +29,7 @@ typedef std::pair<Channel *, std::string> channel_pair;
 M2kHardwareTrigger::M2kHardwareTrigger(struct iio_context *ctx, const std::string& fw_version)
 {
 	int diff = Utils::compareVersions(fw_version, "v0.24");
-	if (diff > 0) {	//fw_ver < 0.24
+	if (diff < 0) {	//fw_version < 0.24
 		m_pimpl = std::unique_ptr<M2kHardwareTriggerImpl>(new M2kHardwareTriggerImpl(ctx));
 	} else {
 		m_pimpl = std::unique_ptr<M2kHardwareTriggerV024Impl>(new M2kHardwareTriggerV024Impl(ctx));


### PR DESCRIPTION
The comparison result should be < 0 if fw_version is < 0.24, and >0 when fw_version is > 0.24.
This allows the creation of the appropriate M2kHardwareTrigger object for the current firmware.

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>