### PR TITLE
libm2k.iss: Fix libm2k installer

### DIFF
--- a/libm2k.iss.cmakein
+++ b/libm2k.iss.cmakein
@@ -1,3 +1,5 @@
+#define MsvcLib "msvcp140.dll"
+
 [Setup]
 AppId={{0B97BC46-2BA1-4931-88F2-61E84FC7EFEF}
 AppName="libm2k"
@@ -14,6 +16,7 @@ OutputDir="C:\"
 Compression=lzma
 SolidCompression=yes
 ArchitecturesInstallIn64BitMode=x64
+
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -61,6 +64,15 @@ begin
   end;
  end;
 
+function isMsvcInstalled(): Boolean;
+begin
+  Result := True;
+
+  if not FileExists(ExpandConstant('{sys}\{#MsvcLib}')) then begin
+    Result := False;
+  end;
+ end;
+
  
 [Files]
 Source: "C:\projects\libm2k\build-win64\dist\libm2k-py37-amd64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall
@@ -69,8 +81,8 @@ Source: "C:\projects\libm2k\build-win32\dist\libm2k-py37-win32.exe"; DestDir: "{
 Source: "C:\projects\libm2k\build-win32\libm2k.dll"; DestDir: "{sys}"; Flags: 32bit
 Source: "C:\projects\libm2k\build-win64\libm2k.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode
 
-Source: "C:\projects\libm2k\build-win32\msvcp140.dll"; DestDir: "{sys}"; Flags: 32bit onlyifdoesntexist
-Source: "C:\projects\libm2k\build-win64\msvcp140.dll"; DestDir: "{sys}"; Flags: onlyifdoesntexist; Check: Is64BitInstallMode
+Source: "C:\projects\libm2k\build-win32\{#MsvcLib}"; DestDir: "{sys}"; Check: not isMsvcInstalled; Flags: onlyifdoesntexist 32bit
+Source: "C:\projects\libm2k\build-win64\{#MsvcLib}"; DestDir: "{sys}"; Check: Is64BitInstallMode and (not isMsvcInstalled); Flags: onlyifdoesntexist
 
 ;Source: "C:\projects\libm2k\build-win32\*.exe"; DestDir: "{sys}"; Check: not Is64BitInstallMode
 ;Source: "C:\projects\libm2k\build-win64\*.exe"; DestDir: "{sys}"; Check: Is64BitInstallMode

--- a/libm2k.iss.cmakein
+++ b/libm2k.iss.cmakein
@@ -94,16 +94,16 @@ Source: "C:\projects\libm2k\build-win32\libm2k.lib"; DestDir: "{pf32}\Microsoft 
 Source: "C:\projects\libm2k\build-win64\libm2k.lib"; DestDir: "{pf32}\Microsoft Visual Studio 15.0\VC\lib\amd64"; Check: Is64BitInstallMode
 Source: "C:\projects\libm2k\include\*"; DestDir: "{pf32}\Microsoft Visual Studio 15.0\VC\include"; Flags: ignoreversion recursesubdirs
 
-Source: "C:\libiio-win32\libiio.dll"; DestDir: "{sys}"; Flags: 32bit
+Source: "C:\libiio-win32\libiio.dll"; DestDir: "{sys}"; Tasks: install_libiio_force install_libiio; Flags: 32bit
 Source: "C:\libiio-win64\libiio.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Tasks: install_libiio_force install_libiio;
 
-Source: "C:\libiio-win32\libxml2.dll"; DestDir: "{sys}"; Flags: 32bit
+Source: "C:\libiio-win32\libxml2.dll"; DestDir: "{sys}"; Tasks: install_libiio_force install_libiio; Flags: 32bit
 Source: "C:\libiio-win64\libxml2.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Tasks: install_libiio_force install_libiio;
 
-Source: "C:\libiio-win32\libusb-1.0.dll"; DestDir: "{sys}"; Flags: 32bit
+Source: "C:\libiio-win32\libusb-1.0.dll"; DestDir: "{sys}"; Tasks: install_libiio_force install_libiio; Flags: 32bit
 Source: "C:\libiio-win64\libusb-1.0.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Tasks: install_libiio_force install_libiio;
 
-Source: "C:\libiio-win32\libserialport-0.dll"; DestDir: "{sys}"; Flags: 32bit
+Source: "C:\libiio-win32\libserialport-0.dll"; DestDir: "{sys}"; Tasks: install_libiio_force install_libiio; Flags: 32bit
 Source: "C:\libiio-win64\libserialport-0.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Tasks: install_libiio_force install_libiio;
 
 Source: "C:\projects\libm2k\build-win32\libm2k-sharp.dll"; DestDir: "{cf}\libm2k"; Check: not Is64BitInstallMode


### PR DESCRIPTION
The installer tried to replace the existing msvcp140.dll despite the "onlyifdoesntexist" flag. In this PR we introduced a function to check for its presence.

Also, the 32 bit installer should only install libiio and its dependencies if the "Install libiio" or "Overwrite libiio" is checked. This was missing from the 32bit install rules.