### PR TITLE
M2K and Generic DAC fixes.

### DIFF
--- a/include/libm2k/analog/genericanalogout.hpp
+++ b/include/libm2k/analog/genericanalogout.hpp
@@ -57,6 +57,7 @@ public:
 
 	virtual std::string getName() = 0;
 	virtual void enableChannel(unsigned int chnIdx, bool enable) = 0;
+	virtual bool isChannelEnabled(unsigned int chnIdx) = 0;
 };
 }
 }

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -406,6 +406,14 @@ public:
 	* @return The number of channels
 	*/
 	virtual unsigned int getNbChannels() = 0;
+
+
+	/**
+	 * @brief Get the channel name for each DAC channel
+	 * @param channel - unsigned int representing the index of the channel
+	 * @return std::string - name of the channel
+	 */
+	virtual std::string getChannelName(unsigned int channel) = 0;
 };
 }
 }

--- a/src/analog/generic/genericanalogout_impl.cpp
+++ b/src/analog/generic/genericanalogout_impl.cpp
@@ -33,6 +33,9 @@ using namespace libm2k::utils;
 GenericAnalogOutImpl::GenericAnalogOutImpl(iio_context *ctx, std::string dac_dev)
 {
 	m_devices_out.push_back(make_shared<DeviceOut>(ctx, dac_dev));
+	for (auto dac : m_devices_out) {
+		m_cyclic.push_back(false);
+	}
 }
 
 GenericAnalogOutImpl::~GenericAnalogOutImpl()
@@ -83,15 +86,15 @@ std::vector<double> GenericAnalogOutImpl::getAvailableSampleRates()
 
 void GenericAnalogOutImpl::setCyclic(bool en)
 {
-	for (unsigned int i = 0; i < getDacDevice(0)->getNbChannels(true); i++) {
+	for (unsigned int i = 0; i < m_devices_out.size(); i++) {
 		m_cyclic.at(i) = en;
+		getDacDevice(i)->setCyclic(en);
 	}
-	getDacDevice(0)->setCyclic(en);
 }
 
 void GenericAnalogOutImpl::setCyclic(unsigned int chn, bool en)
 {
-	if (chn >= getDacDevice(0)->getNbChannels(true)) {
+	if (chn >= m_devices_out.size()) {
 		throw_exception(EXC_INVALID_PARAMETER, "Generic Analog Out: No such channel");
 	}
 	m_cyclic.at(chn) = en;
@@ -99,7 +102,7 @@ void GenericAnalogOutImpl::setCyclic(unsigned int chn, bool en)
 
 bool GenericAnalogOutImpl::getCyclic(unsigned int chn)
 {
-	if (chn >= getDacDevice(0)->getNbChannels(true)) {
+	if (chn >=  m_devices_out.size()) {
 		throw_exception(EXC_INVALID_PARAMETER, "Generic Analog Out: No such channel");
 	}
 	return m_cyclic.at(chn);
@@ -138,4 +141,9 @@ string GenericAnalogOutImpl::getName()
 void GenericAnalogOutImpl::enableChannel(unsigned int chnIdx, bool enable)
 {
 	getDacDevice(0)->enableChannel(chnIdx, enable, true);
+}
+
+bool GenericAnalogOutImpl::isChannelEnabled(unsigned int chnIdx)
+{
+	return getDacDevice(0)->isChannelEnabled(chnIdx, true);
 }

--- a/src/analog/generic/genericanalogout_impl.hpp
+++ b/src/analog/generic/genericanalogout_impl.hpp
@@ -59,6 +59,7 @@ public:
 
 	std::string getName();
 	void enableChannel(unsigned int chnIdx, bool enable);
+	bool isChannelEnabled(unsigned int chnIdx);
 
 private:
 	std::vector<bool> m_cyclic;

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -285,7 +285,7 @@ string M2kAnalogInImpl::getChannelName(unsigned int channel)
 	std::string name = "";
 	auto chn = m_m2k_adc->getChannel(channel, false);
 	if (chn) {
-		name = chn->getName();
+		name = chn->getId();
 	}
 	return name;
 }

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -23,6 +23,7 @@
 #include "utils/deviceout.hpp"
 #include <libm2k/m2kexceptions.hpp>
 #include <libm2k/utils/utils.hpp>
+#include "utils/channel.hpp"
 
 #include <iostream>
 #include <thread>
@@ -603,4 +604,14 @@ void M2kAnalogOutImpl::cancelBuffer(unsigned int chn)
 unsigned int M2kAnalogOutImpl::getNbChannels()
 {
 	return m_dac_devices.size();
+}
+
+string M2kAnalogOutImpl::getChannelName(unsigned int channel)
+{
+	std::string name = "";
+	auto chn = getDacDevice(channel)->getChannel(0, true);
+	if (chn) {
+		name = chn->getId();
+	}
+	return name;
 }

--- a/src/analog/m2kanalogout_impl.hpp
+++ b/src/analog/m2kanalogout_impl.hpp
@@ -85,6 +85,7 @@ public:
 	void cancelBuffer(unsigned int chn);
 
 	unsigned int getNbChannels();
+	std::string getChannelName(unsigned int channel);
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
 	std::vector<double> m_calib_vlsb;


### PR DESCRIPTION
- Fix the cyclic attribute for Generic Analog Out.
- Add a channel name getter for M2k Analog Out.