### PR TITLE
M2kHardwareTrigger: Fix digital source confusion when retrieving its value

### DIFF
--- a/include/libm2k/m2khardwaretrigger.hpp
+++ b/include/libm2k/m2khardwaretrigger.hpp
@@ -330,7 +330,7 @@ public:
 	 * @brief getDigitalExternalCondition
 	 * @return M2K_TRIGGER_CONDITION_DIGITAL
 	 */
-	virtual M2K_TRIGGER_CONDITION_DIGITAL getDigitalExternalCondition() = 0;
+	virtual M2K_TRIGGER_CONDITION_DIGITAL getDigitalExternalCondition() const = 0;
 
 
 	/**

--- a/src/m2khardwaretrigger_impl.cpp
+++ b/src/m2khardwaretrigger_impl.cpp
@@ -200,7 +200,7 @@ bool M2kHardwareTriggerImpl::hasCrossInstrumentTrigger() const
 }
 
 
-M2K_TRIGGER_CONDITION_DIGITAL M2kHardwareTriggerImpl::getDigitalExternalCondition()
+M2K_TRIGGER_CONDITION_DIGITAL M2kHardwareTriggerImpl::getDigitalExternalCondition() const
 {
 	std::string buf = m_digital_trigger_device->getStringValue(16, "trigger");
 

--- a/src/m2khardwaretrigger_impl.hpp
+++ b/src/m2khardwaretrigger_impl.hpp
@@ -96,7 +96,7 @@ public:
 	void setAnalogExternalCondition(unsigned int chnIdx, M2K_TRIGGER_CONDITION_DIGITAL cond);
 
 
-	M2K_TRIGGER_CONDITION_DIGITAL getDigitalExternalCondition();
+	M2K_TRIGGER_CONDITION_DIGITAL getDigitalExternalCondition() const;
 	void setDigitalExternalCondition(M2K_TRIGGER_CONDITION_DIGITAL cond);
 
 	bool hasExternalTriggerIn() const;

--- a/src/m2khardwaretrigger_v0.24_impl.cpp
+++ b/src/m2khardwaretrigger_v0.24_impl.cpp
@@ -174,7 +174,15 @@ M2K_TRIGGER_SOURCE_DIGITAL M2kHardwareTriggerV024Impl::getDigitalSource() const
 		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: trigger");
 	}
 
-	return static_cast<M2K_TRIGGER_SOURCE_DIGITAL>(it - m_trigger_ext_digital_source.begin());
+	auto src = static_cast<M2K_TRIGGER_SOURCE_DIGITAL>(it - m_trigger_ext_digital_source.begin());
+	if (src == SRC_ANALOG_IN) {
+		return src;
+	}
+
+	if (getDigitalExternalCondition() != NO_TRIGGER_DIGITAL) {
+		return SRC_TRIGGER_IN;
+	}
+	return SRC_NONE;
 }
 
 M2K_TRIGGER_SOURCE_DIGITAL M2kHardwareTrigger::getDigitalSource() const


### PR DESCRIPTION
The digital trigger source can be either "trigger-logic" or "trigger-in" (if we're talking about IIO attributes). In libm2k, we added SRC_TRIGGER_IN (trigger-logic), SRC_ANALOG_IN (trigger-in) and SRC_NONE.

The third should also point to "trigger-logic", because that is the default value for this attribute. However, we didn't check this when calling "getDigitalSource". This commit should verify whether there is a trigger condition attached to this source and return SRC_NONE or SRC_TRIGGER_IN
accordingly.

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>