### PR TITLE
Buffer: Handle timeout exception.

### DIFF
--- a/include/libm2k/m2kexceptions.hpp
+++ b/include/libm2k/m2kexceptions.hpp
@@ -94,6 +94,9 @@ static void throw_exception(libm2k::M2K_EXCEPTION exc_type, std::string exceptio
 	case libm2k::EXC_INVALID_PARAMETER: {
 		throw std::invalid_argument("ERR: Invalid argument - " + exception);
 	}
+	case libm2k::EXC_TIMEOUT: {
+		throw std::invalid_argument("ERR: Timeout - " + exception);
+	}
 	default: {
 		throw std::runtime_error("ERR: Generic - " + exception);
 	}

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -113,6 +113,10 @@ void Buffer::push(unsigned short *data, unsigned int channel, unsigned int nb_sa
 		ssize_t ret = iio_buffer_push(m_buffer);
 		if (ret < 0) {
 			destroy();
+			// timeout error code
+			if (ret == -ETIMEDOUT) {
+				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+			}
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
 		}
 	} else {
@@ -159,6 +163,10 @@ void Buffer::push(std::vector<short> const &data, unsigned int channel,
 		ssize_t ret = iio_buffer_push(m_buffer);
 		if (ret < 0) {
 			destroy();
+			// timeout error code
+			if (ret == -ETIMEDOUT) {
+				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+			}
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
 		}
 	} else {
@@ -204,6 +212,10 @@ void Buffer::push(std::vector<unsigned short> const &data, unsigned int channel,
 		ssize_t ret = iio_buffer_push(m_buffer);
 		if (ret < 0) {
 			destroy();
+			// timeout error code
+			if (ret == -ETIMEDOUT) {
+				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+			}
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
 		}
 	} else {
@@ -237,6 +249,10 @@ void Buffer::push(std::vector<double> const &data, unsigned int channel, bool cy
 		ssize_t ret = iio_buffer_push(m_buffer);
 		if (ret < 0) {
 			destroy();
+			// timeout error code
+			if (ret == -ETIMEDOUT) {
+				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+			}
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
 		}
 	} else {
@@ -282,6 +298,10 @@ void Buffer::push(double *data, unsigned int channel, unsigned int nb_samples, b
 		ssize_t ret = iio_buffer_push(m_buffer);
 		if (ret < 0) {
 			destroy();
+			// timeout error code
+			if (ret == -ETIMEDOUT) {
+				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+			}
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
 		}
 	} else {
@@ -313,6 +333,10 @@ void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bo
 		ssize_t ret = iio_buffer_push(m_buffer);
 		if (ret < 0) {
 			destroy();
+			// timeout error code
+			if (ret == -ETIMEDOUT) {
+				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+			}
 			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
 		}
 	} else {
@@ -339,6 +363,10 @@ void Buffer::getSamples(std::vector<unsigned short> &data, unsigned int nb_sampl
 
 	if (ret < 0) {
 		destroy();
+		// timeout error code
+		if (ret == -ETIMEDOUT) {
+			throw_exception(EXC_TIMEOUT, "Buffer: Refill timeout occurred");
+		}
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 	}
 
@@ -374,6 +402,10 @@ const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 
 	if (ret < 0) {
 		destroy();
+		// timeout error code
+		if (ret == -ETIMEDOUT) {
+			throw_exception(EXC_TIMEOUT, "Buffer: Refill timeout occurred");
+		}
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 		return nullptr;
 	}
@@ -451,6 +483,10 @@ void* Buffer::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 	ssize_t ret = iio_buffer_refill(m_buffer);
 	if (ret < 0) {
 		destroy();
+		// timeout error code
+		if (ret == -ETIMEDOUT) {
+			throw_exception(EXC_TIMEOUT, "Buffer: Refill timeout occurred");
+		}
 		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
 		return nullptr;
 	}

--- a/src/utils/buffer.hpp
+++ b/src/utils/buffer.hpp
@@ -39,7 +39,7 @@ public:
 	Buffer(struct iio_device *dev);
 	~Buffer();
 
-	void initializeBuffer(unsigned int size, bool cyclic);
+	void initializeBuffer(unsigned int size, bool cyclic, bool output);
 	void push(std::vector<short> const &data, unsigned int channel = 0,
 		bool cyclic = true, bool multiplex = false);
 	void push(std::vector<unsigned short> const &data, unsigned int channel = 0,

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -42,7 +42,7 @@ DeviceIn::DeviceIn(struct iio_context* context, std::string dev_name) :
 
 void DeviceIn::initializeBuffer(unsigned int nb_samples)
 {
-	m_buffer->initializeBuffer(nb_samples, false);
+	m_buffer->initializeBuffer(nb_samples, false, false);
 }
 
 void DeviceIn::cancelBuffer()

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -51,7 +51,7 @@ void DeviceOut::initializeBuffer(unsigned int size, bool cyclic)
 	if (!m_buffer) {
 		throw_exception(EXC_RUNTIME_ERROR, "Device: Cannot push; device not buffer capable");
 	}
-	m_buffer->initializeBuffer(size, cyclic);
+	m_buffer->initializeBuffer(size, cyclic, true);
 }
 
 void DeviceOut::push(std::vector<short> const &data, unsigned int channel,


### PR DESCRIPTION
When a timeout occur in the refill/push process, a specific error is thrown for a more appropriate handling of the given situation.