### PR TITLE
DAC and ADC calibration coefficients setters.

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -337,15 +337,6 @@ public:
 
 
 	/**
-	* @brief Retrieve the value of the calibration scale for the given channel
-	*
-	* @param index The index corresponding to the channel
-	* @return The value of the calibration scale
-	*/
-	virtual double getCalibscale(unsigned int index) = 0;
-
-
-	/**
 	* @brief Retrieve the filter compensation for the given sample rate
 	*
 	* @param samplerate A double value representing the sample rate

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -190,15 +190,6 @@ public:
 
 
 	/**
-	* @brief Retrieve the calibration scale for the given channel
-	*
-	* @param index The index corresponding to the channel
-	* @return The value of the calibration scale
-	*/
-	virtual double getCalibscale(unsigned int index) = 0;
-
-
-	/**
 	* @brief Retrieve the scaling factor for the given channel
 	*
 	* @param chn The index corresponding to the channel

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -214,7 +214,8 @@ public:
 	* @param chn The index corresponding to a channel
 	* @param gain The calibration gain value
 	* @note Overrides the calibration coefficients.\n
-	* Can be reset by running a calibration.
+	* Can be reset by running a calibration.\n
+	* The gain value is currently limited at the (-2,2) range  by the hardware.
 	*/
 	virtual void setDacCalibrationGain(unsigned int chn, double gain) = 0;
 
@@ -234,7 +235,8 @@ public:
 	* @param chn The index corresponding to a channel
 	* @param gain The calibration gain value
 	* @note Overrides the calibration coefficients.\n
-	* Can be reset by running a calibration.
+	* Can be reset by running a calibration.\n
+	* The gain value is currently limited at the (-2,2) range  by the hardware.
 	*/
 	virtual void setAdcCalibrationGain(unsigned int chn, double gain) = 0;
 

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -164,35 +164,21 @@ public:
 
 
 	/**
-	* @brief Get the calibration offset of the DAC-B
+	* @brief Get the calibration offset of the DAC
 	*
+	* @param chn The index corresponding to a channel
 	* @return The value of the calibration offset
 	*/
-	virtual int getDacBCalibrationOffset() = 0;
+	virtual int getDacCalibrationOffset(unsigned int chn) = 0;
 
 
 	/**
-	* @brief Get the calibration offset of the DAC-A
+	* @brief Get the calibration gain of the DAC
 	*
-	* @return The value of the calibration offset
-	*/
-	virtual int getDacACalibrationOffset() = 0;
-
-
-	/**
-	* @brief Get the calibration gain of the DAC-B
-	*
+	* @param chn The index corresponding to a channel
 	* @return The value of the calibration gain
 	*/
-	virtual double getDacBCalibrationGain() = 0;
-
-
-	/**
-	* @brief Get the calibration gain of the DAC-A
-	*
-	* @return The value of the calibration gain
-	*/
-	virtual double getDacACalibrationGain() = 0;
+	virtual double getDacCalibrationGain(unsigned int chn) = 0;
 
 
 	/**
@@ -211,6 +197,46 @@ public:
 	* @return The value of the calibration gain
 	*/
 	virtual double getAdcCalibrationGain(unsigned int chn) = 0;
