### PR TITLE
M2k Digital and Analog In capture: Get samples in vector 

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -494,6 +494,18 @@ public:
 	 */
 	struct IIO_OBJECTS getIioObjects();
 
+
+	/**
+	* @brief Retrieve a specific number of samples from each channel
+	*
+	* @param data - a reference to a vector owned/created by the client;
+	* the vector will be cleaned and then filled with samples;
+	* @param nb_samples The number of samples that will be retrieved
+	*
+	* @note The index of the list corresponds to the index of the channel
+	*/
+	void getSamples(std::vector<std::vector<double>> &data, unsigned int nb_samples);
+
 private:
 	class M2kAnalogInImpl;
 	std::unique_ptr<M2kAnalogInImpl> m_pimpl;

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -398,6 +398,15 @@ public:
 	unsigned int getNbChannelsOut();
 
 
+	/**
+	 * @brief Retrieve a specific number of samples
+	 * @param data - a reference to a vector owned/created by the client;
+	 * the vector will be cleaned and then filled with samples;
+	 * @param nb_samples The number of samples that will be retrieved
+	 */
+	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples);
+
+
 	/** @} */
 
 private:

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -63,6 +63,9 @@ public:
 	const short *getSamplesRawInterleaved(unsigned int nb_samples);
 	void* getSamplesRawInterleavedVoid(int nb_samples);
 
+	void getSamples(std::vector<std::vector<double>> &data, int nb_samples,
+					std::function<double(int16_t, unsigned int)> process);
+
 	void stop();
 	void setCyclic(bool enable);
 	void cancelBuffer();

--- a/include/libm2k/utils/buffer.hpp
+++ b/include/libm2k/utils/buffer.hpp
@@ -65,6 +65,7 @@ public:
 
 	void getSamples(std::vector<std::vector<double>> &data, int nb_samples,
 					std::function<double(int16_t, unsigned int)> process);
+	void getSamples(std::vector<unsigned short> &data, int nb_samples);
 
 	void stop();
 	void setCyclic(bool enable);

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -53,6 +53,9 @@ public:
 	virtual const short *getSamplesRawInterleaved(unsigned int nb_samples);
 	void* getSamplesRawInterleavedVoid(unsigned int nb_samples);
 
+	void getSamples(std::vector<std::vector<double>> &data, unsigned int nb_samples,
+			std::function<double (int16_t, unsigned int)> process);
+
 	virtual void cancelBuffer();
 	virtual void flushBuffer();
 	virtual struct IIO_OBJECTS getIioObjects();

--- a/include/libm2k/utils/devicein.hpp
+++ b/include/libm2k/utils/devicein.hpp
@@ -55,6 +55,7 @@ public:
 
 	void getSamples(std::vector<std::vector<double>> &data, unsigned int nb_samples,
 			std::function<double (int16_t, unsigned int)> process);
+	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples);
 
 	virtual void cancelBuffer();
 	virtual void flushBuffer();

--- a/src/analog/m2kanalogin.cpp
+++ b/src/analog/m2kanalogin.cpp
@@ -123,6 +123,11 @@ std::vector<std::vector<double>> M2kAnalogIn::getSamples(unsigned int nb_samples
 	return m_pimpl->getSamples(nb_samples, true);
 }
 
+void M2kAnalogIn::getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples)
+{
+	m_pimpl->getSamples(data, nb_samples);
+}
+
 std::vector<std::vector<double> > M2kAnalogIn::getSamplesRaw(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples, false);

--- a/src/analog/private/m2kanalogin_impl.cpp
+++ b/src/analog/private/m2kanalogin_impl.cpp
@@ -255,6 +255,19 @@ public:
 		return samps;
 	}
 
