### PR TITLE
General: Check if attributes exist instead of firmware version checking (where possible).

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -21,7 +21,7 @@
 
 #include "m2kanalogin_impl.hpp"
 #include <libm2k/m2kexceptions.hpp>
-
+#include "utils/channel.hpp"
 
 using namespace libm2k::analog;
 using namespace libm2k::utils;
@@ -51,7 +51,7 @@ M2kAnalogInImpl::M2kAnalogInImpl(iio_context * ctx, std::string adc_dev, bool sy
 	m_filter_compensation_table[1E3] = 1.26;
 
 	// calibbias attribute is only available in firmware versions newer than 0.26
-	m_calibbias_available = (Utils::compareVersions(Utils::getFirmwareVersion(ctx), "v0.26") > 0);
+	m_calibbias_available = m_m2k_adc->getChannel(ANALOG_IN_CHANNEL_1, false)->hasAttribute("calibbias");
 	m_samplerate = 1E8;
 
 	for (unsigned int i = 0; i < getNbChannels(); i++) {

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -64,9 +64,10 @@ M2kAnalogOutImpl::M2kAnalogOutImpl(iio_context *ctx, std::vector<std::string> da
 		syncDevice();
 	}
 	// dma_start_sync attribute is only available in firmware versions newer than 0.24
-	m_dma_start_sync_available = (Utils::compareVersions(Utils::getFirmwareVersion(ctx), "v0.24") > 0);
+	m_dma_start_sync_available = getDacDevice(0)->hasGlobalAttribute("dma_sync_start");
+
 	// data_available attribute exists only in firmware versions newer than 0.23
-	m_dma_data_available = (Utils::compareVersions(Utils::getFirmwareVersion(ctx), "v0.23") > 0);
+	m_dma_data_available = getDacDevice(0)->hasBufferAttribute("data_available");
 }
 
 M2kAnalogOutImpl::~M2kAnalogOutImpl()

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -590,3 +590,13 @@ void DeviceGeneric::setCyclic(bool enable)
 		m_buffer->setCyclic(enable);
 	}
 }
+
+bool DeviceGeneric::hasGlobalAttribute(string attr)
+{
+	return ContextImpl::iioDevHasAttribute(m_dev, attr);
+}
+
+bool DeviceGeneric::hasBufferAttribute(string attr)
+{
+	return ContextImpl::iioDevBufferHasAttribute(m_dev, attr);
+}

--- a/src/utils/devicegeneric.hpp
+++ b/src/utils/devicegeneric.hpp
@@ -98,6 +98,8 @@ public:
 	virtual std::pair<std::string, std::string> getContextAttr(unsigned int attrIdx);
 
 	virtual void setCyclic(bool en);
+	virtual bool hasGlobalAttribute(std::string attr);
+	virtual bool hasBufferAttribute(std::string attr);
 
 protected:
 	struct iio_context *m_context;


### PR DESCRIPTION
This provides a better accuracy and detection for certain features. Some setting should only be done for specific firmware version, but we can keep this as generic as possible if we are just checking the presence of those attributes.