### PR TITLE
M2kAnalogIn/M2kAnalogOut: cancel all buffer operations.

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -466,6 +466,13 @@ public:
 	*/
 	void convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src);
 
+
+	/**
+	* @brief Cancel all buffer operations
+	*/
+	void cancelBuffer();
+
+
 	/**
 	 * @brief Set the kernel buffers to a specific value
 	 * @param count the number of kernel buffers

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -377,6 +377,19 @@ public:
 
 
 	/**
+	* @brief Cancel all buffer operations of enabled channels
+	*/
+	void cancelBuffer();
+
+
+	/**
+	* @brief Cancel all buffer operations of the given channel
+	* @param chn The index corresponding to the channel
+	*/
+	void cancelBuffer(unsigned int chn);
+
+
+	/**
 	* @brief Enable or disable the given digital channel
 	*
 	* @param chnIdx The index corresponding to the channel

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -65,6 +65,7 @@ public:
 
 	void stop();
 	void setCyclic(bool enable);
+	void cancelBuffer();
 	void flushBuffer();
 
 	struct iio_buffer* getBuffer();

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -53,6 +53,7 @@ public:
 	virtual const short *getSamplesRawInterleaved(unsigned int nb_samples);
 	void* getSamplesRawInterleavedVoid(unsigned int nb_samples);
 
+	virtual void cancelBuffer();
 	virtual void flushBuffer();
 	virtual struct IIO_OBJECTS getIioObjects();
 private:

--- a/include/libm2k/utils/deviceout.hpp
+++ b/include/libm2k/utils/deviceout.hpp
@@ -55,6 +55,7 @@ public:
 	virtual void push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
 	virtual void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
 	virtual void stop();
+	virtual void cancelBuffer();
 	virtual void setKernelBuffersCount(unsigned int count);
 	virtual struct IIO_OBJECTS getIioObjects();
 

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -288,6 +288,11 @@ double M2kAnalogIn::getValueForRange(M2K_RANGE range)
 	return m_pimpl->getValueForRange(range);
 }
 
+void M2kAnalogIn::cancelBuffer()
+{
+	m_pimpl->cancelBuffer();
+}
+
 void M2kAnalogIn::setKernelBuffersCount(unsigned int count)
 {
 	return m_pimpl->setKernelBuffersCount(count);

--- a/src/analog/m2kanalogout.cpp
+++ b/src/analog/m2kanalogout.cpp
@@ -203,6 +203,16 @@ void M2kAnalogOut::stop(unsigned int chn)
 	m_pimpl->stop(chn);
 }
 
+void M2kAnalogOut::cancelBuffer()
+{
+	m_pimpl->cancelBuffer();
+}
+
+void M2kAnalogOut::cancelBuffer(unsigned int chn)
+{
+	m_pimpl->cancelBuffer(chn);
+}
+
 void M2kAnalogOut::enableChannel(unsigned int chnIdx, bool enable)
 {
 	m_pimpl->enableChannel(chnIdx, enable);

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -197,6 +197,11 @@ public:
 		return m_trigger;
 	}
 
+	void cancelBuffer()
+	{
+		DeviceIn::cancelBuffer();
+	}
+
 	void flushBuffer()
 	{
 		DeviceIn::flushBuffer();

--- a/src/analog/private/m2kanalogout_impl.cpp
+++ b/src/analog/private/m2kanalogout_impl.cpp
@@ -547,6 +547,18 @@ public:
 		getDacDevice(chn)->stop();
 	}
 
+	void cancelBuffer()
+	{
+		for (DeviceOut *dev : m_dac_devices) {
+			dev->cancelBuffer();
+		}
+	}
+
+	void cancelBuffer(unsigned int chn)
+	{
+		getDacDevice(chn)->cancelBuffer();
+	}
+
 	void enableChannel(unsigned int chnIdx, bool enable)
 	{
 		m_m2k_fabric->setBoolValue(chnIdx, false, "powerdown", true);

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -126,6 +126,11 @@ void Buffer::setCyclic(bool enable)
 	m_pimpl->setCyclic(enable);
 }
 
+void Buffer::cancelBuffer()
+{
+	m_pimpl->cancelBuffer();
+}
+
 void Buffer::flushBuffer()
 {
 	m_pimpl->flushBuffer();

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -71,6 +71,11 @@ void* DeviceIn::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 	return m_pimpl->getSamplesRawInterleavedVoid(nb_samples);
 }
 
+void DeviceIn::cancelBuffer()
+{
+	m_pimpl->cancelBuffer();
+}
+
 void DeviceIn::flushBuffer()
 {
 	m_pimpl->flushBuffer();

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -82,6 +82,11 @@ void DeviceOut::stop()
 	m_pimpl->stop();
 }
 
+void DeviceOut::cancelBuffer()
+{
+	m_pimpl->cancelBuffer();
+}
+
 void DeviceOut::setKernelBuffersCount(unsigned int count)
 {
 	m_pimpl->setKernelBuffersCount(count);

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -486,6 +486,13 @@ public:
 		}
 	}
 
+	void cancelBuffer()
+	{
+		if (m_buffer) {
+			iio_buffer_cancel(m_buffer);
+		}
+	}
+
 	void flushBuffer()
 	{
 		destroy();

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -160,6 +160,14 @@ public:
 		return m_buffer->getSamplesRawInterleaved(nb_samples);
 	}
 
+	void cancelBuffer()
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: not buffer capable");
+		}
+		m_buffer->cancelBuffer();
+	}
+
 	void flushBuffer()
 	{
 		if (!m_buffer) {

--- a/src/utils/private/deviceout_impl.cpp
+++ b/src/utils/private/deviceout_impl.cpp
@@ -174,6 +174,14 @@ public:
 		}
 	}
 
+	void cancelBuffer()
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: not buffer capable");
+		}
+		m_buffer->cancelBuffer();
+	}
+
 	void setKernelBuffersCount(unsigned int count)
 	{
 		if (m_dev) {


### PR DESCRIPTION
This method cancels all pending buffer operations, such as getSamples(...) or push(...).