### PR TITLE
Calibrate using predefined values

### DIFF
--- a/bindings/python/calibration/README.md
+++ b/bindings/python/calibration/README.md
@@ -1,0 +1,47 @@
+# ADALM2000 calibrated using predefined values
+
+## Generating your own calibration file
+A calibration file is a file used at boot time to write inside the
+context some predefined values for the calibration process. The values
+will be stored until they will be overwritten.
+
+This file must be called 'm2k-calib-temp-lut.ini' and it should contain
+only a row having the following format:
+
+cal,temp_lut=[\<temperature>,<adc_offset1>,<adc_offset2>,<adc_gain1> <adc_gain2>,
+<dac_offset1>,<dac_offset2>,<dac_gain1>,<dac_gain2> [...]]
+
+### Command
+    generate_temperature_calib_lut <uri> [-h] [-t max_temp] [-T min] [-v nb_values] [-f path] [-a]
+
+### Examples
+Create the ini file 'm2k-calib-temp-lut.ini'. The process can be stopped by
+pressing 'CTRL + C', otherwise the process will stop when the temperature
+of the board rises up to 75 °C or after 30 minutes
+
+    python3 generate_temperature_calib_lut.py ip:192.168.2.1
+
+Create the ini file 'm2k-calib-temp-lut.ini'. The process can be stopped by
+pressing 'CTRL + C' or when the temperature of the board rises up to 54 °C
+
+    python3 generate_temperature_calib_lut.py auto -t 54
+
+Create the ini file 'm2k-calib-temp-lut.ini'. Extract 5 values from all
+computed calibration parameters.
+
+    python3 generate_temperature_calib_lut.py auto -v 5 -t 54
+
+## Calibrating using ini file
+The purpose of this calibration type is to automate and to make the calibration
+process more efficient. Please make sure to have the following minimum requirements:
+* A valid calibration file. The file can be generated using the script mentioned above.
+* Firmware v0.26 on your board (https://github.com/analogdevicesinc/m2k-fw/releases/tag/v0.26).
+* libm2k v0.3.1
+
+After the board booted, copy the ini file inside the m2k drive. Then eject the drive and wait
+for ADALM2000 to boot. Once booted, the temperature calibration lookup table will be usable from libm2k.
+
+In order to perform a fast calibration call
+the fallowing context method: calibrateFromContext()
+
+For more information, please visit out wiki page: https://wiki.analog.com/university/tools/m2k/libm2k/calibration

--- a/bindings/python/calibration/generate_temperature_calib_lut.py
+++ b/bindings/python/calibration/generate_temperature_calib_lut.py
@@ -1,0 +1,221 @@
+import argparse
+import libm2k
+import signal
+import time
+import math
+import sys
+import os
+
+
+PREFIX = 'cal,temp_lut='
+
+example = '''\
+Examples:
+    |============================================================================|
+    |Create the ini file 'm2k-calib-temp-lut.ini'. The process can be stopped by |
+    |pressing 'CTRL + C', otherwise the process will stop when the temperature   |
+    |of the board rises up to 75 °C or after 30 minutes                          |
+    |                                                                            |
+    |    python3 generate_temperature_calib_lut.py ip:192.168.2.1                |
+    |                                                                            |
+    |============================================================================|
+    |Create the ini file 'm2k-calib-temp-lut.ini'. The process can be stopped by |
+    |pressing 'CTRL + C' or when the temperature of the board rises up to 54 °C  |
+    |                                                                            |
+    |    python3 generate_temperature_calib_lut.py auto -t 54                    |
+    |                                                                            |
+    |============================================================================|
+    |Create the ini file 'example.ini'. Extract 5 values from all computed       |
+    |calibration parameters. The maximum temperature will be 54 °C               |
+    |                                                                            |
+    | python3 generate_temperature_calib_lut.py auto -v 5 -t 54 -f "example.ini" |
+    |                                                                            |
+    |============================================================================|
+'''
+
+
+def create_file(calibration_values, file, append):
+    if os.path.isfile(file) is False:
+        f = open(file, 'w+')
+        f.close()
+
+    if append:
+        with open(file, mode='r') as file:
+            content = file.read()
+            content = content.replace(PREFIX, '')
+            if not content:
+                return
+            values = content.split(',')
+
+            while len(values) > 0:
+                key = float(values.pop(0))
+                parameters = []
+                for i in range(8):
+                    val = float(values.pop(0))
+                    if val.is_integer():
+                        parameters.append(int(val))
+                    else:
+                        parameters.append(val)
+                calibration_values[key] = parameters
+
+
+def write_in_file(calibration_values, nb_values, file_name):
+    keys = list(calibration_values.keys())
+    if 0 < nb_values < len(keys):
+        length = float(len(keys))
+        valid_keys = []
+        for i in range(nb_values):
+            valid_keys.append(keys[math.ceil(i * length / nb_values)])
+
+        newdict = {k: calibration_values[k] for k in valid_keys}
+        calibration_values = newdict
+
+    with open(file_name, mode='w') as file:
+        file.write(PREFIX)
+
+        content = ''
+        for key, values in sorted(calibration_values.items()):
+            content += ('{0},{1},'.format(key, ','.join(str(round(v, 6)) for v in values)))
+        content = content[:-1]
+        file.write(content)
+    print('The calibration values were written to the file: ' + file_name)
+    print('Copy the file into the device and eject it (do not unplug!) in order to apply the values. After ejecting, '
+          'the device will reboot. Once booted, the temperature calibration look-up table will be usable from libm2k')
+    print('IMPORTANT: if you are using the -f or --file option you should rename the file to '
+          '\'m2k-calib-temp-lut.ini\' before copying it to the device.')
+
+
+def get_key_values(context):
+    key = context.getDMM('ad9963').readChannel('temp0').value
+    parameters = [context.getAdcCalibrationOffset(0), context.getAdcCalibrationOffset(1),
+                  context.getAdcCalibrationGain(0), context.getAdcCalibrationGain(1),
+                  context.getDacCalibrationOffset(0), context.getDacCalibrationOffset(1),
+                  context.getDacCalibrationGain(0), context.getDacCalibrationGain(1)]
+
+    return key, parameters
+
+
+def get_new_temperatures(visited, new):
+    new_temperatures = []
+    for key in new.keys():
+        if key not in visited:
+            new_temperatures.append(key)
+    return new_temperatures
+
+
+def print_msg(time_left, new_temperatures, calibration_values):
+    displayed_temp = get_new_temperatures(new_temperatures, calibration_values)
+    if displayed_temp:
+        print('New calibration temperatures found: ' + ", ".join(str(x) for x in displayed_temp))
+        new_temperatures.extend(displayed_temp)
+    print('Time left: ' + str(time_left) + ' min')
+
+
+def generate_file(ctx, calibration_values, max_temperature, timeout, nb_values, file, append):
+    print("'CTRL + C' to stop the calibration data extraction process")
+    create_file(calibration_values, file, append)
+    start_time = time.time()
+    time_left = 1
+    i = 0
+    new_temperatures = []
+    print_msg(timeout, new_temperatures, calibration_values)
+    while True:
+        current_time = time.time()
+        if (current_time - start_time) // 60 >= timeout:
+            break
+
+        if (current_time - start_time) / 60 >= time_left:
+            print_msg(timeout - time_left, new_temperatures, calibration_values)
+            time_left += 1
+
+        ctx.calibrateADC()
+        ctx.calibrateDAC()
+
+        key, parameters = get_key_values(ctx)
+        if key >= max_temperature:
+            break
+
+        calibration_values[key] = parameters
+        i += 1
+    write_in_file(calibration_values, nb_values, file)
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='generate_temperature_calib_lut',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     description='Generate the temperature calibration lookup table',
+                                     epilog=example)
+
+    parser.add_argument('uri',
+                        action='store',
+                        metavar='uri',
+                        type=str,
+                        help='describe the context location ')
+
+    parser.add_argument('-t', '--temperature',
+                        action='store',
+                        metavar='max_temp',
+                        type=int,
+                        default=75,
+                        help='the maximum temperature (default: 75)')
+
+    parser.add_argument('-T', '--timeout',
+                        action='store',
+                        metavar='min',
+                        type=int,
+                        default=30,
+                        help='the number of minutes after timeout occur (default: 30)')
+
+    parser.add_argument('-v', '--values',
+                        action='store',
+                        metavar='nb_values',
+                        type=int,
+                        default=-1,
+                        help='the maximum number of values to be extracted (default: unlimited)')
+
+    parser.add_argument('-f', '--file',
+                        action='store',
+                        metavar='path',
+                        type=str,
+                        default="m2k-calib-temp-lut.ini",
+                        help='file path (default: m2k-calib-temp-lut.ini)')
+
+    parser.add_argument('-a', '--append',
+                        action='store_true',
+                        help='append the values to the file, otherwise override it')
+
+    parser.set_defaults(func=parse_arguments)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+def parse_arguments(args):
+    try:
+        if args.uri == 'auto':
+            ctx = libm2k.m2kOpen()
+        else:
+            ctx = libm2k.m2kOpen(args.uri)
+        if ctx is None:
+            raise Exception('Invalid uri')
+        print('Connection established')
+
+        def signal_handler(sig, frame):
+            nonlocal calibration_values
+            write_in_file(calibration_values, args.values, args.file)
+            libm2k.contextClose(ctx)
+            sys.exit(0)
+        signal.signal(signal.SIGINT, signal_handler)
+
+        calibration_values = dict()
+        generate_file(ctx, calibration_values, args.temperature, args.timeout, args.values, args.file, args.append)
+
+        libm2k.contextClose(ctx)
+        return 0
+    except Exception as error:
+        print(error)
+        return -1
+
+
+if __name__ == "__main__":
+    main()

