### PR TITLE
include/libm2k/m2khardwaretrigger.hpp: add a note on streaming flag

### DIFF
--- a/include/libm2k/m2khardwaretrigger.hpp
+++ b/include/libm2k/m2khardwaretrigger.hpp
@@ -293,6 +293,11 @@ public:
 	/**
 	 * @brief Set the streaming flag for the digital part
 	 * @param enable the streaming
+	 *
+	 * @note The digital condition needs to be set before setting the
+	 * digital streaming flag to true, otherwise after setting the streaming
+	 * flag to true, a trigger might occur on the old condition.
+	 *
 	 */
 	void setDigitalStreamingFlag(bool enable);
 


### PR DESCRIPTION
When using this method together with setDigitalCondition, make sure setDigitalCondition happens first before calling setDigitalStreamingFlag(true)

Signed-off-by: Daniel Guramulta <daniel.guramulta@analog.com>