### PR TITLE
Calibration: Add handling for calibration data persistence.

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -20,23 +20,11 @@
  */
 
 #include "m2kanalogin_impl.hpp"
-#include "utils/devicegeneric.hpp"
-#include "utils/devicein.hpp"
-#include <libm2k/analog/m2kanalogin.hpp>
 #include <libm2k/m2kexceptions.hpp>
-#include <libm2k/utils/utils.hpp>
 
-#include <iostream>
-#include <functional>
-#include <thread>
-#include <chrono>
-#include <iio.h>
-#include <string.h>
 
-using namespace libm2k;
 using namespace libm2k::analog;
 using namespace libm2k::utils;
-using namespace std;
 using namespace std::placeholders;
 
 #define HIGH_MAX 2.5
@@ -193,7 +181,7 @@ double M2kAnalogInImpl::setCalibscale(unsigned int index, double calibscale)
 	return m_m2k_adc->setDoubleValue(index, calibscale, "calibscale");
 }
 
-M2kHardwareTrigger *M2kAnalogInImpl::getTrigger()
+libm2k::M2kHardwareTrigger *M2kAnalogInImpl::getTrigger()
 {
 	return m_trigger;
 }
@@ -621,7 +609,7 @@ double M2kAnalogInImpl::getValueForRange(M2K_RANGE range)
 	}
 }
 
-struct IIO_OBJECTS M2kAnalogInImpl::getIioObjects()
+struct libm2k::IIO_OBJECTS M2kAnalogInImpl::getIioObjects()
 {
 	return m_m2k_adc->getIioObjects();
 }

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -33,7 +33,7 @@
 
 namespace libm2k {
 namespace analog {
-class M2kAnalogInImpl : public M2kAnalogIn, public libm2k::utils::DeviceIn
+class M2kAnalogInImpl : public M2kAnalogIn
 {
 public:
 	M2kAnalogInImpl(struct iio_context*, std::string adc_dev, bool sync, M2kHardwareTrigger *trigger);
@@ -120,6 +120,7 @@ public:
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
+	std::shared_ptr<libm2k::utils::DeviceIn> m_m2k_adc;
 	bool m_need_processing;
 
 	double m_samplerate;

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -29,7 +29,6 @@
 #include <libm2k/m2khardwaretrigger.hpp>
 #include <vector>
 #include <map>
-#include <memory>
 
 namespace libm2k {
 namespace analog {

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -57,7 +57,9 @@ public:
 	const double *getVoltageP() override;
 
 	void setVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset) override;
+	void setRawVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset);
 	double getVerticalOffset(ANALOG_IN_CHANNEL channel) override;
+	int getRawVerticalOffset(ANALOG_IN_CHANNEL channel);
 
 	double getScalingFactor(libm2k::analog::ANALOG_IN_CHANNEL ch) override;
 
@@ -81,6 +83,7 @@ public:
 	std::pair<double, double> getHysteresisRange(ANALOG_IN_CHANNEL chn) override;
 
 	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset);
+	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset, int vert_offset);
 
 	double setCalibscale(unsigned int index, double calibscale);
 	double getCalibscale(unsigned int index) override;
@@ -127,8 +130,8 @@ private:
 	std::vector<M2K_RANGE> m_input_range;
 
 	std::vector<double> m_adc_calib_gain;
-	std::vector<double> m_adc_calib_offset;
-	std::vector<double> m_adc_hw_vert_offset_raw;
+	std::vector<int> m_adc_calib_offset;
+	std::vector<int> m_adc_hw_offset_raw;
 	std::vector<double> m_adc_hw_vert_offset;
 	std::map<double, double> m_filter_compensation_table;
 	std::vector<bool> m_channels_enabled;
@@ -148,6 +151,9 @@ private:
 	const double *getSamplesInterleaved(unsigned int nb_samples, bool processed = false);
 
 	double processSample(int16_t sample, unsigned int channel);
+
+	const int convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset);
+	const double convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset);
 };
 }
 }

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -129,6 +129,7 @@ private:
 	libm2k::M2kHardwareTrigger *m_trigger;
 	std::vector<M2K_RANGE> m_input_range;
 
