### PR TITLE
M2kCalibration: Don't try to load the old vertical offset for firmware which does not contain the calibbias attribute.

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -323,6 +323,11 @@ void M2kAnalogInImpl::deinitialize()
 	}
 }
 
+bool M2kAnalogInImpl::hasCalibbias()
+{
+	return m_calibbias_available;
+}
+
 const double* M2kAnalogInImpl::getSamplesInterleaved(unsigned int nb_samples)
 {
 	return this->getSamplesInterleaved(nb_samples, true);

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -126,6 +126,7 @@ public:
 	double getMaximumSamplerate() override;
 
 	void deinitialize();
+	bool hasCalibbias();
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -214,8 +214,13 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 	setCalibrationMode(ADC_GND);
 
 	// Set DAC channels to middle scale
-	m_adc_ch0_vert_offset = m_m2k_adc->getRawVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(0));
-	m_adc_ch1_vert_offset = m_m2k_adc->getRawVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(1));
+	if (m_m2k_adc->hasCalibbias()) {
+		m_adc_ch0_vert_offset = m_m2k_adc->getRawVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(0));
+		m_adc_ch1_vert_offset = m_m2k_adc->getRawVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(1));
+	} else {
+		m_adc_ch0_vert_offset = 0;
+		m_adc_ch1_vert_offset = 0;
+	}
 
 	m_m2k_adc->setAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(0), 2048);
 	m_m2k_adc->setVerticalOffset(static_cast<ANALOG_IN_CHANNEL>(0), 0);


### PR DESCRIPTION


Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>