### PR TITLE
M2kAnalogIn: Return samples only from the enabled channels.

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -96,6 +96,10 @@ public:
 	*
 	* @param nb_samples The number of samples that will be retrieved
 	* @return A pointer to the interleaved samples
+	*
+	* @note Before the acquisition, both channels will be automatically enabled
+	* @note The data array will contain samples from both channels
+	* @note After the acquisition is finished, the channels will return to their initial state
 	*/
 	virtual const double* getSamplesInterleaved(unsigned int nb_samples) = 0;
 
@@ -105,6 +109,10 @@ public:
 	*
 	* @param nb_samples The number of samples that will be retrieved
 	* @return A pointer to the interleaved raw samples
+	*
+	* @note Before the acquisition, both channels will be automatically enabled
+	* @note The data array will contain samples from both channels
+	* @note After the acquisition is finished, the channels will return to their initial state
 	*/
 	virtual const short* getSamplesRawInterleaved(unsigned int nb_samples) = 0;
 

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -242,6 +242,15 @@ void M2kAnalogInImpl::handleChannelsEnableState(bool before_refill)
 
 }
 
+void M2kAnalogInImpl::removeSamplesDisabledChannels(std::vector<std::vector<double>> &samples)
+{
+	for (unsigned int i = 0; i < getNbChannels(); i++) {
+		if (!m_channels_enabled.at(i)) {
+			samples.at(i) = std::vector<double>();
+		}
+	}
+}
+
 std::vector<std::vector<double>> M2kAnalogInImpl::getSamples(unsigned int nb_samples)
 {
 	return this->getSamples(nb_samples, true);
@@ -263,6 +272,7 @@ std::vector<std::vector<double>> M2kAnalogInImpl::getSamples(unsigned int nb_sam
 	auto fp = std::bind(&M2kAnalogInImpl::processSample, this, std::placeholders::_1, std::placeholders::_2);
 	auto samps = m_m2k_adc->getSamples(nb_samples, fp);
 
+	removeSamplesDisabledChannels(samps);
 	handleChannelsEnableState(false);
 	if (processed) {
 		m_need_processing = false;
@@ -279,6 +289,7 @@ void M2kAnalogInImpl::getSamples(std::vector<std::vector<double> > &data, unsign
 	auto fp = std::bind(&M2kAnalogInImpl::processSample, this, _1, _2);
 	m_m2k_adc->getSamples(data, nb_samples, fp);
 
+	removeSamplesDisabledChannels(data);
 	handleChannelsEnableState(false);
 	m_need_processing = false;
 }

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -157,6 +157,7 @@ private:
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples, bool processed);
 
 	void handleChannelsEnableState(bool before_refill);
+	void removeSamplesDisabledChannels(std::vector<std::vector<double>> &samples);
 
 	const double *getSamplesInterleaved(unsigned int nb_samples, bool processed = false);
 


### PR DESCRIPTION
The state of the channels should dictate whether a channel will acquire samples. Because m2k always needs both channels enabled in order to retrieve correct samples the following behaviour will be applied for getting samples:
- interleaved acquisition methods will always return the samples from both channels regardless of the original state of the channels
- acquisition methods that returns the samples as separate arrays will take in consideration the state of the channels