--- a/include/libm2k/enums.hpp
+++ b/include/libm2k/enums.hpp
@@ -49,6 +49,23 @@ namespace libm2k {
 		NONE
 	};
 
+
+	/**
+	* @struct CALIBRATION_PARAMETERS
+	* @brief Calibration parameters of m2k
+	*/
+	struct CALIBRATION_PARAMETERS {
+		int adc_offset_ch_1; ///< ADC calibration offset - channel 1
+		int adc_offset_ch_2; ///< ADC calibration offset - channel 2
+		double adc_gain_ch_1; ///< ADC calibration gain - channel 1
+		double adc_gain_ch_2; ///< ADC calibration gain - channel 2
+		int dac_a_offset; ///< DAC calibration offset - channel 1
+		int dac_b_offset; ///< DAC calibration offset - channel 2
+		double dac_a_gain; ///< DAC calibration gain - channel 1
+		double dac_b_gain; ///< DAC calibration gain - channel 2
+	};
+
+
 	/**
 	 * @private
 	 */

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -24,8 +24,10 @@
 
 #include <libm2k/m2kglobal.hpp>
 #include <libm2k/context.hpp>
+#include <libm2k/enums.hpp>
 #include <iostream>
 #include <vector>
+#include <map>
 
 namespace libm2k {
 namespace analog {
@@ -104,6 +106,15 @@ public:
 	* @private
 	*/
 	virtual bool resetCalibration() = 0;
+
+
+	/**
+	 * @brief Calibrate both ADC and DACs using predefined calibration values located in context
+	 * @return The closest temperature found in the lookup table
+	 *
+	 * @note Only available from firmware v0.26.
+	 */
+	virtual double calibrateFromContext() = 0;
 
 
 	/**
@@ -264,6 +275,20 @@ public:
 	* The gain value is currently limited at the (-2,2) range  by the hardware.
 	*/
 	virtual void setAdcCalibrationGain(unsigned int chn, double gain) = 0;
+
+
+	/**
+	 * @brief Check if the calibration based on temperature can be performed
+	 * @return True if the calibration parameters are available, False otherwise
+	 */
+	virtual bool hasContextCalibration() = 0;
+
+
+	/**
+	 * @brief Retrieve the predefined calibration parameter
+	 * @return Map <temperature, parameters>
+	 */
+	virtual std::map<double, std::shared_ptr<struct CALIBRATION_PARAMETERS>> &getLUT() = 0;
 
 
 	/**

--- a/src/context_impl.hpp
+++ b/src/context_impl.hpp
@@ -94,13 +94,14 @@ public:
 protected:
 	struct iio_context* m_context;
 	std::vector<libm2k::analog::DMM*> m_instancesDMM;
+	std::map<std::string, std::string> m_context_attributes;
+
 	bool isIioDeviceBufferCapable(std::string dev_name);
 	std::vector<std::pair<std::string, std::string> > getIioDevByChannelAttrs(std::vector<std::string> attr_list);
 	libm2k::utils::DEVICE_TYPE getIioDeviceType(std::string dev_name);
 	libm2k::utils::DEVICE_DIRECTION getIioDeviceDirection(std::string dev_name);
 private:
 	void initializeContextAttributes();
-	std::map<std::string, std::string> m_context_attributes;
 
 	std::string m_uri;
 	std::string m_name;

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -49,6 +49,7 @@ public:
 	bool calibrateADC();
 	bool calibrateDAC();
 	bool resetCalibration();
+	double calibrateFromContext() override;
 
 	libm2k::digital::M2kDigital* getDigital();
 	libm2k::analog::M2kPowerSupply* getPowerSupply();
@@ -71,6 +72,8 @@ public:
 	void setAdcCalibrationOffset(unsigned int chn, int offset);
 	void setAdcCalibrationGain(unsigned int chn, double gain);
 
+	bool hasContextCalibration() override;
+	std::map<double, std::shared_ptr<struct CALIBRATION_PARAMETERS>> &getLUT() override;
 	bool isCalibrated() override;
 
 	void setLed(bool on);
@@ -89,6 +92,9 @@ private:
 	enum libm2k::M2K_TRIGGER_SOURCE_DIGITAL digitalSource;
 	bool hasAnalogTrigger();
 	bool hasDigitalTrigger();
+	std::map<double, shared_ptr<struct CALIBRATION_PARAMETERS>> m_calibration_lut;
+
+	double getCalibrationTemperature(double temperature);
 	void blinkLed(const double duration = 4, bool blocking = false);
 	void initialize();
 };


### PR DESCRIPTION
An ini file with predefined calibration values can be generated or manually written. All its content will be written inside a context attribute at boot time if the file is added inside m2k driver. Then a fast calibration can be performed by using calibrateFromContext() method.
The purpose of this calibration type is to automate and to make the calibration
process more efficient.
This enhancement is described in #89.