### PR TITLE
M2kDigital: Cancel all rx/tx buffer operations.

### DIFF
--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -198,6 +198,17 @@ public:
 
 
 	/**
+	* @brief Cancel all rx-buffer operations
+	*/
+	void cancelBufferIn();
+
+	/**
+	* @brief Cancel all tx-buffer operations
+	*/
+	void cancelBufferOut();
+
+
+	/**
 	* @brief Retrieve a specific number of samples
 	*
 	* @param nb_samples The number of samples that will be retrieved

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -117,6 +117,16 @@ void M2kDigital::flushBufferIn()
 	m_pimpl->flushBufferIn();
 }
 
+void M2kDigital::cancelBufferIn()
+{
+	m_pimpl->cancelBufferIn();
+}
+
+void M2kDigital::cancelBufferOut()
+{
+	m_pimpl->cancelBufferOut();
+}
+
 std::vector<unsigned short> M2kDigital::getSamples(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples);

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -239,6 +239,16 @@ public:
 		m_dev_read->flushBuffer();
 	}
 
+	void cancelBufferIn()
+	{
+		m_dev_read->cancelBuffer();
+	}
+
+	void cancelBufferOut()
+	{
+		m_dev_write->cancelBuffer();
+	}
+
 	std::vector<unsigned short> getSamples(int nb_samples)
 	{
 		__try {


### PR DESCRIPTION
Those methods cancel all pending rx/tx buffer operations, such as getSamples(...) or push(...).