### PR TITLE
Fix trigger level computation and add missing features.

### DIFF
--- a/include/libm2k/analog/genericanalogin.hpp
+++ b/include/libm2k/analog/genericanalogin.hpp
@@ -41,12 +41,16 @@ public:
 	virtual double setSampleRate(double sampleRate) = 0;
 	virtual double setSampleRate(unsigned int chn_idx, double sampleRate) = 0;
 	virtual std::vector<double> getAvailableSampleRates() = 0;
+	virtual std::vector<double> getAvailableSampleRates(unsigned int chn_idx) = 0;
+	virtual double getMaximumSamplerate() = 0;
+	virtual double getMaximumSamplerate(unsigned int chn_idx) = 0;
 
 	virtual void enableChannel(unsigned int index, bool enable) = 0;
 	virtual void setKernelBuffersCount(unsigned int count) = 0;
 	virtual std::string getDeviceName() = 0;
 
 	virtual struct IIO_OBJECTS getIioObjects() = 0;
+	virtual unsigned int getNbChannels() = 0;
 };
 }
 }

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -455,6 +455,12 @@ public:
 	 */
 	virtual std::string getChannelName(unsigned int channel) = 0;
 
+	/**
+	 * @brief Get the maximum samplerate for the ADC
+	 * @return double - the value of the maximum samplerate
+	 */
+	virtual double getMaximumSamplerate() = 0;
+
 };
 }
 }

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -416,6 +416,13 @@ public:
 	 * @return std::string - name of the channel
 	 */
 	virtual std::string getChannelName(unsigned int channel) = 0;
+
+	/**
+	 * @brief Get the maximum samplerate for the DAC
+	 * @param chn_idx - unsigned int representing the index of the channel
+	 * @return double - the value of the maximum samplerate
+	 */
+	virtual double getMaximumSamplerate(unsigned int chn_idx) = 0;
 };
 }
 }

--- a/src/analog/generic/genericanalogin_impl.cpp
+++ b/src/analog/generic/genericanalogin_impl.cpp
@@ -96,6 +96,18 @@ std::vector<double> GenericAnalogInImpl::getAvailableSampleRates()
 	return values;
 }
 
+std::vector<double> GenericAnalogInImpl::getAvailableSampleRates(unsigned int chn_idx)
+{
+	std::vector<std::string> stringValues;
+	std::vector<double> values;
+
+	stringValues = getAdcDevice(0)->getAvailableAttributeValues(chn_idx, "sampling_frequency");
+	std::transform(stringValues.begin(), stringValues.end(), std::back_inserter(values),
+		       [] (std::string &s) -> double { return std::stod(s); });
+	return values;
+}
+
+
 string GenericAnalogInImpl::getDeviceName()
 {
 	return m_dev_name;
@@ -104,6 +116,23 @@ string GenericAnalogInImpl::getDeviceName()
 libm2k::IIO_OBJECTS GenericAnalogInImpl::getIioObjects()
 {
 	return getAdcDevice(0)->getIioObjects();
+}
+
+unsigned int GenericAnalogInImpl::getNbChannels()
+{
+	return getAdcDevice(0)->getNbChannels(false);
+}
+
+double GenericAnalogInImpl::getMaximumSamplerate()
+{
+	auto values = getAvailableSampleRates();
+	return *(max_element(values.begin(), values.end()));
+}
+
+double GenericAnalogInImpl::getMaximumSamplerate(unsigned int chn_idx)
+{
+	auto values = getAvailableSampleRates(chn_idx);
+	return *(max_element(values.begin(), values.end()));
 }
 
 void GenericAnalogInImpl::enableChannel(unsigned int index, bool enable)

--- a/src/analog/generic/genericanalogin_impl.hpp
+++ b/src/analog/generic/genericanalogin_impl.hpp
@@ -43,12 +43,16 @@ public:
 	double setSampleRate(double sampleRate);
 	double setSampleRate(unsigned int chn_idx, double sampleRate);
 	std::vector<double> getAvailableSampleRates();
+	std::vector<double> getAvailableSampleRates(unsigned int chn_idx);
 
 	void enableChannel(unsigned int index, bool enable);
 	void setKernelBuffersCount(unsigned int count);
 	std::string getDeviceName();
 
 	struct IIO_OBJECTS getIioObjects();
+	unsigned int getNbChannels();
+	double getMaximumSamplerate();
+	double getMaximumSamplerate(unsigned int chn_idx);
 private:
 	std::vector<std::shared_ptr<libm2k::utils::DeviceIn>> m_devices_in;
 	std::string m_dev_name;

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -37,6 +37,7 @@ using namespace std::placeholders;
 M2kAnalogInImpl::M2kAnalogInImpl(iio_context * ctx, std::string adc_dev, bool sync, M2kHardwareTrigger *trigger) :
 	M2kAnalogIn(),
 	m_need_processing(false),
+	m_max_samplerate(-1),
 	m_trigger(trigger)
 {
 	m_m2k_adc = make_shared<DeviceIn>(ctx, adc_dev);
@@ -288,6 +289,15 @@ string M2kAnalogInImpl::getChannelName(unsigned int channel)
 		name = chn->getId();
 	}
 	return name;
+}
+
+double M2kAnalogInImpl::getMaximumSamplerate()
+{
+	if (m_max_samplerate < 0) {
+		auto values = getAvailableSampleRates();
+		m_max_samplerate = *(max_element(values.begin(), values.end()));
+	}
+	return m_max_samplerate;
 }
 
 const double* M2kAnalogInImpl::getSamplesInterleaved(unsigned int nb_samples)

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -123,11 +123,13 @@ public:
 	void getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples);
 
 	std::string getChannelName(unsigned int channel);
