### PR TITLE
Fix issues related to Python bindings .

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ build_script:
         -DSWIG_EXECUTABLE=C:/swig/swig.exe \
         -DSWIG_VERSION="4.0.0" \
         -DENABLE_TOOLS=ON \
+        -DPython_EXECUTABLE=C:\Python37\python.exe \
         ..
     - cmake --build . --config Release
     
@@ -76,6 +77,7 @@ build_script:
         -DSWIG_EXECUTABLE=C:/swig/swig.exe \
         -DSWIG_VERSION="4.0.0" \
         -DENABLE_TOOLS=ON \
+        -DPython_EXECUTABLE=C:\Python37-x64\python.exe \
         ..
     - cmake --build . --config Release
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -3,11 +3,9 @@ cmake_minimum_required(VERSION 2.8.7)
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.5")
 	# Check CMake Policy added in v3.13 regarding the SWIG generated target name
 	# https://cmake.org/cmake/help/v3.14/policy/CMP0078.html
-	cmake_policy(SET CMP0078 NEW)
-	set(SWIG_OUTPUT_NAME _libm2k)
-else()
-	set(SWIG_OUTPUT_NAME libm2k)
+	cmake_policy(SET CMP0078 OLD)
 endif()
+set(SWIG_OUTPUT_NAME libm2k)
 
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.14.7")
@@ -36,7 +34,7 @@ endif()
 FIND_PACKAGE(SWIG REQUIRED)
 include(UseSWIG)
 
-INCLUDE_DIRECTORIES(${Python_INCLUDE_PATH}
+INCLUDE_DIRECTORIES(${Python_INCLUDE_DIRS}
 	${CMAKE_SOURCE_DIR}/include
 	${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
Use the OLD cmake_policy for CMP0078. This policy is related to the SWIG generated library name. For older versions, the name of the module and the target would be modify inside the
swig_add_library function.
The new version would keep the exact same name for the generated target.
A constant fix for both versions would mean a change of name for the python
module (which is not accepted right now).

Until we find a better solution we will use the OLD behaviour for all the
CMake versions (since this was proven to work until now) and we'll work
on finding a better solution until the moment of deprecation.