+	bool m_calibbias_available;
 	std::vector<double> m_adc_calib_gain;
 	std::vector<int> m_adc_calib_offset;
 	std::vector<int> m_adc_hw_offset_raw;

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -35,85 +35,85 @@ namespace analog {
 class M2kAnalogInImpl : public M2kAnalogIn
 {
 public:
-	M2kAnalogInImpl(struct iio_context*, std::string adc_dev, bool sync, M2kHardwareTrigger *trigger);
-	virtual ~M2kAnalogInImpl();
+        M2kAnalogInImpl(struct iio_context*, std::string adc_dev, bool sync, M2kHardwareTrigger *trigger);
+	~M2kAnalogInImpl() override;
 
-	void init();
-	void flushBuffer();
+	void init() override;
+	void flushBuffer() override;
 
-	std::vector<std::vector<double>> getSamples(unsigned int nb_samples);
-	std::vector<std::vector<double>> getSamplesRaw(unsigned int nb_samples);
+	std::vector<std::vector<double>> getSamples(unsigned int nb_samples) override;
+	std::vector<std::vector<double>> getSamplesRaw(unsigned int nb_samples) override;
 
-	const double* getSamplesInterleaved(unsigned int nb_samples);
-	const short* getSamplesRawInterleaved(unsigned int nb_samples);
+	const double* getSamplesInterleaved(unsigned int nb_samples) override;
+	const short* getSamplesRawInterleaved(unsigned int nb_samples) override;
 
-	short getVoltageRaw(unsigned int ch);
-	double getVoltage(unsigned int ch);
-	short getVoltageRaw(libm2k::analog::ANALOG_IN_CHANNEL ch);
-	double getVoltage(libm2k::analog::ANALOG_IN_CHANNEL ch);
-	std::vector<short> getVoltageRaw();
-	std::vector<double> getVoltage();
-	const short *getVoltageRawP();
-	const double *getVoltageP();
+	short getVoltageRaw(unsigned int ch) override;
+	double getVoltage(unsigned int ch) override;
+	short getVoltageRaw(libm2k::analog::ANALOG_IN_CHANNEL ch) override;
+	double getVoltage(libm2k::analog::ANALOG_IN_CHANNEL ch) override;
+	std::vector<short> getVoltageRaw() override;
+	std::vector<double> getVoltage() override;
+	const short *getVoltageRawP() override;
+	const double *getVoltageP() override;
 
-	void setVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset);
-	double getVerticalOffset(ANALOG_IN_CHANNEL channel);
+	void setVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset) override;
+	double getVerticalOffset(ANALOG_IN_CHANNEL channel) override;
 
-	double getScalingFactor(libm2k::analog::ANALOG_IN_CHANNEL ch);
+	double getScalingFactor(libm2k::analog::ANALOG_IN_CHANNEL ch) override;
 
-	void setRange(ANALOG_IN_CHANNEL channel, M2K_RANGE range);
-	void setRange(ANALOG_IN_CHANNEL channel, double min, double max);
-	libm2k::analog::M2K_RANGE getRange(libm2k::analog::ANALOG_IN_CHANNEL channel);
-	std::pair<double, double> getRangeLimits(libm2k::analog::M2K_RANGE range);
-	std::vector<std::pair<std::string, std::pair<double, double>>> getAvailableRanges();
+	void setRange(ANALOG_IN_CHANNEL channel, M2K_RANGE range) override;
+	void setRange(ANALOG_IN_CHANNEL channel, double min, double max) override;
+	libm2k::analog::M2K_RANGE getRange(libm2k::analog::ANALOG_IN_CHANNEL channel) override;
+	std::pair<double, double> getRangeLimits(libm2k::analog::M2K_RANGE range) override;
+	std::vector<std::pair<std::string, std::pair<double, double>>> getAvailableRanges() override;
 
-	int getOversamplingRatio();
-	int getOversamplingRatio(unsigned int chn_idx);
-	int setOversamplingRatio(int oversampling);
-	int setOversamplingRatio(unsigned int chn_idx, int oversampling);
+	int getOversamplingRatio() override;
+	int getOversamplingRatio(unsigned int chn_idx) override;
+	int setOversamplingRatio(int oversampling) override;
+	int setOversamplingRatio(unsigned int chn_idx, int oversampling) override;
 
-	double getSampleRate();
-	double getSampleRate(unsigned int chn_idx);
-	std::vector<double> getAvailableSampleRates();
-	double setSampleRate(double samplerate);
-	double setSampleRate(unsigned int chn_idx, double samplerate);
+	double getSampleRate() override;
+	double getSampleRate(unsigned int chn_idx) override;
+	std::vector<double> getAvailableSampleRates() override;
+	double setSampleRate(double samplerate) override;
+	double setSampleRate(unsigned int chn_idx, double samplerate) override;
 
-	std::pair<double, double> getHysteresisRange(ANALOG_IN_CHANNEL chn);
+	std::pair<double, double> getHysteresisRange(ANALOG_IN_CHANNEL chn) override;
 
 	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset);
 
 	double setCalibscale(unsigned int index, double calibscale);
-	double getCalibscale(unsigned int index);
+	double getCalibscale(unsigned int index) override;
 
 	void setAdcCalibGain(ANALOG_IN_CHANNEL channel, double gain);
 
-	double getFilterCompensation(double samplerate);
+	double getFilterCompensation(double samplerate) override;
 
