### PR TITLE
M2k destruction: Fix some issues related to context destruction and deinit. 

### DIFF
--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -124,6 +124,8 @@ public:
 
 	std::string getChannelName(unsigned int channel);
 	double getMaximumSamplerate() override;
+
+	void deinitialize();
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -75,11 +75,15 @@ M2kAnalogOutImpl::M2kAnalogOutImpl(iio_context *ctx, std::vector<std::string> da
 
 M2kAnalogOutImpl::~M2kAnalogOutImpl()
 {
-	stop();
 	for (auto d : m_dac_devices) {
 		delete d;
 	}
 	m_dac_devices.clear();
+}
+
+void M2kAnalogOutImpl::deinitialize()
+{
+	stop();
 }
 
 void M2kAnalogOutImpl::reset()

--- a/src/analog/m2kanalogout_impl.hpp
+++ b/src/analog/m2kanalogout_impl.hpp
@@ -87,6 +87,7 @@ public:
 	unsigned int getNbChannels();
 	std::string getChannelName(unsigned int channel);
 	double getMaximumSamplerate(unsigned int chn_idx) override;
+	void deinitialize();
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
 	std::vector<double> m_max_samplerate;

--- a/src/contextbuilder.cpp
+++ b/src/contextbuilder.cpp
@@ -238,13 +238,17 @@ M2k *ContextBuilder::m2kOpen()
 
 void ContextBuilder::contextClose(Context* device, bool deinit)
 {
-	if (deinit) {
-		device->deinitialize();
-	}
-
 	s_connectedDevices.erase(std::remove(s_connectedDevices.begin(),
 					     s_connectedDevices.end(),
 					     device), s_connectedDevices.end());
+	try {
+		if (deinit) {
+			device->deinitialize();
+		}
+	} catch (std::exception &e ){
+		delete device;
+		throw_exception(EXC_RUNTIME_ERROR, "Context deinit: " + std::string(e.what()));
+	}
 	delete device;
 }
 

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -45,8 +45,7 @@ using namespace libm2k::utils;
 
 M2kImpl::M2kImpl(std::string uri, iio_context* ctx, std::string name, bool sync) :
 	ContextImpl(uri, ctx, name, sync),
-	m_sync(sync),
-	m_deinit(false)
+	m_sync(sync)
 {
 	initialize();
 	setTimeout(UINT_MAX);
@@ -86,20 +85,6 @@ M2kImpl::M2kImpl(std::string uri, iio_context* ctx, std::string name, bool sync)
 
 M2kImpl::~M2kImpl()
 {
-	if (m_deinit) {
-		std::shared_ptr<DeviceGeneric> m_m2k_fabric = make_shared<DeviceGeneric>(m_context, "m2k-fabric");
-		if (m_m2k_fabric) {
-			m_m2k_fabric->setBoolValue(0, true, "powerdown", false);
-			m_m2k_fabric->setBoolValue(1, true, "powerdown", false);
-
-			/* ADF4360 global clock power down */
-			m_m2k_fabric->setBoolValue(true, "clk_powerdown");
-			for (auto ps : m_instancesPowerSupply) {
-				ps->powerDownDacs(true);
-			}
-		}
-	}
-
 	// The vertical offset register in the device has dual purpose:
 	// 1. use as ADC offset for calibration
 	// 2. use as ADC vertical offset for measurement
@@ -141,7 +126,17 @@ M2kImpl::~M2kImpl()
 
 void M2kImpl::deinitialize()
 {
-	m_deinit = true;
+	std::shared_ptr<DeviceGeneric> m_m2k_fabric = make_shared<DeviceGeneric>(m_context, "m2k-fabric");
+	if (m_m2k_fabric) {
+		m_m2k_fabric->setBoolValue(0, true, "powerdown", false);
+		m_m2k_fabric->setBoolValue(1, true, "powerdown", false);
+
+		/* ADF4360 global clock power down */
+		m_m2k_fabric->setBoolValue(true, "clk_powerdown");
+		for (auto ps : m_instancesPowerSupply) {
+			ps->powerDownDacs(true);
+		}
+	}
 }
 
 void M2kImpl::reset()

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -126,6 +126,10 @@ void M2kImpl::deinitialize()
 	if (ain_impl) {
 		ain_impl->deinitialize();
 	}
+	auto aout_impl = dynamic_cast<M2kAnalogOutImpl*>(getAnalogOut());
+	if (aout_impl) {
+		aout_impl->deinitialize();
+	}
 }
 
 void M2kImpl::reset()

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -85,22 +85,6 @@ M2kImpl::M2kImpl(std::string uri, iio_context* ctx, std::string name, bool sync)
 
 M2kImpl::~M2kImpl()
 {
-	// The vertical offset register in the device has dual purpose:
-	// 1. use as ADC offset for calibration
-	// 2. use as ADC vertical offset for measurement
-	// This can cause some confusion when initializing the board
-	// because it is not clear whether the value in the register is
-	// the calibration value or the calibration+vertical offset value
-	// This workaround will always set the vertical offset to 0 on deinitialization
-	// and upon initialization the offset will be loaded from the register
-	// (when no calibration is done)
-	//
-	// The correct fix would be adding a separate caliboffset register in the firmware
-	// which will clear up the confusion
-
-	getAnalogIn()->setVerticalOffset(ANALOG_IN_CHANNEL_1,0);
-	getAnalogIn()->setVerticalOffset(ANALOG_IN_CHANNEL_2,0);
-
 	delete m_calibration;
 
 	if (m_trigger) {
@@ -136,6 +120,11 @@ void M2kImpl::deinitialize()
 		for (auto ps : m_instancesPowerSupply) {
 			ps->powerDownDacs(true);
 		}
+	}
+
+	auto ain_impl = dynamic_cast<M2kAnalogInImpl*>(getAnalogIn());
+	if (ain_impl) {
+		ain_impl->deinitialize();
 	}
 }
 

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -78,7 +78,6 @@ private:
 	std::vector<analog::M2kPowerSupply*> m_instancesPowerSupply;
 	std::vector<digital::M2kDigital*> m_instancesDigital;
 	bool m_sync;
-	bool m_deinit;
 	std::string m_firmware_version;
 
 	void blinkLed(const double duration = 4, bool blocking = false);


### PR DESCRIPTION
Unplugging the board from the PC might lead to undefined behaviour using the current libm2k.
These fixes will move some deinitialization steps outside the destructor and will handle the device destruction properly.
Also, the vertical offset should only be set to 0 if the firmware version is older and does not contain the "calibbias" attribute.