### PR TITLE
Mixed signal acquisition.

### DIFF
--- a/bindings/python/examples/mixed_signal_view.py
+++ b/bindings/python/examples/mixed_signal_view.py
@@ -1,0 +1,110 @@
+#
+# Copyright (c) 2020 Analog Devices Inc.
+#
+# This file is part of libm2k
+# (see http://www.github.com/analogdevicesinc/libm2k).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This example assumes the following connections:
+# DIO_0 -> 1+
+# GND -> 1-
+#
+# The application will generate a square on DIO_0. The signal is fed back into the analog input and digital input
+# and the voltage values are displayed on the screen
+
+
+import libm2k
+import numpy as np
+import matplotlib.pyplot as plt
+
+DIGITAL_CH = 0
+ANALOG_CH = 0
+
+SAMPLING_FREQUENCY = 10000000
+OVERSAMPLING = 1
+
+BUFFER_SIZE = 1600
+SAMPLES_PER_PERIOD = 16
+
+
+def generate_clock_signal(digital, sampling_frequency):
+    digital.setSampleRateOut(sampling_frequency)
+    duty = SAMPLES_PER_PERIOD / 2  # 50%
+    signal = np.arange(SAMPLES_PER_PERIOD) < duty
+    buffer = list(map(lambda s: int(s) << DIGITAL_CH, signal))
+    for i in range(8):
+        buffer.extend(buffer)
+    digital.push(buffer)
+
+
+def main():
+    context = libm2k.m2kOpen()
+    if context is None:
+        print("Connection Error: No ADALM2000 device available/connected to your PC.")
+        exit(1)
+
+    # check if mixed signal is available on your firmware version
+    if context.hasMixedSignal() is False:
+        print("Mixed Signal not available")
+        exit(1)
+
+    context.calibrateDAC()
+
+    analog_in = context.getAnalogIn()
+    digital = context.getDigital()
+    trigger = analog_in.getTrigger()
+
+    analog_in.enableChannel(libm2k.CHANNEL_1, True)
+    analog_in.enableChannel(libm2k.CHANNEL_2, True)
+
+    # configure the trigger
+    trigger.setAnalogDelay(-20)
+    trigger.setDigitalDelay(-20)
+    trigger.setAnalogLevel(ANALOG_CH, 2)
+    trigger.setDigitalCondition(DIGITAL_CH, libm2k.NONE)
+    trigger.setAnalogSource(ANALOG_CH)
+    trigger.setAnalogMode(ANALOG_CH, libm2k.ANALOG)
+    trigger.setAnalogCondition(ANALOG_CH, libm2k.RISING_EDGE_ANALOG)
+
+    # configure digital out interface
+    digital.setOutputMode(DIGITAL_CH, libm2k.DIO_PUSHPULL)
+    digital.setDirection(DIGITAL_CH, libm2k.DIO_OUTPUT)
+    digital.enableChannel(DIGITAL_CH, True)
+    digital.setCyclic(False)
+
+    # use the same samplerate for both analog and digital interface
+    analog_in.setSampleRate(SAMPLING_FREQUENCY)
+    analog_in.setOversamplingRatio(OVERSAMPLING)
+    digital.setSampleRateIn(SAMPLING_FREQUENCY // OVERSAMPLING)
+
+    # startMixedSignal -> extract the data -> stopMixedSignal
+    context.startMixedSignalAcquisition(BUFFER_SIZE)
+    generate_clock_signal(digital, SAMPLING_FREQUENCY // (10 * OVERSAMPLING))
+    digital_data, analog_data = [], []
+    digital_data.extend(digital.getSamples(BUFFER_SIZE))
+    analog_data.extend(analog_in.getSamples(BUFFER_SIZE))
+    context.stopMixedSignalAcquisition()
+
+    # get only the used digital channel
+    digital_data_one_ch = list(map(lambda s: ((0x0001 << DIGITAL_CH) & int(s)) >> DIGITAL_CH, digital_data))
+    plt.plot(digital_data_one_ch, label='Digital')
+    plt.plot(analog_data[ANALOG_CH], label='Analog')
+    plt.show()
+
+    libm2k.contextClose(context, True)
+
+if __name__ == '__main__':
+    main()

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -407,6 +407,22 @@ public:
 	 */
 	virtual void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples) = 0;
 
+
+	/**
+	 * @brief Force the digital interface to use the analogical rate
+	 *
+	 * @note Only available from firmware v0.26.
+	 */
+	virtual void setRateMux() = 0;
+
+
+	/**
+	 * @brief Reset the digital rate to default
+	 *
+	 * @note Only available from firmware v0.26.
+	 */
+	virtual void resetRateMux() = 0;
+
 };
 }
 }