+	void getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples)
+	{
+		m_need_processing = true;
+		m_samplerate = getSampleRate();
+		handleChannelsEnableState(true);
+
+		auto fp = std::bind(&M2kAnalogInImpl::processSample, this, _1, _2);
+		DeviceIn::getSamples(data, nb_samples, fp);
+
+		handleChannelsEnableState(false);
+		m_need_processing = false;
+	}
+
 	const double *getSamplesInterleaved(unsigned int nb_samples,
 						bool processed = false)
 	{

--- a/src/digital/m2kdigital.cpp
+++ b/src/digital/m2kdigital.cpp
@@ -237,3 +237,8 @@ unsigned int M2kDigital::getNbChannelsOut()
 	return m_pimpl->getNbChannelsOut();
 }
 
+void M2kDigital::getSamples(std::vector<unsigned short> &data, unsigned int nb_samples)
+{
+	m_pimpl->getSamples(data, nb_samples);
+}
+

--- a/src/digital/private/m2kdigital_impl.cpp
+++ b/src/digital/private/m2kdigital_impl.cpp
@@ -268,6 +268,26 @@ public:
 		}
 	}
 
+	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples)
+	{
+		__try {
+			if (!anyChannelEnabled(DIO_INPUT)) {
+				throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No RX channel enabled.");
+
+			}
+
+			/* There is a restriction in the HDL that the buffer size must
+			 * be a multiple of 8 bytes (4x 16-bit samples). Round up to the
+			 * nearest multiple.*/
+			nb_samples = ((nb_samples + 3) / 4) * 4;
+			m_dev_read->getSamples(data, nb_samples);
+
+		} __catch (exception_type &e) {
+			throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: " + string(e.what()));
+		}
+	}
+
+
 	const unsigned short* getSamplesP(int nb_samples)
 	{
 		__try {

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -85,6 +85,11 @@ void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bo
 	m_pimpl->push(data, channel, nb_samples, cyclic);
 }
 
+void Buffer::getSamples(std::vector<unsigned short> &data, int nb_samples)
+{
+	m_pimpl->getSamples(data, nb_samples);
+}
+
 std::vector<unsigned short> Buffer::getSamples(unsigned int nb_samples)
 {
 	return m_pimpl->getSamples(nb_samples);

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -95,6 +95,12 @@ const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 	return m_pimpl->getSamplesP(nb_samples);
 }
 
+void Buffer::getSamples(std::vector<std::vector<double>> &data, int nb_samples,
+				std::function<double(int16_t, unsigned int)> process)
+{
+	m_pimpl->getSamples(data, nb_samples, process);
+}
+
 std::vector<std::vector<double>> Buffer::getSamples(unsigned int nb_samples,
 				std::function<double(int16_t, unsigned int)> process)
 {

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -71,6 +71,12 @@ void* DeviceIn::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 	return m_pimpl->getSamplesRawInterleavedVoid(nb_samples);
 }
 
+void DeviceIn::getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples,
+			  std::function<double(int16_t, unsigned int)> process)
+{
+	m_pimpl->getSamples(data, nb_samples, process);
+}
+
 void DeviceIn::cancelBuffer()
 {
 	m_pimpl->cancelBuffer();

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -77,6 +77,11 @@ void DeviceIn::getSamples(std::vector<std::vector<double> > &data, unsigned int 
 	m_pimpl->getSamples(data, nb_samples, process);
 }
 
+void DeviceIn::getSamples(std::vector<unsigned short> &data, unsigned int nb_samples)
+{
+	m_pimpl->getSamples(data, nb_samples);
+}
+
 void DeviceIn::cancelBuffer()
 {
 	m_pimpl->cancelBuffer();

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -298,13 +298,13 @@ public:
 		}
 	}
 
