### PR TITLE
Calibration: Fix ADC calibration.

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -98,7 +98,7 @@ void M2kAnalogInImpl::init()
 		m_trigger->setAnalogMode(ch, ALWAYS);
 		setRange(ch, PLUS_MINUS_25V);
 		setAdcCalibOffset(ch, 2048);
-		setAdcCalibGain(ch, 1);
+		m_adc_calib_gain.at(i) = 1;
 		setVerticalOffset(ch, 0);
 	}
 	setKernelBuffersCount(4);
@@ -117,7 +117,6 @@ void M2kAnalogInImpl::syncDevice()
 		} else {
                         m_adc_calib_offset.at(i) = 2048;
 		}
-		m_adc_calib_gain.at(i) = m_m2k_adc->getDoubleValue(i, "calibscale", false);
 		m_adc_hw_offset_raw.at(i) = m_ad5625_dev->getLongValue(2 + i, "raw", true);
 		m_adc_hw_vert_offset.at(i) = convertRawToVoltsVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(i), m_adc_hw_offset_raw.at(i) - m_adc_calib_offset.at(i));
 
@@ -130,7 +129,7 @@ void M2kAnalogInImpl::syncDevice()
 void M2kAnalogInImpl::setAdcCalibGain(ANALOG_IN_CHANNEL channel, double gain)
 {
 
-	m_adc_calib_gain.at(channel) = m_m2k_adc->setDoubleValue(channel, gain, "calibscale");
+	m_adc_calib_gain.at(channel) = gain;
 	m_trigger->setCalibParameters(channel, getScalingFactor(channel), m_adc_hw_vert_offset.at(channel));
 }
 

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -202,7 +202,8 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 	double gain = 1.3;
 	double range = 3.192;
 	bool calibrated = false;
-	double voltage0, voltage1 = 0;
+	double voltage0 = 0;
+	double voltage1 = 0;
 	std::vector<std::vector<double>> ch_data = {};
 
 	if (!m_initialized) {
@@ -340,7 +341,7 @@ void M2kCalibrationImpl::updateDacCorrections()
 void M2kCalibrationImpl::updateAdcCorrections()
 {
 	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), m_adc_ch0_offset, m_adc_ch0_vert_offset);
-	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), m_adc_ch0_offset, m_adc_ch1_vert_offset);
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), m_adc_ch1_offset, m_adc_ch1_vert_offset);
 
 	m_m2k_adc->setCalibscale(ANALOG_IN_CHANNEL_1, m_adc_ch0_gain);
 	m_m2k_adc->setCalibscale(ANALOG_IN_CHANNEL_2, m_adc_ch1_gain);
@@ -432,8 +433,8 @@ bool M2kCalibrationImpl::fine_tune(size_t span, int16_t centerVal0, int16_t cent
 	m_adc_ch0_offset = candidateOffsets0[i0];
 	m_adc_ch1_offset = candidateOffsets1[i1];
 
-	m_ad5625_dev->setDoubleValue(2, m_adc_ch0_offset, "raw", true);
-	m_ad5625_dev->setDoubleValue(3, m_adc_ch1_offset, "raw", true);
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), m_adc_ch0_offset);
+	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), m_adc_ch1_offset);
 
 out_cleanup:
 	delete[] candidateOffsets0;


### PR DESCRIPTION
Fix the computation of calibration offset.
Do not use calibscale for converting samples.