-	double getValueForRange(M2K_RANGE range);
+	double getValueForRange(M2K_RANGE range) override;
 
 	double convRawToVolts(int sample, double correctionGain = 1,
 		double hw_gain = 0.02,
 		double filterCompensation = 1,
 		double offset = 0) const;
 
-	double convertRawToVolts(unsigned int channel, short raw);
-	short convertVoltsToRaw(unsigned int channel, double voltage);
+	double convertRawToVolts(unsigned int channel, short raw) override;
+	short convertVoltsToRaw(unsigned int channel, double voltage) override;
 
-	unsigned int getNbChannels();
-	std::string getName();
+	unsigned int getNbChannels() override;
+	std::string getName() override;
 
-	void enableChannel(unsigned int chnIdx, bool enable);
-	bool isChannelEnabled(unsigned int chnIdx);
+	void enableChannel(unsigned int chnIdx, bool enable) override;
+	bool isChannelEnabled(unsigned int chnIdx) override;
 
 	void convertChannelHostFormat(unsigned int chn_idx, int16_t *avg, int16_t *src);
 	void convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src);
 
-	void setKernelBuffersCount(unsigned int count);
+	void setKernelBuffersCount(unsigned int count) override;
 
-	libm2k::M2kHardwareTrigger* getTrigger();
-	struct IIO_OBJECTS getIioObjects();
+	libm2k::M2kHardwareTrigger* getTrigger() override;
+	struct IIO_OBJECTS getIioObjects() override;
 
-	void cancelBuffer();
+	void cancelBuffer() override;
 
 	void getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples);
 private:
@@ -137,7 +137,7 @@ private:
 
 	M2K_RANGE getRangeDevice(ANALOG_IN_CHANNEL channel);
 
-	short convVoltsToRaw(double voltage, double correctionGain, double hw_gain, double filterCompensation, double offset);
+	static short convVoltsToRaw(double voltage, double correctionGain, double hw_gain, double filterCompensation, double offset);
 
 	double getScalingFactor(unsigned int ch);
 

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -213,8 +213,13 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 	setCalibrationMode(ADC_GND);
 
 	// Set DAC channels to middle scale
-	m_ad5625_dev->setDoubleValue(2, 2048, "raw", true);
-	m_ad5625_dev->setDoubleValue(3, 2048, "raw", true);
+	m_adc_ch0_vert_offset = m_m2k_adc->getRawVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(0));
+	m_adc_ch1_vert_offset = m_m2k_adc->getRawVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(1));
+
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), 2048);
+	m_m2k_adc->setVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(0), 0);
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), 2048);
+	m_m2k_adc->setVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(1), 0);
 
 	// Allow some time for the voltage to settle
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -334,10 +339,8 @@ void M2kCalibrationImpl::updateDacCorrections()
 
 void M2kCalibrationImpl::updateAdcCorrections()
 {
-	m_m2k_adc->setAdcCalibOffset(ANALOG_IN_CHANNEL_1, m_adc_ch0_offset);
-	m_m2k_adc->setAdcCalibOffset(ANALOG_IN_CHANNEL_2, m_adc_ch1_offset);
-	m_ad5625_dev->setDoubleValue(2, m_adc_ch0_offset, "raw", true);
-	m_ad5625_dev->setDoubleValue(3, m_adc_ch1_offset, "raw", true);
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), m_adc_ch0_offset, m_adc_ch0_vert_offset);
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), m_adc_ch0_offset, m_adc_ch1_vert_offset);
 
 	m_m2k_adc->setCalibscale(ANALOG_IN_CHANNEL_1, m_adc_ch0_gain);
 	m_m2k_adc->setCalibscale(ANALOG_IN_CHANNEL_2, m_adc_ch1_gain);
@@ -389,8 +392,8 @@ bool M2kCalibrationImpl::fine_tune(size_t span, int16_t centerVal0, int16_t cent
 	for (i = 0; i < span + 1; i++) {
 		candidateOffsets0[i] = offset0;
 		candidateOffsets1[i] = offset1;
-		m_ad5625_dev->setDoubleValue(2, offset0, "raw", true);
-		m_ad5625_dev->setDoubleValue(3, offset1, "raw", true);
+		m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), offset0);
+		m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), offset1);
 		offset0++;
 		offset1++;
 

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -84,6 +84,8 @@ private:
 
 	int m_adc_ch0_offset;
 	int m_adc_ch1_offset;
+	int m_adc_ch0_vert_offset;
+	int m_adc_ch1_vert_offset;
 	int m_dac_a_ch_offset;
 	int m_dac_b_ch_offset;
 	double m_adc_ch0_gain;


### PR DESCRIPTION
Add the m2k-adc device as a member of M2kAnalogIn.
Save/load the calibration data from registers: offset, gain.
Save/load the vertical offset. 