+
+
+	/**
+	* @brief Set the calibration offset of the DAC
+	* @param chn The index corresponding to a channel
+	* @param offset The calibration offset value
+	* @note Overrides the calibration coefficients.\n
+	* Can be reset by running a calibration.
+	*/
+	virtual void setDacCalibrationOffset(unsigned int chn, int offset) = 0;
+
+
+	/**
+	* @brief Set the calibration gain of the DAC
+	* @param chn The index corresponding to a channel
+	* @param gain The calibration gain value
+	* @note Overrides the calibration coefficients.\n
+	* Can be reset by running a calibration.
+	*/
+	virtual void setDacCalibrationGain(unsigned int chn, double gain) = 0;
+
+
+	/**
+	* @brief Set the calibration offset of the ADC
+	* @param chn The index corresponding to a channel
+	* @param offset The calibration offset value
+	* @note Overrides the calibration coefficients.\n
+	* Can be reset by running a calibration.
+	*/
+	virtual void setAdcCalibrationOffset(unsigned int chn, int offset) = 0;
+
+
+	/**
+	* @brief Set the calibration gain of the ADC
+	* @param chn The index corresponding to a channel
+	* @param gain The calibration gain value
+	* @note Overrides the calibration coefficients.\n
+	* Can be reset by running a calibration.
+	*/
+	virtual void setAdcCalibrationGain(unsigned int chn, double gain) = 0;
 
 
 	/**

--- a/include/libm2k/m2kcalibration.hpp
+++ b/include/libm2k/m2kcalibration.hpp
@@ -55,6 +55,11 @@ public:
 	virtual double dacBvlsb() const = 0;
 
 	virtual bool resetCalibration() = 0;
+
+	virtual void setDacGain(unsigned int chn, double gain) = 0;
+	virtual void setDacOffset(unsigned int chn, int offset) = 0;
+	virtual void setAdcOffset(unsigned int chn, int offset) = 0;
+	virtual void setAdcGain(unsigned int chn, double gain) = 0;
 };
 
 }

--- a/include/libm2k/m2kcalibration.hpp
+++ b/include/libm2k/m2kcalibration.hpp
@@ -45,14 +45,11 @@ public:
 	virtual bool calibrateDAC() = 0;
 	virtual void cancelCalibration() = 0;
 
-	virtual int adcOffsetChannel0() const = 0;
-	virtual int adcOffsetChannel1() const = 0;
-	virtual int dacAoffset() const = 0;
-	virtual int dacBoffset() const = 0;
-	virtual double adcGainChannel0() const = 0;
-	virtual double adcGainChannel1() const = 0;
-	virtual double dacAvlsb() const = 0;
-	virtual double dacBvlsb() const = 0;
+	virtual int getAdcOffset(unsigned int channel) = 0;
+	virtual int getDacOffset(unsigned int channel) = 0;
+	virtual double getAdcGain(unsigned int channel) = 0;
+	virtual double getDacGain(unsigned int channel) = 0;
+
 
 	virtual bool resetCalibration() = 0;
 

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -703,3 +703,13 @@ void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_off
 
 	m_trigger->setCalibParameters(channel, getScalingFactor(channel), m_adc_hw_vert_offset.at(channel));
 }
+
+int M2kAnalogInImpl::getAdcCalibOffset(ANALOG_IN_CHANNEL channel)
+{
+	if (m_calibbias_available) {
+		return m_m2k_adc->getLongValue(channel, "calibbias", false);
+	} else {
+		auto adc_hw_offset = m_ad5625_dev->getLongValue(channel + 2, "raw", true);
+		return (adc_hw_offset - m_adc_hw_vert_offset.at(channel));
+	}
+}

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -87,9 +87,10 @@ public:
 	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset, int vert_offset);
 
 	double setCalibscale(unsigned int index, double calibscale);
-	double getCalibscale(unsigned int index) override;
+	double getCalibscale(unsigned int index);
 
 	void setAdcCalibGain(ANALOG_IN_CHANNEL channel, double gain);
+	int getAdcCalibOffset(ANALOG_IN_CHANNEL channel);
 
 	double getFilterCompensation(double samplerate) override;
 

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -107,8 +107,7 @@ double M2kAnalogOutImpl::getCalibscale(unsigned int index)
 
 double M2kAnalogOutImpl::setCalibscale(unsigned int index, double calibscale)
 {
-	getDacDevice(index)->setDoubleValue(calibscale, "calibscale");
-	return getCalibscale(index);
+	return getDacDevice(index)->setDoubleValue(calibscale, "calibscale");
 }
 
 std::vector<int> M2kAnalogOutImpl::getOversamplingRatio()

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -238,24 +238,60 @@ int M2kImpl::getAdcCalibrationOffset(unsigned int chn)
 	}
 }
 
-double M2kImpl::getDacACalibrationGain()
+double M2kImpl::getDacCalibrationGain(unsigned int chn)
 {
-	return m_calibration->dacAvlsb();
+	if (chn >= getAnalogOut()->getNbChannels()) {
+		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+	}
+	if (chn == 0) {
+		return m_calibration->dacAvlsb();
+	} else {
+		return m_calibration->dacBvlsb();
+	}
 }
 
-double M2kImpl::getDacBCalibrationGain()
+int M2kImpl::getDacCalibrationOffset(unsigned int chn)
 {
-	return m_calibration->dacBvlsb();
+	if (chn >= getAnalogOut()->getNbChannels()) {
+		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+	}
+	if (chn == 0) {
+		return m_calibration->dacAoffset();
+	} else {
+		return m_calibration->dacBoffset();
+	}
 }
 
-int M2kImpl::getDacACalibrationOffset()
+void M2kImpl::setAdcCalibrationGain(unsigned int chn, double gain)
 {
-	return m_calibration->dacAoffset();
+	if (chn >= getAnalogIn()->getNbChannels()) {
+		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+	}
+	m_calibration->setAdcGain(chn, gain);
 }
 
-int M2kImpl::getDacBCalibrationOffset()
+void M2kImpl::setAdcCalibrationOffset(unsigned int chn, int offset)
 {
-	return m_calibration->dacBoffset();
+	if (chn >= getAnalogIn()->getNbChannels()) {
+		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+	}
+	m_calibration->setAdcOffset(chn, offset);
+}
+
+void M2kImpl::setDacCalibrationOffset(unsigned int chn, int offset)
+{
+	if (chn >= getAnalogOut()->getNbChannels()) {
+		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+	}
+	m_calibration->setDacOffset(chn, offset);
+}
+
+void M2kImpl::setDacCalibrationGain(unsigned int chn, double gain)
+{
+	if (chn >= getAnalogOut()->getNbChannels()) {
+		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+	}
+	m_calibration->setDacGain(chn, gain);
 }
 
 M2kAnalogIn* M2kImpl::getAnalogIn()

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -216,50 +216,22 @@ bool M2kImpl::calibrateDAC()
 
 double M2kImpl::getAdcCalibrationGain(unsigned int chn)
 {
-	if (chn >= getAnalogIn()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
-	}
-	if (chn == 0) {
-		return m_calibration->adcGainChannel0();
-	} else {
-		return m_calibration->adcGainChannel1();
-	}
+	return m_calibration->getAdcGain(chn);
 }
 
 int M2kImpl::getAdcCalibrationOffset(unsigned int chn)
 {
-	if (chn >= getAnalogIn()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
-	}
-	if (chn == 0) {
-		return m_calibration->adcOffsetChannel0();
-	} else {
-		return m_calibration->adcOffsetChannel1();
-	}
+	return m_calibration->getAdcOffset(chn);
 }
 
 double M2kImpl::getDacCalibrationGain(unsigned int chn)
 {
-	if (chn >= getAnalogOut()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
-	}
-	if (chn == 0) {
-		return m_calibration->dacAvlsb();
-	} else {
-		return m_calibration->dacBvlsb();
-	}
+	return m_calibration->getDacGain(chn);
 }
 
 int M2kImpl::getDacCalibrationOffset(unsigned int chn)
 {
-	if (chn >= getAnalogOut()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
-	}
-	if (chn == 0) {
-		return m_calibration->dacAoffset();
-	} else {
-		return m_calibration->dacBoffset();
-	}
+	return m_calibration->getDacOffset(chn);
 }
 
 void M2kImpl::setAdcCalibrationGain(unsigned int chn, double gain)

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -57,12 +57,15 @@ public:
 	std::vector<libm2k::analog::M2kAnalogIn*> getAllAnalogIn();
 	std::vector<libm2k::analog::M2kAnalogOut*> getAllAnalogOut();
 
-	int getDacBCalibrationOffset();
-	int getDacACalibrationOffset();
-	double getDacBCalibrationGain();
-	double getDacACalibrationGain();
+	int getDacCalibrationOffset(unsigned int chn);
+	double getDacCalibrationGain(unsigned int chn);
 	int getAdcCalibrationOffset(unsigned int chn);
 	double getAdcCalibrationGain(unsigned int chn);
+	void setDacCalibrationOffset(unsigned int chn, int offset);
+	void setDacCalibrationGain(unsigned int chn, double gain);
+	void setAdcCalibrationOffset(unsigned int chn, int offset);
+	void setAdcCalibrationGain(unsigned int chn, double gain);
+
 
 	void setLed(bool on);
 	bool getLed();

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -326,6 +326,31 @@ double M2kCalibrationImpl::adcGainChannel1() const
 	return m_adc_ch1_gain;
 }
 
+void M2kCalibrationImpl::setAdcOffset(unsigned int chn, int offset)
+{
+	if (chn == 0) {
+		m_adc_ch0_offset = offset;
+		m_adc_ch0_vert_offset = 0;
+		m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), m_adc_ch0_offset, m_adc_ch0_vert_offset);
+	} else if (chn == 1) {
+		m_adc_ch1_offset = offset;
+		m_adc_ch1_vert_offset = 0;
+		m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(1), m_adc_ch1_offset, m_adc_ch1_vert_offset);
+	}
+}
+
+
+void M2kCalibrationImpl::setAdcGain(unsigned int chn, double gain)
+{
+	if (chn == 0) {
+		m_adc_ch0_gain = gain;
+		m_m2k_adc->setCalibscale(ANALOG_IN_CHANNEL_1, m_adc_ch0_gain);
+	} else if (chn == 1) {
+		m_adc_ch1_gain = gain;
+		m_m2k_adc->setCalibscale(ANALOG_IN_CHANNEL_2, m_adc_ch1_gain);
+	}
+}
+
 void M2kCalibrationImpl::updateDacCorrections()
 {
 	m_ad5625_dev->setDoubleValue(0, m_dac_a_ch_offset, "raw", true);
@@ -461,6 +486,28 @@ double M2kCalibrationImpl::dacAvlsb() const
 double M2kCalibrationImpl::dacBvlsb() const
 {
 	return m_dac_b_ch_vlsb;
+}
+
+void M2kCalibrationImpl::setDacOffset(unsigned int chn, int offset)
+{
+	if (chn == 0) {
+		m_dac_a_ch_offset = offset;
+		m_ad5625_dev->setDoubleValue(0, m_dac_a_ch_offset, "raw", true);
+	} else if (chn == 1) {
+		m_dac_b_ch_offset = offset;
+		m_ad5625_dev->setDoubleValue(1, m_dac_b_ch_offset, "raw", true);
+	}
+}
+
+void M2kCalibrationImpl::setDacGain(unsigned int chn, double gain)
+{
+	if (chn == 0) {
+		m_dac_a_ch_vlsb = gain;
+		m_m2k_dac->setCalibscale(0, m_dac_default_vlsb / dacAvlsb());
+	} else if (chn == 1) {
+		m_dac_b_ch_vlsb = gain;
+		m_m2k_dac->setCalibscale(1, m_dac_default_vlsb / dacBvlsb());
+	}
 }
 
 bool M2kCalibrationImpl::calibrateDACoffset()

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -59,14 +59,10 @@ public:
 	bool calibrateDACgain();
 	void cancelCalibration();
 
-	int adcOffsetChannel0() const;
-	int adcOffsetChannel1() const;
-	int dacAoffset() const;
-	int dacBoffset() const;
-	double adcGainChannel0() const;
-	double adcGainChannel1() const;
-	double dacAvlsb() const;
-	double dacBvlsb() const;
+	int getAdcOffset(unsigned int channel);
+	int getDacOffset(unsigned int channel);
+	double getAdcGain(unsigned int channel);
+	double getDacGain(unsigned int channel);
 
 	bool resetCalibration();
 	void updateAdcCorrections();

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -74,6 +74,10 @@ public:
 
 	bool setCalibrationMode(int);
 
+	void setDacGain(unsigned int chn, double gain);
+	void setDacOffset(unsigned int chn, int offset);
+	void setAdcOffset(unsigned int chn, int offset);
+	void setAdcGain(unsigned int chn, double gain);
 private:
 	bool m_cancel;
 


### PR DESCRIPTION
Expose to the user some methods which overwrite the ADC and DAC calibration gain and offset. Those will affect the read/written data. The values can be reset using the automatic calibration().
