### PR TITLE
Revert cancel acquisition commit which added a buffer destruction

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -410,6 +410,7 @@ public:
 
 	/**
 	* @brief Cancel all buffer operations
+	* @note Should be used to cancel an ongoing acquisition
 	*/
 	virtual void cancelAcquisition() = 0;
 

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -335,6 +335,7 @@ public:
 
 	/**
 	 * @brief Cancel all buffer operations of enabled channels
+	 * @note Should be used to cancel an ongoing data write.
 	 */
 	virtual void cancelBuffer() = 0;
 
@@ -342,6 +343,7 @@ public:
 	/**
 	 * @brief Cancel all buffer operations of the given channel
 	 * @param chn The index corresponding to the channel
+	 * @note Should be used to cancel an ongoing data write.
 	 */
 	virtual void cancelBuffer(unsigned int chn) = 0;
 

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -189,11 +189,13 @@ public:
 
 	/**
 	* @brief Cancel all rx-buffer operations
+	* @note Should be used to cancel an ongoing acquisition
 	*/
 	virtual void cancelAcquisition() = 0;
 
 	/**
 	* @brief Cancel all tx-buffer operations
+	* @note Should be used to cancel an ongoing data write.
 	*/
 	virtual void cancelBufferOut() = 0;
 

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -630,7 +630,6 @@ struct libm2k::IIO_OBJECTS M2kAnalogInImpl::getIioObjects()
 void M2kAnalogInImpl::cancelAcquisition()
 {
 	m_m2k_adc->cancelBuffer();
-	m_m2k_adc->flushBuffer();
 }
 
 void M2kAnalogInImpl::setKernelBuffersCount(unsigned int count)

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -592,7 +592,7 @@ struct IIO_OBJECTS M2kAnalogOutImpl::getIioObjects()
 void M2kAnalogOutImpl::cancelBuffer()
 {
 	for (DeviceOut *dev : m_dac_devices) {
-		dev->stop();
+		dev->cancelBuffer();
 	}
 }
 

--- a/src/digital/m2kdigital_impl.cpp
+++ b/src/digital/m2kdigital_impl.cpp
@@ -424,12 +424,11 @@ struct IIO_OBJECTS M2kDigitalImpl::getIioObjects()
 void M2kDigitalImpl::cancelAcquisition()
 {
 	m_dev_read->cancelBuffer();
-	m_dev_read->flushBuffer();
 }
 
 void M2kDigitalImpl::cancelBufferOut()
 {
-	m_dev_write->stop();
+	m_dev_write->cancelBuffer();
 }
 
 unsigned int M2kDigitalImpl::getNbChannelsIn()

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -110,7 +110,11 @@ void Buffer::push(unsigned short *data, unsigned int channel, unsigned int nb_sa
 			}
 
 		}
-		iio_buffer_push(m_buffer);
+		ssize_t ret = iio_buffer_push(m_buffer);
+		if (ret < 0) {
+			destroy();
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+		}
 	} else {
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
 
@@ -152,7 +156,11 @@ void Buffer::push(std::vector<short> const &data, unsigned int channel,
 			}
 
 		}
-		iio_buffer_push(m_buffer);
+		ssize_t ret = iio_buffer_push(m_buffer);
+		if (ret < 0) {
+			destroy();
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+		}
 	} else {
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
 
@@ -193,7 +201,11 @@ void Buffer::push(std::vector<unsigned short> const &data, unsigned int channel,
 			}
 
 		}
-		iio_buffer_push(m_buffer);
+		ssize_t ret = iio_buffer_push(m_buffer);
+		if (ret < 0) {
+			destroy();
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+		}
 	} else {
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
 
@@ -222,7 +234,11 @@ void Buffer::push(std::vector<double> const &data, unsigned int channel, bool cy
 
 	if (channel < m_channel_list.size() ) {
 		m_channel_list.at(channel)->write(m_buffer, data);
-		iio_buffer_push(m_buffer);
+		ssize_t ret = iio_buffer_push(m_buffer);
+		if (ret < 0) {
+			destroy();
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+		}
 	} else {
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
 	}
@@ -263,7 +279,11 @@ void Buffer::push(double *data, unsigned int channel, unsigned int nb_samples, b
 
 	if (channel < m_channel_list.size() ) {
 		m_channel_list.at(channel)->write(m_buffer, data, nb_samples);
-		iio_buffer_push(m_buffer);
+		ssize_t ret = iio_buffer_push(m_buffer);
+		if (ret < 0) {
+			destroy();
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+		}
 	} else {
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
 	}
@@ -290,7 +310,11 @@ void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bo
 
 	if (channel < m_channel_list.size() ) {
 		m_channel_list.at(channel)->write(m_buffer, data, nb_samples);
-		iio_buffer_push(m_buffer);
+		ssize_t ret = iio_buffer_push(m_buffer);
+		if (ret < 0) {
+			destroy();
+			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+		}
 	} else {
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
 	}
@@ -310,7 +334,7 @@ void Buffer::getSamples(std::vector<unsigned short> &data, unsigned int nb_sampl
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot create the RX buffer");
 	}
 
-	int ret = iio_buffer_refill(m_buffer);
+	ssize_t ret = iio_buffer_refill(m_buffer);
 
 
 	if (ret < 0) {
@@ -345,7 +369,7 @@ const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 		return nullptr;
 	}
 
-	int ret = iio_buffer_refill(m_buffer);
+	ssize_t ret = iio_buffer_refill(m_buffer);
 
 
 	if (ret < 0) {


### PR DESCRIPTION
The buffer canceling leaves the buffer in an invalid state. It should be
used only to disrupt a blocked operation.  It should not be used if the
buffer is not currently performing a blocking operation.

However, this operation should not include buffer destroying. The
destroy is done by managing the buffer state after refill/push
operations.