### PR TITLE
M2kHardwareTrigger: Set the streaming flag to 0 before enabling it.

### DIFF
--- a/src/private/m2khardwaretrigger_impl.cpp
+++ b/src/private/m2khardwaretrigger_impl.cpp
@@ -529,6 +529,10 @@ public:
 
 	void setDigitalStreamingFlag(bool val)
 	{
+		/* Make sure the trigger is reset before enabling the streaming flag. */
+		if (val) {
+			m_digital_trigger_device->setBoolValue(0, "streaming");
+		}
 		m_streaming_flag_digital = val;
 		m_digital_trigger_device->setBoolValue(val, "streaming");
 	}
@@ -540,6 +544,10 @@ public:
 
 	void setAnalogStreamingFlag(bool val)
 	{
+		/* Make sure the trigger is reset before enabling the streaming flag. */
+		if (val) {
+			setBoolValue(0, "streaming");
+		}
 		m_streaming_flag_analog = val;
 		setBoolValue(val, "streaming");
 	}


### PR DESCRIPTION
If the streaming was previously enabled, the trigger condition will no longer be active if we don't reset the flag.

From the docs: "If the streaming bit is set, after the trigger condition
is met data will be continuosly captured by the DMA.
The streaming bit must be set to 0 to reset triggering."

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>