--- a/include/libm2k/enums.hpp
+++ b/include/libm2k/enums.hpp
@@ -130,6 +130,7 @@ namespace libm2k {
 		CHANNEL_1_OR_SRC_LOGIC_ANALYZER = 6,
 		CHANNEL_2_OR_SRC_LOGIC_ANALYZER = 7,
 		CHANNEL_1_OR_CHANNEL_2_OR_SRC_LOGIC_ANALYZER = 8,
+		NO_SOURCE = 9, ///< NO_SOURCE - block the AnalogIn interface
 	};
 
 
@@ -140,7 +141,8 @@ namespace libm2k {
 	enum M2K_TRIGGER_SOURCE_DIGITAL {
 		SRC_TRIGGER_IN = 0, ///< SRC_TRIGGER_IN - trigger events on the TI(trigger in) pin trigger the DigitalIn interface
 		SRC_ANALOG_IN = 1, ///< SRC_ANALOG_IN - trigger events on the AnalogIn interface trigger the DigitalIn interface
-		SRC_NONE = 2 ///< SRC_NONE - trigger events on the DigitalIn are conditioned by the internal digital trigger structure
+		SRC_NONE = 2, ///< SRC_NONE - trigger events on the DigitalIn are conditioned by the internal digital trigger structure
+		SRC_DISABLED = 3, ///< SRC_DISABLED - block the DigitalIn interface
 	};
 
 

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -164,6 +164,15 @@ public:
 
 
 	/**
+	 * @brief Initiate the mixed acquisition
+	 * @param nb_samples The number of samples that will be retrieved
+	 *
+	 * @note Only available from firmware v0.26.
+	 */
+	virtual void startMixedSignalAcquisition(unsigned int nb_samples) = 0;
+
+
+	/**
 	* @brief Get the calibration offset of the DAC
 	*
 	* @param chn The index corresponding to a channel

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -143,7 +143,6 @@ public:
 	virtual libm2k::analog::M2kAnalogIn* getAnalogIn(std::string dev_name) = 0;
 
 
-
 	/**
 	* @brief Retrieve the AnalogOut object
 	*
@@ -157,6 +156,8 @@ public:
 	* @private
 	*/
 	virtual std::vector<libm2k::analog::M2kAnalogIn*> getAllAnalogIn() = 0;
+
+
 	/**
 	* @private
 	*/
@@ -170,6 +171,14 @@ public:
 	 * @note Only available from firmware v0.26.
 	 */
 	virtual void startMixedSignalAcquisition(unsigned int nb_samples) = 0;
+
+
+	/**
+	 * @brief Stop the mixed acquisition
+	 *
+	 * @note Only available from firmware v0.26.
+	 */
+	virtual void stopMixedSignalAcquisition() = 0;
 
 
 	/**

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -165,6 +165,13 @@ public:
 
 
 	/**
+	 * @brief Check if the mixed signal acquisition is available on the current firmware version
+	 * @return True if the mixed signal acquisition is available, false otherwise
+	 */
+	virtual bool hasMixedSignal() = 0;
+
+
+	/**
 	 * @brief Initiate the mixed acquisition
 	 * @param nb_samples The number of samples that will be retrieved
 	 *

--- a/src/digital/m2kdigital_impl.cpp
+++ b/src/digital/m2kdigital_impl.cpp
@@ -452,3 +452,18 @@ void M2kDigitalImpl::getSamples(std::vector<unsigned short> &data, unsigned int 
 	nb_samples = ((nb_samples + 3) / 4) * 4;
 	m_dev_read->getSamples(data, nb_samples);
 }
+
+bool M2kDigitalImpl::hasRateMux()
+{
+	return m_dev_read->hasGlobalAttribute("rate_mux");
+}
+
+void M2kDigitalImpl::setRateMux()
+{
+	m_dev_read->setStringValue("rate_mux", "oscilloscope");
+}
+
+void M2kDigitalImpl::resetRateMux()
+{
+	m_dev_read->setStringValue("rate_mux", "logic_analyzer");
+}

--- a/src/digital/m2kdigital_impl.hpp
+++ b/src/digital/m2kdigital_impl.hpp
@@ -98,6 +98,10 @@ public:
 	unsigned int getNbChannelsOut();
 
 	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples);
+
+	bool hasRateMux();
+	void setRateMux() override;
+	void resetRateMux() override;
 private:
 	bool m_cyclic;
 	std::shared_ptr<libm2k::utils::DeviceIn> m_dev_read;

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -353,6 +353,19 @@ void M2kImpl::startMixedSignalAcquisition(unsigned int nb_samples)
 	}
 }
 
+void M2kImpl::stopMixedSignalAcquisition()
+{
+	for (auto analogIn : m_instancesAnalogIn) {
+		analogIn->stopAcquisition();
+	}
+	for (auto digital : m_instancesDigital) {
+		digital->stopAcquisition();
+	}
+	m_instancesDigital.at(0)->resetRateMux();
+	m_trigger->setAnalogSource(analogSource);
+	m_trigger->setDigitalSource(digitalSource);
+}
+
 bool M2kImpl::hasAnalogTrigger()
 {
 	enum M2K_TRIGGER_SOURCE_ANALOG source;

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -23,6 +23,7 @@
 #include "analog/m2kanalogout_impl.hpp"
 #include "analog/m2kanalogin_impl.hpp"
 #include "analog/m2kpowersupply_impl.hpp"
+#include <digital/m2kdigital_impl.hpp>
 #include "m2khardwaretrigger_impl.hpp"
 #include "m2khardwaretrigger_v0.24_impl.hpp"
 #include "m2kcalibration_impl.hpp"
@@ -313,6 +314,12 @@ std::vector<M2kAnalogIn*> M2kImpl::getAllAnalogIn()
 std::vector<M2kAnalogOut*> M2kImpl::getAllAnalogOut()
 {
 	return m_instancesAnalogOut;
+}
+
+bool M2kImpl::hasMixedSignal()
+{
+	auto digital_impl = dynamic_cast<M2kDigitalImpl*>(getDigital());
+	return digital_impl->hasRateMux();
 }
 
 void M2kImpl::startMixedSignalAcquisition(unsigned int nb_samples)

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -80,6 +80,8 @@ private:
 	bool m_sync;
 	std::string m_firmware_version;
 
+	bool hasAnalogTrigger();
+	bool hasDigitalTrigger();
 	void blinkLed(const double duration = 4, bool blocking = false);
 	void initialize();
 };

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -59,6 +59,7 @@ public:
 	std::vector<libm2k::analog::M2kAnalogOut*> getAllAnalogOut();
 
 	void startMixedSignalAcquisition(unsigned int nb_samples) override;
+	void stopMixedSignalAcquisition() override;
 
 	int getDacCalibrationOffset(unsigned int chn);
 	double getDacCalibrationGain(unsigned int chn);

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -24,6 +24,7 @@
 
 #include <libm2k/m2k.hpp>
 #include "context_impl.hpp"
+#include <libm2k/enums.hpp>
 
 namespace libm2k {
 class M2kHardwareTrigger;
@@ -57,6 +58,8 @@ public:
 	std::vector<libm2k::analog::M2kAnalogIn*> getAllAnalogIn();
 	std::vector<libm2k::analog::M2kAnalogOut*> getAllAnalogOut();
 
+	void startMixedSignalAcquisition(unsigned int nb_samples) override;
+
 	int getDacCalibrationOffset(unsigned int chn);
 	double getDacCalibrationGain(unsigned int chn);
 	int getAdcCalibrationOffset(unsigned int chn);
@@ -79,7 +82,8 @@ private:
 	std::vector<digital::M2kDigital*> m_instancesDigital;
 	bool m_sync;
 	std::string m_firmware_version;
-
+	enum libm2k::M2K_TRIGGER_SOURCE_ANALOG analogSource;
+	enum libm2k::M2K_TRIGGER_SOURCE_DIGITAL digitalSource;
 	bool hasAnalogTrigger();
 	bool hasDigitalTrigger();
 	void blinkLed(const double duration = 4, bool blocking = false);

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -58,6 +58,7 @@ public:
 	std::vector<libm2k::analog::M2kAnalogIn*> getAllAnalogIn();
 	std::vector<libm2k::analog::M2kAnalogOut*> getAllAnalogOut();
 
+	bool hasMixedSignal() override;
 	void startMixedSignalAcquisition(unsigned int nb_samples) override;
 	void stopMixedSignalAcquisition() override;
 

--- a/src/m2khardwaretrigger_v0.24_impl.cpp
+++ b/src/m2khardwaretrigger_v0.24_impl.cpp
@@ -57,11 +57,13 @@ std::vector<std::string> M2kHardwareTriggerV024Impl::m_trigger_source = {
 	"a_OR_trigger_in",
 	"b_OR_trigger_in",
 	"a_OR_b_OR_trigger_in",
+	"disabled",
 };
 
 std::vector<std::string> M2kHardwareTriggerV024Impl::m_trigger_ext_digital_source = {
 	"trigger-logic",
-	"trigger-in"
+	"trigger-in",
+	"disabled"
 };
 
 typedef std::pair<Channel *, std::string> channel_pair;
@@ -145,16 +147,24 @@ bool M2kHardwareTriggerV024Impl::hasCrossInstrumentTrigger() const
 
 void M2kHardwareTriggerV024Impl::setDigitalSource(M2K_TRIGGER_SOURCE_DIGITAL external_src)
 {
+	std::string source;
 	if (!hasCrossInstrumentTrigger()) {
 		M2kHardwareTriggerImpl::setDigitalSource(external_src);
 	}
 
-	if (external_src == SRC_NONE) {
-		external_src = SRC_TRIGGER_IN;
+	switch(external_src) {
+	case SRC_NONE:
+	case SRC_TRIGGER_IN:
+		source = "trigger-logic";
+		break;
+	case SRC_ANALOG_IN:
+		source = "trigger-in";
+		break;
+	case SRC_DISABLED:
+		source = "disabled";
+		break;
 	}
-
-	m_digital_trigger_device->setStringValue(16, "trigger_mux_out",
-						 m_trigger_ext_digital_source.at(external_src));
+	m_digital_trigger_device->setStringValue(16, "trigger_mux_out", source);
 }
 
 void M2kHardwareTrigger::setDigitalSource(M2K_TRIGGER_SOURCE_DIGITAL external_src)
@@ -170,21 +180,15 @@ M2K_TRIGGER_SOURCE_DIGITAL M2kHardwareTriggerV024Impl::getDigitalSource() const
 	if (!hasCrossInstrumentTrigger()) {
 		M2kHardwareTriggerImpl::getDigitalSource();
 	}
-
-	std::string buf = m_digital_trigger_device->getStringValue(16, "trigger_mux_out");
-	auto it = std::find(m_trigger_ext_digital_source.begin(),
-			    m_trigger_ext_digital_source.end(), buf.c_str());
-	if  (it == m_trigger_ext_digital_source.end()) {
-		THROW_M2K_EXCEPTION("Unexpected value read from attribute: trigger", libm2k::EXC_OUT_OF_RANGE);
-	}
-
-	auto src = static_cast<M2K_TRIGGER_SOURCE_DIGITAL>(it - m_trigger_ext_digital_source.begin());
-	if (src == SRC_ANALOG_IN) {
-		return src;
-	}
-
-	if (getDigitalExternalCondition() != NO_TRIGGER_DIGITAL) {
-		return SRC_TRIGGER_IN;
+	std::string source = m_digital_trigger_device->getStringValue(16, "trigger_mux_out");
+	if (source == "trigger-logic") {
+		if (getDigitalExternalCondition() != NO_TRIGGER_DIGITAL) {
+			return SRC_TRIGGER_IN;
+		}
+	} else if (source == "trigger-in") {
+		return SRC_ANALOG_IN;
+	} else if (source == "disabled") {
+		return SRC_DISABLED;
 	}
 	return SRC_NONE;
 }


### PR DESCRIPTION
startMixedSignalAcquisition simplifies the process of acquiring mixed signals, that are synchronized one with the other. This process, for an end-user, will be reduced to:
- setting the same sampling frequency for both components
- calling startMixedSignalAcquisition method
- extracting the samples using getSamples() methods from both OSC and LA

This enhancement is described in #147.