### PR TITLE
ContextBuilder: Open the available context with m2kOpen().

### DIFF
--- a/src/contextbuilder.cpp
+++ b/src/contextbuilder.cpp
@@ -187,11 +187,25 @@ TODO: try to use the "local" context,
 before trying the "usb" one. */
 Context* ContextBuilder::contextOpen()
 {
-	auto lst = getAllContexts();
-	if (lst.size() <= 0) {
+	auto uries = getAllContexts();
+	if (uries.empty()) {
 		return nullptr;
 	}
-	return contextOpen(lst.at(0).c_str());
+#ifdef _WIN32
+	return contextOpen(uries.at(0).c_str());
+#else
+	struct iio_context *context;
+	fclose(stderr);
+	for (auto &uri : uries) {
+		context = iio_create_context_from_uri(uri.c_str());
+		if (context) {
+			stderr = fdopen(2 , "a");
+			return contextOpen(context, uri.c_str());
+		}
+	}
+	stderr = fdopen(2 , "a");
+	return nullptr;
+#endif
 }
 
 M2k *ContextBuilder::m2kOpen(struct iio_context* ctx, const char *uri)


### PR DESCRIPTION
In later versions of libm2k, calling m2kOpen()  on Linux distributions could result in an exception, even though an USB interface would be available. This problem was caused by trying to establish a connection to the first USB interface.
The verification is made by using iio_create_context, and checking if the context is null. Also stderr was suppressed inside this function.