### PR TITLE
bindings/python: Fix CMake Policy warnings related to SWIG.

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,5 +1,21 @@
 cmake_minimum_required(VERSION 2.8.7)
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.5")
+	# Check CMake Policy added in v3.13 regarding the SWIG generated target name
+	# https://cmake.org/cmake/help/v3.14/policy/CMP0078.html
+	cmake_policy(SET CMP0078 NEW)
+	set(SWIG_OUTPUT_NAME _libm2k)
+else()
+	set(SWIG_OUTPUT_NAME libm2k)
+endif()
+
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.7")
+	# Check CMake Policy added in v3.14 regarding the SWIG_MODULE_NAME flag
+	# https://cmake.org/cmake/help/v3.14/policy/CMP0086.html
+	cmake_policy(SET CMP0086 NEW)
+endif()
+
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
 	if (NOT WIN32)
 		set(Python_ADDITIONAL_VERSIONS 3)
@@ -51,7 +67,11 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 set_property(SOURCE ../${PROJECT_NAME}.i PROPERTY SWIG_MODULE_NAME "libm2k")
 
-SWIG_ADD_LIBRARY(${PROJECT_NAME} TYPE MODULE LANGUAGE python OUTPUT_DIR ${CMAKE_BINARY_DIR} OUTFILE_DIR ${CMAKE_BINARY_DIR} SOURCES ../${PROJECT_NAME}.i)
+SWIG_ADD_LIBRARY(${SWIG_OUTPUT_NAME} TYPE MODULE LANGUAGE python OUTPUT_DIR ${CMAKE_BINARY_DIR} OUTFILE_DIR ${CMAKE_BINARY_DIR} SOURCES ../${PROJECT_NAME}.i)
+
+if (SWIG_MODULE_libm2k_REAL_NAME)
+	set(SWIG_OUTPUT_NAME ${SWIG_MODULE_libm2k_REAL_NAME})
+endif()
 
 # Handle Anaconda issues on OSX
 execute_process(COMMAND ${Python_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_config_var('LDSHARED'))"
@@ -68,7 +88,7 @@ ENDIF()
 IF (NOT PYTHON_LINK)
 	IF (APPLE)
 		message("--- Using LD_SHARED " ${PY_LD_SHARED})
-		SET_TARGET_PROPERTIES(${SWIG_MODULE_libm2k_REAL_NAME} PROPERTIES LINK_FLAGS "-flat_namespace -undefined dynamic_lookup")
+		SET_TARGET_PROPERTIES(${SWIG_OUTPUT_NAME} PROPERTIES LINK_FLAGS "-flat_namespace -undefined dynamic_lookup")
 	ENDIF()
 ENDIF()
 
@@ -85,10 +105,10 @@ ENDIF()
 set(PYTHON_EXECUTABLE_LIB_VERSION ${Python_EXECUTABLE})
 if(UNIX)
 	if(NOT APPLE)
-		set_target_properties(${SWIG_MODULE_libm2k_REAL_NAME} PROPERTIES
+		set_target_properties(${SWIG_OUTPUT_NAME} PROPERTIES
 			INSTALL_RPATH	"$ORIGIN")
 	else()
-		set_target_properties(${SWIG_MODULE_libm2k_REAL_NAME} PROPERTIES
+		set_target_properties(${SWIG_OUTPUT_NAME} PROPERTIES
 			SUFFIX ".so"
 			INSTALL_RPATH	"@loader_path")
 #		set_property(TARGET ${SWIG_MODULE_pyBar_REAL_NAME} APPEND PROPERTY
@@ -98,7 +118,7 @@ endif()
 
 if (WIN32)
   # disable lib prefix on windows with mingw
-  set_target_properties(${SWIG_MODULE_libm2k_REAL_NAME} PROPERTIES PREFIX "")
+  set_target_properties(${SWIG_OUTPUT_NAME} PROPERTIES PREFIX "")
 endif()
 
 set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmakein)


### PR DESCRIPTION
bindings/python: Fix CMake Policy warnings related to SWIG module name and generated target name.

Related to issue #139 .

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>