+	double getMaximumSamplerate() override;
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
 	std::shared_ptr<libm2k::utils::DeviceIn> m_m2k_adc;
 	bool m_need_processing;
+	double m_max_samplerate;
 
 	double m_samplerate;
 	libm2k::M2kHardwareTrigger *m_trigger;

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -60,6 +60,7 @@ M2kAnalogOutImpl::M2kAnalogOutImpl(iio_context *ctx, std::vector<std::string> da
 		m_cyclic.push_back(true);
 		m_samplerate.push_back(75E6);
 		m_nb_kernel_buffers.push_back(4);
+		m_max_samplerate.push_back(-1);
 	}
 
 	if (sync) {
@@ -621,4 +622,16 @@ string M2kAnalogOutImpl::getChannelName(unsigned int channel)
 		name = chn->getId();
 	}
 	return name;
+}
+
+double M2kAnalogOutImpl::getMaximumSamplerate(unsigned int chn_idx)
+{
+	if (chn_idx >= m_dac_devices.size()) {
+		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+	}
+	if (m_max_samplerate[chn_idx] < 0) {
+		auto values = getAvailableSampleRates(chn_idx);
+		m_max_samplerate[chn_idx] = *(max_element(values.begin(), values.end()));
+	}
+	return m_max_samplerate[chn_idx];
 }

--- a/src/analog/m2kanalogout_impl.hpp
+++ b/src/analog/m2kanalogout_impl.hpp
@@ -86,8 +86,10 @@ public:
 
 	unsigned int getNbChannels();
 	std::string getChannelName(unsigned int channel);
+	double getMaximumSamplerate(unsigned int chn_idx) override;
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
+	std::vector<double> m_max_samplerate;
 	std::vector<double> m_calib_vlsb;
 	std::vector<bool> m_cyclic;
 	std::vector<double> m_samplerate;

--- a/src/m2khardwaretrigger_impl.cpp
+++ b/src/m2khardwaretrigger_impl.cpp
@@ -337,7 +337,7 @@ double M2kHardwareTriggerImpl::getAnalogLevel(unsigned int chnIdx)
 	}
 
 	int raw = getAnalogLevelRaw(chnIdx);
-	double volts = raw * m_scaling.at(chnIdx) + m_offset.at(chnIdx);
+	double volts = raw * m_scaling.at(chnIdx) - m_offset.at(chnIdx);
 	return volts;
 }
 
@@ -347,7 +347,7 @@ void M2kHardwareTriggerImpl::setAnalogLevel(unsigned int chnIdx, double v_level)
 		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
 	}
 
-	int raw = (v_level - m_offset.at(chnIdx)) / m_scaling.at(chnIdx);
+	int raw = (v_level + m_offset.at(chnIdx)) / m_scaling.at(chnIdx);
 	setAnalogLevelRaw(chnIdx, raw);
 }
 


### PR DESCRIPTION
-These new features were necessary for integrating libm2k into Scopy.
-The trigger level fix refers to a computation error done when converting volts to raw samples.