-	std::vector<unsigned short> getSamples(int nb_samples)
+	void getSamples(std::vector<unsigned short> &data, int nb_samples)
 	{
 		if (Utils::getIioDeviceDirection(m_dev) == OUTPUT) {
 			throw_exception(EXC_RUNTIME_ERROR, "Device not input-buffer capable, so no buffer was created");
 		}
 
-		m_data_short.clear();
+		data.clear();
 
 		bool new_buffer = (nb_samples != m_last_nb_samples);
 		if (new_buffer) {
@@ -325,11 +325,16 @@ public:
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 		}
 
-		unsigned short* data = (unsigned short*)iio_buffer_start(m_buffer);
+		unsigned short* d_ptr = (unsigned short*)iio_buffer_start(m_buffer);
 		for (int i = 0; i < nb_samples; i++) {
-			m_data_short.push_back(data[i]);
+			data.push_back(d_ptr[i]);
 		}
+	}
 
+	std::vector<unsigned short> getSamples(int nb_samples)
+	{
+		m_data_short.clear();
+		getSamples(m_data_short, nb_samples);
 		return m_data_short;
 	}
 

--- a/src/utils/private/buffer_impl.cpp
+++ b/src/utils/private/buffer_impl.cpp
@@ -433,22 +433,29 @@ public:
 		return (const double *)data_p_d;
 	}
 
+
 	std::vector<std::vector<double>> getSamples(int nb_samples,
+					std::function<double(int16_t, unsigned int)> process)
+	{
+		m_data.clear();
+		getSamples(m_data, nb_samples, process);
+		return m_data;
+	}
+
+
+	void getSamples(std::vector<std::vector<double>> &data, int nb_samples,
 					std::function<double(int16_t, unsigned int)> process)
 	{
 		short* data_p = (short *) getSamplesRawInterleaved(nb_samples);
 
 		std::vector<bool> channels_enabled;
-		m_data.clear();
+		data.clear();
 
 		for (auto chn : m_channel_list) {
 			bool en  = chn->isEnabled();
 			channels_enabled.push_back(en);
-			std::vector<double> data {};
-			for (int j = 0; j < nb_samples; j++) {
-				data.push_back(0);
-			}
-			m_data.push_back(data);
+			std::vector<double> ch_data {};
+			data.push_back(ch_data);
 		}
 
 		unsigned int i;
@@ -457,12 +464,10 @@ public:
 		for (i = 0; i < nb_samples; i++) {
 			for (unsigned int ch = 0; ch < nb_channels; ch++) {
 				if (channels_enabled.at(ch)) {
-					m_data[ch][i] = process(data_p[i * nb_channels + ch], ch);
+					data.at(ch).push_back(process(data_p[i * nb_channels + ch], ch));
 				}
 			}
 		}
-
-		return m_data;
 	}
 
 	void stop()

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -141,6 +141,16 @@ public:
 		return m_buffer->getSamplesRawInterleavedVoid(nb_samples);
 	}
 
+	void getSamples(std::vector<std::vector<double>> &data, unsigned int nb_samples,
+			std::function<double(int16_t, unsigned int)> process)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: Cannot refill; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		m_buffer->getSamples(data, nb_samples, process);
+	}
+
 	const double *getSamplesInterleaved(unsigned int nb_samples,
 					std::function<double(int16_t, unsigned int)> process)
 	{

--- a/src/utils/private/devicein_impl.cpp
+++ b/src/utils/private/devicein_impl.cpp
@@ -102,6 +102,16 @@ public:
 		m_channel_list.clear();
 	}
 
+	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples)
+	{
+		if (!m_buffer) {
+			throw_exception(EXC_INVALID_PARAMETER, "Device: Cannot refill; device not buffer capable");
+		}
+		m_buffer->setChannels(m_channel_list);
+		m_buffer->getSamples(data, nb_samples);
+
+	}
+
 	std::vector<unsigned short> getSamples(unsigned int nb_samples)
 	{
 		if (!m_buffer) {


### PR DESCRIPTION
See issue #119 .

Provide getSamplesInVector methods. These methods will get the samples in a buffer that is created/owned by the client, therefore no allocation is done in the library. 

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>