### PR TITLE
M2kException:  Refactor exception throwing mechanism.

### DIFF
--- a/examples/connect.cpp
+++ b/examples/connect.cpp
@@ -43,7 +43,7 @@ using namespace libm2k::analog;
 using namespace libm2k::digital;
 
 void test() {
-	throw_exception(EXC_RUNTIME_ERROR, "no device found");
+	throw_exception(m2k_exception::make("no device found").type(libm2k::EXC_RUNTIME_ERROR).build());
 }
 
 
@@ -336,8 +336,11 @@ int main(int argc, char **argv)
 //	delete m2kd;
 //	__try {
 //		test();
-//	} __catch(no_device_exception& e) {
-//		std::cout << e.what() << std::endl;
+//	} __catch(m2k_exception& e) {
+//		std::cout << "Message: " << e.what() << std::endl;
+//		std::cout << "IIO Code: " << e.iioCode() << std::endl;
+//		std::cout << "Type: " << e.type() << std::endl;
+//
 //	}
 
 

--- a/include/libm2k/enums.hpp
+++ b/include/libm2k/enums.hpp
@@ -58,13 +58,16 @@ namespace libm2k {
 	};
 
 	/**
-	 * @private
-	 */
-	enum M2K_EXCEPTION {
-		EXC_OUT_OF_RANGE,
-		EXC_RUNTIME_ERROR,
-		EXC_INVALID_PARAMETER,
-		EXC_TIMEOUT
+	* @enum M2K_EXCEPTION_TYPE
+	* @brief M2k exception types
+	*
+	*/
+	enum M2K_EXCEPTION_TYPE {
+		EXC_OUT_OF_RANGE = 0,
+		EXC_RUNTIME_ERROR = 1,
+		EXC_INVALID_PARAMETER = 2,
+		EXC_TIMEOUT = 3,
+		EXC_INVALID_FIRMWARE_VERSION = 4
 	};
 
 

--- a/src/analog/dmm_impl.cpp
+++ b/src/analog/dmm_impl.cpp
@@ -60,7 +60,7 @@ void DMMImpl::reset()
 DeviceIn* DMMImpl::getDevice(unsigned int index)
 {
 	if (index >= m_device_in_list.size()) {
-		throw_exception(EXC_INVALID_PARAMETER, "No such DMM device.");
+		throw_exception(m2k_exception::make("No such DMM device.").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	return m_device_in_list.at(index);
 }
@@ -102,8 +102,8 @@ DMM_READING DMMImpl::readChannel(std::string chn_name)
 	} else if (channel->hasAttribute("input")) {
 		value = channel->getDoubleValue("input");
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "DMM: Cannot read channel " +
-				getName() + " : " + chn_name);
+		throw_exception(m2k_exception::make("DMM: Cannot read channel " +
+						    getName() + " : " + chn_name).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (channel->hasAttribute("offset")) {

--- a/src/analog/generic/genericanalogin_impl.cpp
+++ b/src/analog/generic/genericanalogin_impl.cpp
@@ -44,7 +44,7 @@ GenericAnalogInImpl::~GenericAnalogInImpl()
 std::shared_ptr<DeviceIn> GenericAnalogInImpl::getAdcDevice(unsigned int index)
 {
 	if (index >= m_devices_in.size()) {
-		throw_exception(EXC_INVALID_PARAMETER, "Generic Analog In: No such ADC device");
+		throw_exception(m2k_exception::make("Generic Analog In: No such ADC device").type(libm2k::EXC_OUT_OF_RANGE).build());
 		return nullptr;
 	}
 	return m_devices_in.at(index);

--- a/src/analog/generic/genericanalogout_impl.cpp
+++ b/src/analog/generic/genericanalogout_impl.cpp
@@ -46,7 +46,7 @@ GenericAnalogOutImpl::~GenericAnalogOutImpl()
 std::shared_ptr<libm2k::utils::DeviceOut> GenericAnalogOutImpl::getDacDevice(unsigned int index)
 {
 	if (index >= m_devices_out.size()) {
-		throw_exception(EXC_INVALID_PARAMETER, "No such DAC device");
+		throw_exception(m2k_exception::make("No such DAC device").type(libm2k::EXC_OUT_OF_RANGE).build());
 		return nullptr;
 	}
 	return m_devices_out.at(index);
@@ -95,7 +95,7 @@ void GenericAnalogOutImpl::setCyclic(bool en)
 void GenericAnalogOutImpl::setCyclic(unsigned int chn, bool en)
 {
 	if (chn >= m_devices_out.size()) {
-		throw_exception(EXC_INVALID_PARAMETER, "Generic Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Generic Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_cyclic.at(chn) = en;
 }
@@ -103,7 +103,7 @@ void GenericAnalogOutImpl::setCyclic(unsigned int chn, bool en)
 bool GenericAnalogOutImpl::getCyclic(unsigned int chn)
 {
 	if (chn >=  m_devices_out.size()) {
-		throw_exception(EXC_INVALID_PARAMETER, "Generic Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Generic Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	return m_cyclic.at(chn);
 }

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -227,7 +227,7 @@ void M2kAnalogInImpl::handleChannelsEnableState(bool before_refill)
 			anyChannelEnabled = en ? true : anyChannelEnabled;
 		}
 		if (!anyChannelEnabled) {
-			throw_exception(EXC_INVALID_PARAMETER, "M2kAnalogIn: No channel enabled for RX buffer");
+			throw_exception(m2k_exception::make("M2kAnalogIn: No channel enabled for RX buffer").type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 
 		for (unsigned int i = 0; i < getNbChannels(); i++) {
@@ -397,7 +397,7 @@ short M2kAnalogInImpl::getVoltageRaw(ANALOG_IN_CHANNEL ch)
 	bool enabled;
 
 	if (ch >= getNbChannels()) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2kAnalogIn: no such channel");
+		throw_exception(m2k_exception::make("M2kAnalogIn: no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 		return -1;
 	}
 
@@ -457,7 +457,7 @@ double M2kAnalogInImpl::getVoltage(ANALOG_IN_CHANNEL ch)
 	bool enabled;
 
 	if (ch >= getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kAnalogIn: no such channel");
+		throw_exception(m2k_exception::make("M2kAnalogIn: no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 		return -1;
 	}
 	mode = m_trigger->getAnalogMode(ch);
@@ -655,7 +655,7 @@ double M2kAnalogInImpl::getFilterCompensation(double samplerate)
 	if(m_filter_compensation_table.find(samplerate) != m_filter_compensation_table.end()) {
 		compensation = m_filter_compensation_table.at(samplerate);
 	} else {
-		throw invalid_parameter_exception("Cannot get compensation value for the given samplerate.");
+		throw_exception(m2k_exception::make("Cannot get compensation value for the given samplerate.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return compensation;
 }

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -43,7 +43,7 @@ M2kAnalogOutImpl::M2kAnalogOutImpl(iio_context *ctx, std::vector<std::string> da
 
 	m_m2k_fabric = make_shared<DeviceGeneric>(ctx, "m2k-fabric");
 	if (!m_m2k_fabric) {
-		throw_exception(EXC_INVALID_PARAMETER, "Analog out: Cannot find m2k fabric device");
+		throw_exception(m2k_exception::make("Analog out: Cannot find m2k fabric device").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	m_calib_vlsb.push_back(10.0 / ((double)( 1 << 12 )));
@@ -167,7 +167,7 @@ double M2kAnalogOutImpl::getSampleRate(unsigned int chn_idx)
 std::vector<double> M2kAnalogOutImpl::setSampleRate(std::vector<double> samplerates)
 {
 	if (samplerates.size() >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	std::vector<double> values = {};
 	for (unsigned int i = 0; i < samplerates.size(); i++) {
@@ -181,7 +181,7 @@ std::vector<double> M2kAnalogOutImpl::setSampleRate(std::vector<double> samplera
 double M2kAnalogOutImpl::setSampleRate(unsigned int chn_idx, double samplerate)
 {
 	if (chn_idx >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_samplerate.at(chn_idx) = getDacDevice(chn_idx)->setDoubleValue(samplerate, "sampling_frequency");
 	return m_samplerate.at(chn_idx);
@@ -206,7 +206,7 @@ bool M2kAnalogOutImpl::getSyncedDma(int chn)
 void M2kAnalogOutImpl::setSyncedStartDma(bool en, int chn)
 {
 	if (!m_dma_start_sync_available) {
-		throw_exception(EXC_RUNTIME_ERROR, "Invalid firmware version: 0.24 or greater is required.");
+		throw_exception(m2k_exception::make("Invalid firmware version: 0.24 or greater is required.").type(libm2k::EXC_INVALID_FIRMWARE_VERSION).build());
 	}
 	if (chn < 0) {
 		for (auto dac : m_dac_devices) {
@@ -220,7 +220,7 @@ void M2kAnalogOutImpl::setSyncedStartDma(bool en, int chn)
 bool M2kAnalogOutImpl::getSyncedStartDma(int chn)
 {
 	if (!m_dma_start_sync_available) {
-		throw_exception(EXC_RUNTIME_ERROR, "Invalid firmware version: 0.24 or greater is required.");
+		throw_exception(m2k_exception::make("Invalid firmware version: 0.24 or greater is required.").type(libm2k::EXC_INVALID_FIRMWARE_VERSION).build());
 	}
 	return getDacDevice(chn)->getBoolValue("dma_sync_start");
 }
@@ -242,7 +242,7 @@ void M2kAnalogOutImpl::setCyclic(unsigned int chn, bool en)
 bool M2kAnalogOutImpl::getCyclic(unsigned int chn)
 {
 	if (chn >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	return m_cyclic.at(chn);
 }
@@ -257,7 +257,7 @@ short M2kAnalogOutImpl::convVoltsToRaw(double voltage, double vlsb,
 short M2kAnalogOutImpl::convertVoltsToRaw(unsigned int channel, double voltage)
 {
 	if (channel >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return convVoltsToRaw(voltage, m_calib_vlsb.at(channel),
@@ -273,7 +273,7 @@ double M2kAnalogOutImpl::convRawToVolts(short raw, double vlsb, double filterCom
 double M2kAnalogOutImpl::convertRawToVolts(unsigned int channel, short raw)
 {
 	if (channel >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return convRawToVolts(raw, m_calib_vlsb.at(channel),
@@ -296,7 +296,7 @@ void M2kAnalogOutImpl::pushRaw(unsigned int chnIdx, std::vector<short> const &da
 void M2kAnalogOutImpl::pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples)
 {
 	if (chnIdx >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	m_dac_devices.at(chnIdx)->push(data, 0, nb_samples, getCyclic(chnIdx));
@@ -315,7 +315,7 @@ void M2kAnalogOutImpl::push(unsigned int chnIdx, std::vector<double> const &data
 void M2kAnalogOutImpl::pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples)
 {
 	if (chnIdx >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	std::vector<short> raw_data_buffer = {};
 
@@ -375,7 +375,7 @@ void M2kAnalogOutImpl::pushRaw(std::vector<std::vector<short>> const &data)
 void M2kAnalogOutImpl::pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples)
 {
 	if ((nb_samples % nb_channels) !=0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Analog Out: Input array length must be multiple of channels");
+		throw_exception(m2k_exception::make("Analog Out: Input array length must be multiple of channels").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	std::vector<std::vector<short>> data_buffers;
 	unsigned int bufferSize = nb_samples/nb_channels;
@@ -474,7 +474,7 @@ void M2kAnalogOutImpl::push(std::vector<std::vector<double>> const &data)
 void M2kAnalogOutImpl::pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples)
 {
 	if ((nb_samples % nb_channels) !=0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Analog Out: Input array length must be multiple of channels");
+		throw_exception(m2k_exception::make("Analog Out: Input array length must be multiple of channels").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	std::vector<std::vector<short>> data_buffers;
 	unsigned int bufferSize = nb_samples/nb_channels;
@@ -521,7 +521,8 @@ void M2kAnalogOutImpl::pushInterleaved(double *data, unsigned int nb_channels, u
 double M2kAnalogOutImpl::getScalingFactor(unsigned int chn)
 {
 	if (chn >= m_calib_vlsb.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
+
 	}
 	return (-1 * (1 / m_calib_vlsb.at(chn)) * 16) /
 			getFilterCompensation(getSampleRate(chn));
@@ -566,7 +567,7 @@ bool M2kAnalogOutImpl::isChannelEnabled(unsigned int chnIdx)
 DeviceOut* M2kAnalogOutImpl::getDacDevice(unsigned int chnIdx)
 {
 	if (chnIdx >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kAnalogOut: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	return m_dac_devices.at(chnIdx);
 }
@@ -585,7 +586,7 @@ std::vector<double> M2kAnalogOutImpl::getAvailableSampleRates(unsigned int chnId
 void M2kAnalogOutImpl::setKernelBuffersCount(unsigned int chnIdx, unsigned int count)
 {
 	if (chnIdx >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kAnalogOut: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_dac_devices[chnIdx]->setKernelBuffersCount(count);
 	m_nb_kernel_buffers[chnIdx] = count;
@@ -631,7 +632,7 @@ string M2kAnalogOutImpl::getChannelName(unsigned int channel)
 double M2kAnalogOutImpl::getMaximumSamplerate(unsigned int chn_idx)
 {
 	if (chn_idx >= m_dac_devices.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Analog Out: No such channel");
+		throw_exception(m2k_exception::make("Analog Out: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	if (m_max_samplerate[chn_idx] < 0) {
 		auto values = getAvailableSampleRates(chn_idx);

--- a/src/context_impl.cpp
+++ b/src/context_impl.cpp
@@ -105,7 +105,7 @@ DEVICE_DIRECTION ContextImpl::getIioDeviceDirection(std::string dev_name)
 	DEVICE_DIRECTION dir = NO_DIRECTION;
 	auto dev = iio_context_find_device(m_context, dev_name.c_str());
 	if (!dev) {
-		throw_exception(EXC_RUNTIME_ERROR, "No device found with name: " + dev_name);
+		throw_exception(m2k_exception::make("No device found with name: " + dev_name).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	auto chn_count = iio_device_get_channels_count(dev);
@@ -133,7 +133,7 @@ DEVICE_TYPE ContextImpl::getIioDeviceType(std::string dev_name)
 {
 	auto dev = iio_context_find_device(m_context, dev_name.c_str());
 	if (!dev) {
-		throw_exception(EXC_INVALID_PARAMETER, "No device found with name: " + dev_name);
+		throw_exception(m2k_exception::make("No device found with name: " + dev_name).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	auto chn = iio_device_get_channel(dev, 0);
@@ -274,7 +274,7 @@ std::string ContextImpl::getContextAttributeValue(std::string attr)
 	__try {
 		val = m_context_attributes.at(attr);
 	} __catch (std::exception &) {
-		throw_exception(EXC_INVALID_PARAMETER, "No such context attribute" + attr);
+		throw_exception(m2k_exception::make("No such context attribute" + attr).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return val;
 }
@@ -345,8 +345,8 @@ void ContextImpl::initializeContextAttributes()
 		std::pair<std::string, std::string> pair;
 		int ret = iio_context_get_attr(m_context, i, &name, &value);
 		if (ret < 0) {
-			throw_exception(EXC_RUNTIME_ERROR, "Device: Can't get context attribute " +
-					std::to_string(i));
+			throw_exception(m2k_exception::make("Device: Can't get context attribute " +
+							    std::to_string(i)).type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		}
 		pair.first = std::string(name);
 		pair.second = std::string(value);

--- a/src/contextbuilder.cpp
+++ b/src/contextbuilder.cpp
@@ -247,7 +247,7 @@ void ContextBuilder::contextClose(Context* device, bool deinit)
 		}
 	} catch (std::exception &e ){
 		delete device;
-		throw_exception(EXC_RUNTIME_ERROR, "Context deinit: " + std::string(e.what()));
+		throw_exception(m2k_exception::make("Context deinit: " + std::string(e.what())).type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	delete device;
 }

--- a/src/digital/m2kdigital_impl.cpp
+++ b/src/digital/m2kdigital_impl.cpp
@@ -44,7 +44,7 @@ M2kDigitalImpl::M2kDigitalImpl(struct iio_context *ctx, std::string logic_dev, b
 		m_dev_generic = make_shared<DeviceGeneric>(ctx, logic_dev);
 	} __catch (exception_type &e) {
 		m_dev_generic = nullptr;
-		throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: No generic digital device was found.");
+		throw_exception(m2k_exception::make("M2K Digital: No generic digital device was found.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	m_trigger = trigger;
@@ -56,7 +56,7 @@ M2kDigitalImpl::M2kDigitalImpl(struct iio_context *ctx, std::string logic_dev, b
 			m_dev_write = make_shared<DeviceOut>(ctx, m_dev_name_write);
 		} __catch (exception_type &e) {
 			m_dev_write = nullptr;
-			throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: No device was found for writing");
+			throw_exception(m2k_exception::make("M2K Digital: No device was found for writing").type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 	}
 
@@ -65,14 +65,14 @@ M2kDigitalImpl::M2kDigitalImpl(struct iio_context *ctx, std::string logic_dev, b
 			m_dev_read = make_shared<DeviceIn>(ctx, m_dev_name_read);
 		} __catch (exception_type &e) {
 			m_dev_read = nullptr;
-			throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: No device was found for reading");
+			throw_exception(m2k_exception::make("M2K Digital: No device was found for reading").type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 	}
 
 	if (!m_dev_read || !m_dev_write) {
 		m_dev_read = nullptr;
 		m_dev_write = nullptr;
-		throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: logic device not found");
+		throw_exception(m2k_exception::make("M2K Digital: logic device not found").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (sync) {
@@ -170,7 +170,7 @@ void M2kDigitalImpl::setDirection(DIO_CHANNEL index, DIO_DIRECTION dir)
 		}
 		m_dev_generic->setStringValue(index, "direction", dir_str);
 	} else {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel.");
+		throw_exception(m2k_exception::make("M2kDigital: No such digital channel.").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 }
@@ -178,7 +178,7 @@ void M2kDigitalImpl::setDirection(DIO_CHANNEL index, DIO_DIRECTION dir)
 DIO_DIRECTION M2kDigitalImpl::getDirection(DIO_CHANNEL index)
 {
 	if (index >= m_dev_generic->getNbChannels(false)) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel");
+		throw_exception(m2k_exception::make("M2kDigital: No such digital channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	std::string dir_str = m_dev_generic->getStringValue(index, "direction");
@@ -191,7 +191,7 @@ DIO_DIRECTION M2kDigitalImpl::getDirection(DIO_CHANNEL index)
 void M2kDigitalImpl::setValueRaw(DIO_CHANNEL index, DIO_LEVEL level)
 {
 	if (index >= m_dev_generic->getNbChannels(false)) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel");
+		throw_exception(m2k_exception::make("M2kDigital: No such digital channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	long long val = static_cast<long long>(level);
 	m_dev_generic->setDoubleValue(index, val, "raw");
@@ -212,7 +212,7 @@ void M2kDigitalImpl::setValueRaw(DIO_CHANNEL index, bool level)
 DIO_LEVEL M2kDigitalImpl::getValueRaw(DIO_CHANNEL index)
 {
 	if (index >= m_dev_generic->getNbChannels(false)) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: No such digital channel");
+		throw_exception(m2k_exception::make("M2kDigital: No such digital channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	long long val;
 	val = m_dev_generic->getDoubleValue(index, "raw");
@@ -228,7 +228,7 @@ DIO_LEVEL M2kDigitalImpl::getValueRaw(unsigned int index)
 void M2kDigitalImpl::push(std::vector<unsigned short> const &data)
 {
 	if (!anyChannelEnabled(DIO_OUTPUT)) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No TX channel enabled.");
+		throw_exception(m2k_exception::make("M2kDigital: No TX channel enabled.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_dev_write->push(data, 0, getCyclic(), true);
 }
@@ -236,7 +236,7 @@ void M2kDigitalImpl::push(std::vector<unsigned short> const &data)
 void M2kDigitalImpl::push(unsigned short *data, unsigned int nb_samples)
 {
 	if (!anyChannelEnabled(DIO_OUTPUT)) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No TX channel enabled.");
+		throw_exception(m2k_exception::make("M2kDigital: No TX channel enabled.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_dev_write->push(data, 0, nb_samples, getCyclic(), true);
 }
@@ -260,7 +260,7 @@ std::vector<unsigned short> M2kDigitalImpl::getSamples(unsigned int nb_samples)
 {
 	__try {
 		if (!anyChannelEnabled(DIO_INPUT)) {
-			throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No RX channel enabled.");
+			throw_exception(m2k_exception::make("M2kDigital: No RX channel enabled.").type(libm2k::EXC_INVALID_PARAMETER).build());
 
 		}
 
@@ -271,7 +271,7 @@ std::vector<unsigned short> M2kDigitalImpl::getSamples(unsigned int nb_samples)
 		return m_dev_read->getSamplesShort(nb_samples);
 
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: " + string(e.what()));
+		throw_exception(m2k_exception::make("M2K Digital: " + string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 		return std::vector<unsigned short>();
 	}
 }
@@ -280,7 +280,7 @@ const unsigned short* M2kDigitalImpl::getSamplesP(unsigned int nb_samples)
 {
 	__try {
 		if (!anyChannelEnabled(DIO_INPUT)) {
-			throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No RX channel enabled.");
+			throw_exception(m2k_exception::make("M2kDigital: No RX channel enabled.").type(libm2k::EXC_INVALID_PARAMETER).build());
 			return nullptr;
 		}
 
@@ -291,7 +291,7 @@ const unsigned short* M2kDigitalImpl::getSamplesP(unsigned int nb_samples)
 		return m_dev_read->getSamplesP(nb_samples);
 
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: " + string(e.what()));
+		throw_exception(m2k_exception::make("M2K Digital: " + string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 }
@@ -302,7 +302,7 @@ void M2kDigitalImpl::enableChannel(unsigned int index, bool enable)
 		m_dev_write->enableChannel(index, enable, true);
 		m_tx_channels_enabled.at(index) = enable;
 	} else {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: Cannot enable digital TX channel");
+		throw_exception(m2k_exception::make("M2kDigital: Cannot enable digital TX channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -312,7 +312,7 @@ void M2kDigitalImpl::enableChannel(DIO_CHANNEL index, bool enable)
 		m_dev_write->enableChannel(index, enable, true);
 		m_tx_channels_enabled.at(index) = enable;
 	} else {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: Cannot enable digital TX channel");
+		throw_exception(m2k_exception::make("M2kDigital: Cannot enable digital TX channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -367,7 +367,7 @@ DIO_MODE M2kDigitalImpl::getOutputMode(DIO_CHANNEL chn)
 	auto it = std::find(m_output_mode.begin(), m_output_mode.end(),
 			    output_mode.c_str());
 	if (it == m_output_mode.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "M2kDigital: Cannot read channel attribute: output mode");
+		throw_exception(m2k_exception::make("M2kDigital: Cannot read channel attribute: output mode").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<DIO_MODE>(it - m_output_mode.begin());
@@ -445,8 +445,7 @@ void M2kDigitalImpl::getSamples(std::vector<unsigned short> &data, unsigned int 
 {
 	__try {
 		if (!anyChannelEnabled(DIO_INPUT)) {
-			throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: No RX channel enabled.");
-
+			throw_exception(m2k_exception::make("M2kDigital: No RX channel enabled.").type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 
 		/* There is a restriction in the HDL that the buffer size must
@@ -456,6 +455,6 @@ void M2kDigitalImpl::getSamples(std::vector<unsigned short> &data, unsigned int 
 		m_dev_read->getSamples(data, nb_samples);
 
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2K Digital: " + string(e.what()));
+		throw_exception(m2k_exception::make("M2K Digital: " + string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }

--- a/src/lidar_impl.cpp
+++ b/src/lidar_impl.cpp
@@ -38,8 +38,8 @@ void LidarImpl::channelEnableDisable(string channel, bool enable) {
 	else if (channel == "voltage4")
 		adc_dev->enableChannel(4, enable, false);
 	else
-		throw_exception(EXC_INVALID_PARAMETER, "The supplied channel, " +
-				channel + ", does not exist");
+		throw_exception(m2k_exception::make("The supplied channel, " +
+						    channel + ", does not exist").type(libm2k::EXC_INVALID_PARAMETER).build());
 }
 
 vector<string> LidarImpl::enabledChannelsList() {

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -73,7 +73,7 @@ M2kImpl::M2kImpl(std::string uri, iio_context* ctx, std::string name, bool sync)
 	}
 
 	if (!m_trigger) {
-		throw_exception(EXC_INVALID_PARAMETER, "Can't instantiate M2K board; M2K trigger is invalid.");
+		throw_exception(m2k_exception::make("Can't instantiate M2K board; M2K trigger is invalid.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	scanAllAnalogIn();
@@ -225,7 +225,7 @@ int M2kImpl::getDacCalibrationOffset(unsigned int chn)
 void M2kImpl::setAdcCalibrationGain(unsigned int chn, double gain)
 {
 	if (chn >= getAnalogIn()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+		throw_exception(m2k_exception::make("No such ADC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_calibration->setAdcGain(chn, gain);
 }
@@ -233,7 +233,7 @@ void M2kImpl::setAdcCalibrationGain(unsigned int chn, double gain)
 void M2kImpl::setAdcCalibrationOffset(unsigned int chn, int offset)
 {
 	if (chn >= getAnalogIn()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+		throw_exception(m2k_exception::make("No such ADC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_calibration->setAdcOffset(chn, offset);
 }
@@ -241,7 +241,7 @@ void M2kImpl::setAdcCalibrationOffset(unsigned int chn, int offset)
 void M2kImpl::setDacCalibrationOffset(unsigned int chn, int offset)
 {
 	if (chn >= getAnalogOut()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+		throw_exception(m2k_exception::make("No such DAC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_calibration->setDacOffset(chn, offset);
 }
@@ -249,7 +249,7 @@ void M2kImpl::setDacCalibrationOffset(unsigned int chn, int offset)
 void M2kImpl::setDacCalibrationGain(unsigned int chn, double gain)
 {
 	if (chn >= getAnalogOut()->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+		throw_exception(m2k_exception::make("No such DAC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	m_calibration->setDacGain(chn, gain);
 }
@@ -283,7 +283,7 @@ M2kPowerSupply* M2kImpl::getPowerSupply()
 {
 	M2kPowerSupply* pSupply = dynamic_cast<M2kPowerSupply*>(m_instancesPowerSupply.at(0));
 	if (!pSupply) {
-		throw_exception(EXC_INVALID_PARAMETER, "No M2K power supply");
+		throw_exception(m2k_exception::make("No M2K power supply").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return pSupply;
 }
@@ -292,7 +292,7 @@ M2kDigital* M2kImpl::getDigital()
 {
 	M2kDigital* logic = dynamic_cast<M2kDigital*>(m_instancesDigital.at(0));
 	if (!logic) {
-		throw_exception(EXC_INVALID_PARAMETER, "No M2K digital device found");
+		throw_exception(m2k_exception::make("No M2K digital device found").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return logic;
 }

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -115,7 +115,7 @@ void M2kCalibrationImpl::setAdcInCalibMode()
 		m_m2k_adc->enableChannel(0, true);
 		m_m2k_adc->enableChannel(1, true);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -136,7 +136,7 @@ void M2kCalibrationImpl::setDacInCalibMode()
 		m_m2k_dac->enableChannel(0, true);
 		m_m2k_dac->enableChannel(1, true);
 	} __catch(exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -155,7 +155,7 @@ void M2kCalibrationImpl::restoreAdcFromCalibMode()
 		m_m2k_adc->enableChannel(0, m_adc_channels_enabled.at(0));
 		m_m2k_adc->enableChannel(1, m_adc_channels_enabled.at(1));
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -170,7 +170,7 @@ void M2kCalibrationImpl::restoreDacFromCalibMode()
 		m_m2k_dac->enableChannel(0, m_dac_channels_enabled.at(0));
 		m_m2k_dac->enableChannel(1, m_dac_channels_enabled.at(1));
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -181,7 +181,7 @@ void M2kCalibrationImpl::configAdcSamplerate()
 		m_m2k_adc->setSampleRate(1e8);
 		m_m2k_adc->setOversamplingRatio(1);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -193,7 +193,7 @@ void M2kCalibrationImpl::configDacSamplerate()
 		m_m2k_dac->setSampleRate(1, 75E6);
 		m_m2k_dac->setOversamplingRatio(1, 1);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -234,7 +234,7 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 	__try {
 		ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	if (ch_data.size() == 0) {
 		return false;
@@ -283,7 +283,7 @@ bool M2kCalibrationImpl::calibrateADCgain()
 	__try {
 		ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	if (ch_data.size() == 0) {
 		return false;
@@ -314,7 +314,7 @@ bool M2kCalibrationImpl::calibrateADCgain()
 int M2kCalibrationImpl::getAdcOffset(unsigned int channel)
 {
 	if (channel >= m_m2k_adc->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+		throw_exception(m2k_exception::make("No such ADC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	auto calib_offset = m_m2k_adc->getAdcCalibOffset(static_cast<ANALOG_IN_CHANNEL>(channel));
 	if (channel == 0) {
@@ -328,7 +328,7 @@ int M2kCalibrationImpl::getAdcOffset(unsigned int channel)
 double M2kCalibrationImpl::getAdcGain(unsigned int channel)
 {
 	if (channel >= m_m2k_adc->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+		throw_exception(m2k_exception::make("No such ADC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	auto gain = m_m2k_adc->getCalibscale(channel);
 	if (channel == 0) {
@@ -342,7 +342,7 @@ double M2kCalibrationImpl::getAdcGain(unsigned int channel)
 void M2kCalibrationImpl::setAdcOffset(unsigned int chn, int offset)
 {
 	if (chn >= m_m2k_adc->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+		throw_exception(m2k_exception::make("No such ADC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	if (chn == 0) {
@@ -360,7 +360,7 @@ void M2kCalibrationImpl::setAdcOffset(unsigned int chn, int offset)
 void M2kCalibrationImpl::setAdcGain(unsigned int chn, double gain)
 {
 	if (chn >= m_m2k_adc->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such ADC channel");
+		throw_exception(m2k_exception::make("No such ADC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	if (chn == 0) {
@@ -452,7 +452,7 @@ bool M2kCalibrationImpl::fine_tune(size_t span, int16_t centerVal0, int16_t cent
 		__try {
 			ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 		} __catch (exception_type &e) {
-			throw_exception(EXC_INVALID_PARAMETER, e.what());
+			throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 		if (ch_data.size() == 0) {
 			goto out_cleanup;
@@ -495,7 +495,7 @@ out_cleanup:
 int M2kCalibrationImpl::getDacOffset(unsigned int channel)
 {
 	if (channel >= m_m2k_dac->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+		throw_exception(m2k_exception::make("No such DAC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	double offset = m_ad5625_dev->getDoubleValue(channel, "raw", true);
@@ -510,7 +510,7 @@ int M2kCalibrationImpl::getDacOffset(unsigned int channel)
 double M2kCalibrationImpl::getDacGain(unsigned int channel)
 {
 	if (channel >= m_m2k_dac->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+		throw_exception(m2k_exception::make("No such DAC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto gain = m_m2k_dac->getCalibscale(channel);
@@ -525,7 +525,7 @@ double M2kCalibrationImpl::getDacGain(unsigned int channel)
 void M2kCalibrationImpl::setDacOffset(unsigned int chn, int offset)
 {
 	if (chn >= m_m2k_dac->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+		throw_exception(m2k_exception::make("No such DAC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	if (chn == 0) {
@@ -540,7 +540,7 @@ void M2kCalibrationImpl::setDacOffset(unsigned int chn, int offset)
 void M2kCalibrationImpl::setDacGain(unsigned int chn, double gain)
 {
 	if (chn >= m_m2k_dac->getNbChannels()) {
-		throw_exception(EXC_OUT_OF_RANGE, "No such DAC channel");
+		throw_exception(m2k_exception::make("No such DAC channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	if (chn == 0) {
@@ -592,8 +592,8 @@ bool M2kCalibrationImpl::calibrateDACoffset()
 
 
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "DAC offset calibration failed: "
-				+ std::string(e.what()));
+		throw_exception(m2k_exception::make("DAC offset calibration failed: "
+						    + std::string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	// Allow some time for the voltage to settle
@@ -603,7 +603,7 @@ bool M2kCalibrationImpl::calibrateDACoffset()
 		ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 	} __catch (exception_type &e) {
 		ch_data.clear();
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	if (ch_data.size() == 0) {
 		return false;
@@ -633,7 +633,7 @@ bool M2kCalibrationImpl::calibrateDACoffset()
 		m_m2k_dac->enableChannel(0, false);
 		m_m2k_dac->enableChannel(1, false);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	setCalibrationMode(NONE);
@@ -674,8 +674,8 @@ bool M2kCalibrationImpl::calibrateDACgain()
 		m_m2k_fabric->setBoolValue(0, false, "powerdown", true);
 		m_m2k_fabric->setBoolValue(1, false, "powerdown", true);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "DAC gain calibration failed: "
-				+ std::string(e.what()));
+		throw_exception(m2k_exception::make("DAC gain calibration failed: "
+						    + std::string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	// Allow some time for the voltage to settle
@@ -685,7 +685,7 @@ bool M2kCalibrationImpl::calibrateDACgain()
 	__try {
 		ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	if (ch_data.size() == 0) {
 		return false;
@@ -717,7 +717,7 @@ bool M2kCalibrationImpl::calibrateDACgain()
 		m_m2k_dac->enableChannel(1, false);
 	} __catch (exception_type &e) {
 		//		throw std::runtime_error(
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	setCalibrationMode(NONE);
@@ -756,8 +756,8 @@ bool M2kCalibrationImpl::calibrateADC()
 		m_m2k_adc->stopAcquisition();
 		return true;
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "ADC calibration failed: " +
-				std::string(e.what()));
+		throw_exception(m2k_exception::make("ADC calibration failed: " +
+						    std::string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 calibration_fail:
 	m_cancel=false;
@@ -802,8 +802,8 @@ bool M2kCalibrationImpl::calibrateDAC()
 		m_m2k_adc->stopAcquisition();
 		return true;
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, "DAC calibration failed " +
-				std::string(e.what()));
+		throw_exception(m2k_exception::make("DAC calibration failed " +
+						    std::string(e.what())).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 calibration_fail:
 	m_cancel=false;
@@ -836,7 +836,7 @@ bool M2kCalibrationImpl::calibrateAll()
 
 		return true;
 	} __catch (exception_type &e) {
-		throw_exception(EXC_INVALID_PARAMETER, e.what());
+		throw_exception(m2k_exception::make(e.what()).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 calibration_fail:
 	m_cancel=false;

--- a/src/m2kexception.cpp
+++ b/src/m2kexception.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020 Analog Devices Inc.
+ *
+ * This file is part of libm2k
+ * (see http://www.github.com/analogdevicesinc/libm2k).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#include <libm2k/m2kexceptions.hpp>
+
+using namespace libm2k;
+
+m2k_exception_builder m2k_exception::make(std::string what) {
+	return m2k_exception_builder(what);
+}
+
+int m2k_exception::iioCode() const noexcept
+{
+	return m_iio_code;
+}
+
+libm2k::M2K_EXCEPTION_TYPE m2k_exception::type() const noexcept
+{
+	return m_type;
+}
+
+const char* m2k_exception::what() const noexcept
+{
+	return m_message.c_str();
+}
+
+m2k_exception_builder::m2k_exception_builder(std::string &what)
+{
+	m2KException = m2k_exception(what);
+	m2KException.m_error = what;
+	m2KException.m_message.append(m2KException.m_error);
+}
+
+m2k_exception_builder::m2k_exception_builder(const char* what)
+{
+	m2KException = m2k_exception(what);
+	m2KException.m_error = what;
+	m2KException.m_message.append(m2KException.m_error);
+}
+
+m2k_exception_builder::operator m2k_exception &&()
+{
+	return std::move(m2KException);
+}
+
+m2k_exception_builder &m2k_exception_builder::iioCode(int code)
+{
+	m2KException.m_iio_code = code;
+	return *this;
+}
+
+m2k_exception_builder &m2k_exception_builder::type(libm2k::M2K_EXCEPTION_TYPE type)
+{
+	switch (type) {
+	case libm2k::EXC_OUT_OF_RANGE: {
+		m2KException.m_message = "ERR: Out of range - " + m2KException.m_error;
+		break;
+	}
+	case libm2k::EXC_RUNTIME_ERROR: {
+		m2KException.m_message = "ERR: Runtime - " + m2KException.m_error;
+		break;
+	}
+	case libm2k::EXC_INVALID_PARAMETER: {
+		m2KException.m_message = "ERR: Invalid argument - " + m2KException.m_error;
+		break;
+	}
+	case libm2k::EXC_TIMEOUT: {
+		m2KException.m_message = "ERR: Timeout - " + m2KException.m_error;
+		break;
+	}
+	default: {
+		m2KException.m_message = "ERR: Generic - " + m2KException.m_error;
+		break;
+	}
+	}
+	m2KException.m_type = type;
+	return *this;
+}
+
+m2k_exception m2k_exception_builder::build() {
+	return m2KException;
+}

--- a/src/m2khardwaretrigger_impl.cpp
+++ b/src/m2khardwaretrigger_impl.cpp
@@ -83,7 +83,7 @@ M2kHardwareTriggerImpl::M2kHardwareTriggerImpl(struct iio_context *ctx, bool ini
 {
 	m_analog_trigger_device = make_shared<DeviceIn>(ctx, "m2k-adc-trigger");
 	if (!m_analog_trigger_device) {
-		throw_exception(EXC_INVALID_PARAMETER, "No analog trigger available");
+		throw_exception(m2k_exception::make("No analog trigger available").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	std::vector<std::pair<Channel*, std::string>> channels;
@@ -128,22 +128,19 @@ M2kHardwareTriggerImpl::M2kHardwareTriggerImpl(struct iio_context *ctx, bool ini
 	m_num_channels = m_analog_channels.size();
 
 	if (m_analog_channels.size() < 1) {
-		throw_exception(EXC_INVALID_PARAMETER,
-				"hardware trigger has no analog channels");
+		throw_exception(m2k_exception::make("Hardware trigger has no analog channels").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (m_digital_channels.size() < 1) {
-		throw_exception(EXC_INVALID_PARAMETER,
-				"hardware trigger has no digital channels");
+		throw_exception(m2k_exception::make("Hardware trigger has no digital channels").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (m_logic_channels.size() < 1) {
-		throw_exception(EXC_INVALID_PARAMETER,
-				"hardware trigger has no trigger_logic channels");
+		throw_exception(m2k_exception::make("Hardware trigger has no trigger_logic channels").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (!m_delay_trigger) {
-		throw_exception(EXC_INVALID_PARAMETER, "no delay trigger available");
+		throw_exception(m2k_exception::make("No delay trigger available").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (init) {
@@ -156,7 +153,7 @@ M2kHardwareTriggerImpl::M2kHardwareTriggerImpl(struct iio_context *ctx, bool ini
 
 	m_digital_trigger_device = make_shared<DeviceIn>(ctx, "m2k-logic-analyzer-rx");
 	if (!m_digital_trigger_device) {
-		throw_exception(EXC_INVALID_PARAMETER, "no digital trigger available");
+		throw_exception(m2k_exception::make("No digital trigger available").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -207,7 +204,7 @@ M2K_TRIGGER_CONDITION_DIGITAL M2kHardwareTriggerImpl::getDigitalExternalConditio
 	auto it = std::find(m_trigger_digital_cond.begin(),
 			    m_trigger_digital_cond.end(), buf.c_str());
 	if  (it == m_trigger_digital_cond.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: trigger");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: trigger").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<M2K_TRIGGER_CONDITION_DIGITAL>(it - m_trigger_digital_cond.begin());
@@ -222,14 +219,14 @@ void M2kHardwareTriggerImpl::setDigitalExternalCondition(M2K_TRIGGER_CONDITION_D
 M2K_TRIGGER_CONDITION_DIGITAL M2kHardwareTriggerImpl::getAnalogExternalCondition(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	std::string buf = m_digital_channels[chnIdx]->getStringValue("trigger");
 
 	auto it = std::find(m_trigger_digital_cond.begin(),
 			    m_trigger_digital_cond.end(), buf.c_str());
 	if  (it == m_trigger_digital_cond.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: trigger");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: trigger").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<M2K_TRIGGER_CONDITION_DIGITAL>(it - m_trigger_digital_cond.begin());
@@ -239,11 +236,11 @@ M2K_TRIGGER_CONDITION_DIGITAL M2kHardwareTriggerImpl::getAnalogExternalCondition
 void M2kHardwareTriggerImpl::setAnalogExternalCondition(unsigned int chnIdx, M2K_TRIGGER_CONDITION_DIGITAL cond)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	if (cond == NO_TRIGGER_DIGITAL) {
-		throw_exception(EXC_INVALID_PARAMETER, "Analog External condition: can't set NO_TRIGGER for this channel.");
+		throw_exception(m2k_exception::make("Analog External condition: can't set NO_TRIGGER for this channel.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	m_digital_channels[chnIdx]->setStringValue("trigger", m_trigger_digital_cond[cond]);
@@ -252,14 +249,14 @@ void M2kHardwareTriggerImpl::setAnalogExternalCondition(unsigned int chnIdx, M2K
 M2K_TRIGGER_CONDITION_ANALOG M2kHardwareTriggerImpl::getAnalogCondition(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	std::string buf = m_analog_channels[chnIdx]->getStringValue("trigger");
 	auto it = std::find(m_trigger_analog_cond.begin(),
 			    m_trigger_analog_cond.end(), buf.c_str());
 	if  (it == m_trigger_analog_cond.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: trigger");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: trigger").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<M2K_TRIGGER_CONDITION_ANALOG>(it - m_trigger_analog_cond.begin());
@@ -269,7 +266,7 @@ M2K_TRIGGER_CONDITION_ANALOG M2kHardwareTriggerImpl::getAnalogCondition(unsigned
 void M2kHardwareTriggerImpl::setAnalogCondition(unsigned int chnIdx, M2K_TRIGGER_CONDITION_ANALOG cond)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	m_analog_channels[chnIdx]->setStringValue("trigger", m_trigger_analog_cond[cond]);
@@ -284,7 +281,7 @@ M2K_TRIGGER_CONDITION_DIGITAL M2kHardwareTriggerImpl::getDigitalCondition(DIO_CH
 	auto it = std::find(available_digital_conditions.begin(),
 			    available_digital_conditions.end(), trigger_val.c_str());
 	if (it == available_digital_conditions.end()) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2kDigital: Cannot read channel attribute: trigger");
+		throw_exception(m2k_exception::make("M2kDigital: Cannot read channel attribute: trigger").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	return static_cast<M2K_TRIGGER_CONDITION_DIGITAL>
@@ -313,7 +310,7 @@ void M2kHardwareTriggerImpl::setDigitalCondition(unsigned int chn, M2K_TRIGGER_C
 int M2kHardwareTriggerImpl::getAnalogLevelRaw(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	double val = m_analog_channels[chnIdx]->getDoubleValue("trigger_level");
@@ -324,7 +321,7 @@ int M2kHardwareTriggerImpl::getAnalogLevelRaw(unsigned int chnIdx)
 void M2kHardwareTriggerImpl::setAnalogLevelRaw(unsigned int chnIdx, int level)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	m_analog_channels[chnIdx]->setLongValue("trigger_level", static_cast<long long>(level));
@@ -333,7 +330,7 @@ void M2kHardwareTriggerImpl::setAnalogLevelRaw(unsigned int chnIdx, int level)
 double M2kHardwareTriggerImpl::getAnalogLevel(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	int raw = getAnalogLevelRaw(chnIdx);
@@ -344,7 +341,7 @@ double M2kHardwareTriggerImpl::getAnalogLevel(unsigned int chnIdx)
 void M2kHardwareTriggerImpl::setAnalogLevel(unsigned int chnIdx, double v_level)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	int raw = (v_level + m_offset.at(chnIdx)) / m_scaling.at(chnIdx);
@@ -354,7 +351,7 @@ void M2kHardwareTriggerImpl::setAnalogLevel(unsigned int chnIdx, double v_level)
 double M2kHardwareTriggerImpl::getAnalogHysteresis(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	double hysteresis_raw = m_analog_channels[chnIdx]->getDoubleValue("trigger_hysteresis");
@@ -364,7 +361,7 @@ double M2kHardwareTriggerImpl::getAnalogHysteresis(unsigned int chnIdx)
 void M2kHardwareTriggerImpl::setAnalogHysteresis(unsigned int chnIdx, double hysteresis)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	int hysteresis_raw = hysteresis / m_scaling.at(chnIdx);
@@ -374,14 +371,14 @@ void M2kHardwareTriggerImpl::setAnalogHysteresis(unsigned int chnIdx, double hys
 M2K_TRIGGER_MODE M2kHardwareTriggerImpl::getAnalogMode(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	std::string buf = m_logic_channels[chnIdx]->getStringValue("mode");
 	auto it = std::find(m_trigger_mode.begin(),
 			    m_trigger_mode.end(), buf.c_str());
 	if  (it == m_trigger_mode.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: mode");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: mode").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<M2K_TRIGGER_MODE>(it - m_trigger_mode.begin());
@@ -390,7 +387,7 @@ M2K_TRIGGER_MODE M2kHardwareTriggerImpl::getAnalogMode(unsigned int chnIdx)
 void M2kHardwareTriggerImpl::setAnalogMode(unsigned int chnIdx, M2K_TRIGGER_MODE mode)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	m_logic_channels[chnIdx]->setStringValue("mode", m_trigger_mode[mode].c_str());
@@ -411,7 +408,7 @@ DIO_TRIGGER_MODE M2kHardwareTriggerImpl::getDigitalMode()
 	auto it = std::find(m_trigger_logic_mode.begin(), m_trigger_logic_mode.end(),
 			    trigger_mode.c_str());
 	if (it == m_trigger_logic_mode.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Cannot read channel attribute: trigger logic mode");
+		throw_exception(m2k_exception::make("Cannot read channel attribute: trigger logic mode").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 	return static_cast<DIO_TRIGGER_MODE>(it - m_trigger_logic_mode.begin());
 }
@@ -423,7 +420,7 @@ M2K_TRIGGER_SOURCE_ANALOG M2kHardwareTriggerImpl::getAnalogSource()
 	auto it = std::find(m_trigger_source.begin(),
 			    m_trigger_source.end(), buf.c_str());
 	if  (it == m_trigger_source.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: logic_mode / source");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: logic_mode / source").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<M2K_TRIGGER_SOURCE_ANALOG>(it - m_trigger_source.begin());
@@ -432,9 +429,9 @@ M2K_TRIGGER_SOURCE_ANALOG M2kHardwareTriggerImpl::getAnalogSource()
 void M2kHardwareTriggerImpl::setAnalogSource(M2K_TRIGGER_SOURCE_ANALOG src)
 {
 	if (src >= m_trigger_source.size()) {
-		throw_exception(EXC_INVALID_PARAMETER, "M2kHardwareTrigger: "
-						       "the provided analog source is not supported on "
-						       "the current board; Check the firmware version.");
+		throw_exception(m2k_exception::make("M2kHardwareTrigger: "
+						    "the provided analog source is not supported on "
+						    "the current board; Check the firmware version.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	std::string src_str = m_trigger_source[src];
 	m_delay_trigger->setStringValue("logic_mode", src_str);
@@ -466,7 +463,7 @@ int M2kHardwareTriggerImpl::getAnalogSourceChannel()
 void M2kHardwareTriggerImpl::setAnalogSourceChannel(unsigned int chnIdx)
 {
 	if (chnIdx >= m_num_channels) {
-		throw_exception(EXC_OUT_OF_RANGE, "Source channel index is out of range");
+		throw_exception(m2k_exception::make("Channel index is out of range").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	// Currently we don't need trigger on multiple channels simultaneously

--- a/src/m2khardwaretrigger_v0.24_impl.cpp
+++ b/src/m2khardwaretrigger_v0.24_impl.cpp
@@ -110,7 +110,7 @@ M2K_TRIGGER_OUT_SELECT M2kHardwareTriggerV024Impl::getAnalogExternalOutSelect()
 		auto it = std::find(m_digital_out_select.begin(),
 				    m_digital_out_select.end(), buf.c_str());
 		if  (it == m_digital_out_select.end()) {
-			throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: out_select");
+			throw_exception(m2k_exception::make("Unexpected value read from attribute: out_select").type(libm2k::EXC_OUT_OF_RANGE).build());
 		}
 
 		return static_cast<M2K_TRIGGER_OUT_SELECT>(it - m_digital_out_select.begin());
@@ -171,7 +171,7 @@ M2K_TRIGGER_SOURCE_DIGITAL M2kHardwareTriggerV024Impl::getDigitalSource() const
 	auto it = std::find(m_trigger_ext_digital_source.begin(),
 			    m_trigger_ext_digital_source.end(), buf.c_str());
 	if  (it == m_trigger_ext_digital_source.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: trigger");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: trigger").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto src = static_cast<M2K_TRIGGER_SOURCE_DIGITAL>(it - m_trigger_ext_digital_source.begin());
@@ -199,7 +199,7 @@ M2K_TRIGGER_SOURCE_ANALOG M2kHardwareTriggerV024Impl::getAnalogSource()
 	auto it = std::find(m_trigger_source.begin(),
 			    m_trigger_source.end(), buf.c_str());
 	if  (it == m_trigger_source.end()) {
-		throw_exception(EXC_OUT_OF_RANGE, "unexpected value read from attribute: logic_mode / source");
+		throw_exception(m2k_exception::make("Unexpected value read from attribute: logic_mode / source").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	return static_cast<M2K_TRIGGER_SOURCE_ANALOG>(it - m_trigger_source.begin());

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -36,12 +36,12 @@ Buffer::Buffer(struct iio_device *dev) {
 
 	if (!m_dev) {
 		m_dev = nullptr;
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Device not found, so no buffer can be created");
+		throw_exception(m2k_exception::make("Buffer: Device not found, so no buffer can be created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	unsigned int dev_count = iio_device_get_buffer_attrs_count(m_dev);
 	if (dev_count <= 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Device is not buffer capable, no buffer can be created");
+		throw_exception(m2k_exception::make("Buffer: Device is not buffer capable, no buffer can be created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_buffer = nullptr;
 	m_last_nb_samples = 0;
@@ -68,16 +68,14 @@ void Buffer::initializeBuffer(unsigned int size, bool cyclic, bool output)
 		if (!m_buffer) {
 			if (output) {
 				if (errno == ETIMEDOUT) {
-					throw_exception(EXC_TIMEOUT,
-							"Buffer: Cannot create the TX buffer");
+					throw_exception(m2k_exception::make("Buffer: Cannot create the TX buffer").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 				}
-				throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot create the TX buffer");
+				throw_exception(m2k_exception::make("Buffer: Cannot create the TX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(errno).build());
 			} else {
 				if (errno == ETIMEDOUT) {
-					throw_exception(EXC_TIMEOUT,
-							"Buffer: Cannot create the RX buffer");
+					throw_exception(m2k_exception::make("Buffer: Cannot create the RX buffer").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 				}
-				throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot create the RX buffer");
+				throw_exception(m2k_exception::make("Buffer: Cannot create the RX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(errno).build());
 			}
 		}
 	}
@@ -96,7 +94,7 @@ void Buffer::push(unsigned short *data, unsigned int channel, unsigned int nb_sa
 	  bool cyclic, bool multiplex)
 {
 	if (Utils::getIioDeviceDirection(m_dev) != OUTPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not output buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	initializeBuffer(nb_samples, cyclic, true);
@@ -126,13 +124,12 @@ void Buffer::push(unsigned short *data, unsigned int channel, unsigned int nb_sa
 			destroy();
 			// timeout error code
 			if (ret == -ETIMEDOUT) {
-				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+				throw_exception(m2k_exception::make("Buffer: Push timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 			}
-			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+			throw_exception(m2k_exception::make("Buffer: Cannot push TX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		}
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
-
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
@@ -142,7 +139,7 @@ void Buffer::push(std::vector<short> const &data, unsigned int channel,
 {
 	size_t size = data.size();
 	if (Utils::getIioDeviceDirection(m_dev) != OUTPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not output buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	initializeBuffer(size, cyclic, true);
@@ -172,12 +169,12 @@ void Buffer::push(std::vector<short> const &data, unsigned int channel,
 			destroy();
 			// timeout error code
 			if (ret == -ETIMEDOUT) {
-				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+				throw_exception(m2k_exception::make("Buffer: Push timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 			}
-			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+			throw_exception(m2k_exception::make("Buffer: Cannot push TX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		}
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_INVALID_PARAMETER).build());
 
 	}
 }
@@ -187,7 +184,7 @@ void Buffer::push(std::vector<unsigned short> const &data, unsigned int channel,
 {
 	size_t size = data.size();
 	if (Utils::getIioDeviceDirection(m_dev) != OUTPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not output buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	initializeBuffer(size, cyclic, true);
@@ -217,12 +214,12 @@ void Buffer::push(std::vector<unsigned short> const &data, unsigned int channel,
 			destroy();
 			// timeout error code
 			if (ret == -ETIMEDOUT) {
-				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+				throw_exception(m2k_exception::make("Buffer: Push timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 			}
-			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+			throw_exception(m2k_exception::make("Buffer: Cannot push TX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		}
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_INVALID_PARAMETER).build());
 
 	}
 }
@@ -231,7 +228,7 @@ void Buffer::push(std::vector<double> const &data, unsigned int channel, bool cy
 {
 	size_t size = data.size();
 	if (Utils::getIioDeviceDirection(m_dev) == INPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not output buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	initializeBuffer(size, cyclic, true);
@@ -250,12 +247,13 @@ void Buffer::push(std::vector<double> const &data, unsigned int channel, bool cy
 			destroy();
 			// timeout error code
 			if (ret == -ETIMEDOUT) {
-				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+				throw_exception(m2k_exception::make("Buffer: Push timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 			}
-			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+			throw_exception(m2k_exception::make("Buffer: Cannot push TX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		}
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_INVALID_PARAMETER).build());
+
 	}
 }
 
@@ -264,7 +262,7 @@ void Buffer::push(std::vector<std::vector<short>> const &data)
 	size_t data_ch_nb = data.size();
 
 	if (data_ch_nb > m_channel_list.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Buffer: Please setup channels before pushing data");
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	for (unsigned int i = 0; i < data_ch_nb; i++) {
@@ -275,7 +273,7 @@ void Buffer::push(std::vector<std::vector<short>> const &data)
 void Buffer::push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
 {
 	if (Utils::getIioDeviceDirection(m_dev) == INPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not output buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	initializeBuffer(nb_samples, cyclic, true);
@@ -294,19 +292,20 @@ void Buffer::push(double *data, unsigned int channel, unsigned int nb_samples, b
 			destroy();
 			// timeout error code
 			if (ret == -ETIMEDOUT) {
-				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+				throw_exception(m2k_exception::make("Buffer: Push timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 			}
-			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+			throw_exception(m2k_exception::make("Buffer: Cannot push TX buffer").type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_INVALID_PARAMETER).build());
+
 	}
 }
 
 void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
 {
 	if (Utils::getIioDeviceDirection(m_dev) == INPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not output buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not output buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	initializeBuffer(nb_samples, cyclic, true);
@@ -325,19 +324,20 @@ void Buffer::push(short *data, unsigned int channel, unsigned int nb_samples, bo
 			destroy();
 			// timeout error code
 			if (ret == -ETIMEDOUT) {
-				throw_exception(EXC_TIMEOUT, "Buffer: Push timeout occurred");
+				throw_exception(m2k_exception::make("Buffer: Push timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 			}
-			throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot push TX buffer");
+			throw_exception(m2k_exception::make("Buffer: Cannot push TX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		}
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Please setup channels before pushing data");
+		throw_exception(m2k_exception::make("Buffer: Please setup channels before pushing data").type(libm2k::EXC_INVALID_PARAMETER).build());
+
 	}
 }
 
 void Buffer::getSamples(std::vector<unsigned short> &data, unsigned int nb_samples)
 {
 	if (Utils::getIioDeviceDirection(m_dev) == OUTPUT) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device not input-buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not input-buffer capable, so no buffer was created").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 
 	data.clear();
@@ -351,9 +351,9 @@ void Buffer::getSamples(std::vector<unsigned short> &data, unsigned int nb_sampl
 		destroy();
 		// timeout error code
 		if (ret == -ETIMEDOUT) {
-			throw_exception(EXC_TIMEOUT, "Buffer: Refill timeout occurred");
+			throw_exception(m2k_exception::make("Buffer: Refill timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 		}
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
+		throw_exception(m2k_exception::make("Buffer: Cannot refill RX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 	}
 
 	unsigned short* d_ptr = (unsigned short*)iio_buffer_start(m_buffer);
@@ -372,7 +372,7 @@ std::vector<unsigned short> Buffer::getSamples(unsigned int nb_samples)
 const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 {
 	if (Utils::getIioDeviceDirection(m_dev) == OUTPUT) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device not input-buffer capable, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not input-buffer capable, so no buffer was created").type(libm2k::EXC_RUNTIME_ERROR).build());
 		return nullptr;
 	}
 
@@ -385,9 +385,9 @@ const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 		destroy();
 		// timeout error code
 		if (ret == -ETIMEDOUT) {
-			throw_exception(EXC_TIMEOUT, "Buffer: Refill timeout occurred");
+			throw_exception(m2k_exception::make("Buffer: Refill timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 		}
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
+		throw_exception(m2k_exception::make("Buffer: Cannot refill RX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		return nullptr;
 	}
 
@@ -440,7 +440,7 @@ void* Buffer::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 {
 	bool anyChannelEnabled = false;
 	if (Utils::getIioDeviceDirection(m_dev) != INPUT) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device not found, so no buffer was created");
+		throw_exception(m2k_exception::make("Device not input-buffer capable, so no buffer was created").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 
@@ -450,7 +450,7 @@ void* Buffer::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 	}
 
 	if (!anyChannelEnabled) {
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: No channel enabled for RX buffer");
+		throw_exception(m2k_exception::make("Buffer: No channel enabled for RX buffer").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 
@@ -461,9 +461,9 @@ void* Buffer::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 		destroy();
 		// timeout error code
 		if (ret == -ETIMEDOUT) {
-			throw_exception(EXC_TIMEOUT, "Buffer: Refill timeout occurred");
+			throw_exception(m2k_exception::make("Buffer: Refill timeout occurred").type(libm2k::EXC_TIMEOUT).iioCode(-ETIMEDOUT).build());
 		}
-		throw_exception(EXC_INVALID_PARAMETER, "Buffer: Cannot refill RX buffer");
+		throw_exception(m2k_exception::make("Buffer: Cannot refill RX buffer").type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 		return nullptr;
 	}
 

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -59,7 +59,7 @@ Channel::~Channel() {
 std::string Channel::getName()
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	std::string name = "";
 	auto n = iio_channel_get_name(m_channel);
@@ -72,7 +72,7 @@ std::string Channel::getName()
 std::string Channel::getId()
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return iio_channel_get_id(m_channel);
 }
@@ -80,7 +80,7 @@ std::string Channel::getId()
 unsigned int Channel::getIndex()
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return iio_channel_get_index(m_channel);
 }
@@ -88,7 +88,7 @@ unsigned int Channel::getIndex()
 bool Channel::isOutput()
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return iio_channel_is_output(m_channel);
 }
@@ -96,7 +96,7 @@ bool Channel::isOutput()
 bool Channel::isEnabled()
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return iio_channel_is_enabled(m_channel);
 }
@@ -104,7 +104,7 @@ bool Channel::isEnabled()
 bool Channel::hasAttribute(std::string attr)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	if (iio_channel_find_attr(m_channel, attr.c_str()) != NULL) {
 		return true;
@@ -115,7 +115,7 @@ bool Channel::hasAttribute(std::string attr)
 void Channel::enableChannel(bool enable)
 {
 	if (!m_channel) {
-		throw_exception(EXC_OUT_OF_RANGE, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	if (enable) {
@@ -139,7 +139,7 @@ void* Channel::getFirstVoid(iio_buffer *buffer)
 void Channel::write(struct iio_buffer* buffer, std::vector<short> const &data)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	size_t size = data.size();
@@ -147,14 +147,14 @@ void Channel::write(struct iio_buffer* buffer, std::vector<short> const &data)
 				       size * sizeof(short));
 
 	if (ret == 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write; result is 0 bytes");
+		throw_exception(m2k_exception::make("Channel: could not write; result is 0 bytes").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 void Channel::write(struct iio_buffer* buffer, std::vector<unsigned short> const &data)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	size_t size = data.size();
@@ -162,14 +162,14 @@ void Channel::write(struct iio_buffer* buffer, std::vector<unsigned short> const
 				       size * sizeof(unsigned short));
 
 	if (ret == 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write; result is 0 bytes");
+		throw_exception(m2k_exception::make("Channel: could not write; result is 0 bytes").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 void Channel::write(struct iio_buffer* buffer, std::vector<double> const &data)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	size_t size = data.size();
@@ -177,56 +177,56 @@ void Channel::write(struct iio_buffer* buffer, std::vector<double> const &data)
 				       size * sizeof(double));
 
 	if (ret == 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write; result is 0 bytes");
+		throw_exception(m2k_exception::make("Channel: could not write; result is 0 bytes").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 void Channel::write(struct iio_buffer* buffer, double *data, unsigned int nb_samples)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Can not find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	size_t ret = iio_channel_write(m_channel, buffer, data,
 				       nb_samples * sizeof(double));
 
 	if (ret == 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: could not write; result is 0 bytes");
+		throw_exception(m2k_exception::make("Channel: could not write; result is 0 bytes").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 void Channel::write(struct iio_buffer* buffer, short *data, unsigned int nb_samples)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Can not find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	size_t ret = iio_channel_write(m_channel, buffer, data,
 				       nb_samples * sizeof(short));
 
 	if (ret == 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: could not write; result is 0 bytes");
+		throw_exception(m2k_exception::make("Channel: could not write; result is 0 bytes").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 void Channel::write(struct iio_buffer* buffer, unsigned short *data, unsigned int nb_samples)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Can not find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	size_t ret = iio_channel_write(m_channel, buffer, data,
 				       nb_samples * sizeof(unsigned short));
 
 	if (ret == 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: could not write; result is 0 bytes");
+		throw_exception(m2k_exception::make("Channel: could not write; result is 0 bytes").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 void Channel::convert(int16_t *avg, int16_t *src)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	iio_channel_convert(m_channel, (void *)avg, (const void *)src);
 }
@@ -234,7 +234,7 @@ void Channel::convert(int16_t *avg, int16_t *src)
 void Channel::convert(double *avg, int16_t *src)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	iio_channel_convert(m_channel, (void *)avg, (const void *)src);
 }
@@ -242,12 +242,12 @@ void Channel::convert(double *avg, int16_t *src)
 double Channel::getDoubleValue(std::string attr)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	double value = 0.0;
 	int ret = iio_channel_attr_read_double(m_channel, attr.c_str(), &value);
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot read " + attr);
+		throw_exception(m2k_exception::make( "Channel: Cannot read " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 	return value;
 }
@@ -255,34 +255,34 @@ double Channel::getDoubleValue(std::string attr)
 void Channel::setDoubleValue(std::string attr, double val)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	int ret = iio_channel_attr_write_double(m_channel, attr.c_str(), val);
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 }
 
 void Channel::setLongValue(std::string attr, long long val)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	int ret = iio_channel_attr_write_longlong(m_channel, attr.c_str(), val);
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 }
 
 long long Channel::getLongValue(std::string attr)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	long long value = 0;
 	int ret = iio_channel_attr_read_longlong(m_channel, attr.c_str(), &value);
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 	return value;
 }
@@ -290,23 +290,23 @@ long long Channel::getLongValue(std::string attr)
 void Channel::setStringValue(std::string attr, std::string val)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	int ret = iio_channel_attr_write(m_channel, attr.c_str(), val.c_str());
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 }
 
 std::string Channel::getStringValue(std::string attr)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	char value[1024];
 	int ret = iio_channel_attr_read(m_channel, attr.c_str(), value, sizeof(value));
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 	return std::string(value);
 }
@@ -314,23 +314,23 @@ std::string Channel::getStringValue(std::string attr)
 void Channel::setBoolValue(std::string attr, bool val)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	int ret = iio_channel_attr_write_bool(m_channel, attr.c_str(), val);
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 }
 
 bool Channel::getBoolValue(std::string attr)
 {
 	if (!m_channel) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot find associated channel");
+		throw_exception(m2k_exception::make("Channel: Cannot find associated channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	bool value;
 	int ret = iio_channel_attr_read_bool(m_channel, attr.c_str(), &value);
 	if (ret < 0) {
-		throw_exception(EXC_INVALID_PARAMETER, "Channel: Cannot write " + attr);
+		throw_exception(m2k_exception::make("Channel: Cannot write " + attr).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 	return value;
 }

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -45,7 +45,7 @@ DeviceGeneric::DeviceGeneric(struct iio_context* context, std::string dev_name)
 	if (dev_name != "") {
 		m_dev = iio_context_find_device(context, dev_name.c_str());
 		if (!m_dev) {
-			throw_exception(EXC_INVALID_PARAMETER, "Device: No such device");
+			throw_exception(m2k_exception::make("Device: No such device").type(libm2k::EXC_INVALID_PARAMETER).build());
 		}
 
 		__try {
@@ -112,7 +112,7 @@ Channel* DeviceGeneric::getChannel(unsigned int chnIdx, bool output)
 		return m_channel_list_in.at(chnIdx);
 	}
 error:
-	throw_exception(EXC_OUT_OF_RANGE, "Device: No such channel: " + to_string(chnIdx));
+	throw_exception(m2k_exception::make("Device: No such channel: " + to_string(chnIdx)).type(libm2k::EXC_OUT_OF_RANGE).build());
 	return nullptr;
 }
 
@@ -153,7 +153,7 @@ bool DeviceGeneric::isChannelEnabled(unsigned int chnIdx, bool output)
 string DeviceGeneric::getName()
 {
 	if (!m_dev) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: No available device");
+		throw_exception(m2k_exception::make("Device: No available device").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return iio_device_get_name(m_dev);
 }
@@ -167,8 +167,8 @@ double DeviceGeneric::getDoubleValue(std::string attr)
 		iio_device_attr_read_double(m_dev, attr.c_str(),
 					    &value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return value;
 }
@@ -179,13 +179,14 @@ double DeviceGeneric::getDoubleValue(unsigned int chn_idx, std::string attr, boo
 	std::string dev_name = getName();
 
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no such channel");
+		throw_exception(m2k_exception::make(dev_name + " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
+
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	return chn->getDoubleValue(attr);
@@ -198,8 +199,8 @@ double DeviceGeneric::setDoubleValue(double value, std::string attr)
 		iio_device_attr_write_double(m_dev, attr.c_str(),
 					     value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return getDoubleValue(attr);
 }
@@ -209,15 +210,15 @@ double DeviceGeneric::setDoubleValue(unsigned int chn_idx, double value, std::st
 	unsigned int nb_channels = iio_device_get_channels_count(m_dev);
 	std::string dev_name = getName();
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no such channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	chn->setDoubleValue(attr, value);
@@ -233,8 +234,8 @@ int DeviceGeneric::getLongValue(std::string attr)
 		iio_device_attr_read_longlong(m_dev, attr.c_str(),
 					      &value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return value;
 }
@@ -245,13 +246,13 @@ int DeviceGeneric::getLongValue(unsigned int chn_idx, std::string attr, bool out
 	std::string dev_name = getName();
 
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no such channel");
+		throw_exception(m2k_exception::make( dev_name + " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	return chn->getLongValue(attr);
@@ -266,8 +267,8 @@ int DeviceGeneric::getBufferLongValue(std::string attr)
 		iio_device_buffer_attr_read_longlong(m_dev, attr.c_str(),
 						     &value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return value;
 }
@@ -279,8 +280,8 @@ int DeviceGeneric::setLongValue(int value, std::string attr)
 		iio_device_attr_write_longlong(m_dev, attr.c_str(),
 					       value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return getLongValue(attr);
 }
@@ -290,15 +291,15 @@ int DeviceGeneric::setLongValue(unsigned int chn_idx, int value, std::string att
 	unsigned int nb_channels = iio_device_get_channels_count(m_dev);
 	std::string dev_name = getName();
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no such channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	chn->setLongValue(attr, value);
@@ -312,8 +313,8 @@ int DeviceGeneric::setBufferLongValue(int value, std::string attr)
 		iio_device_buffer_attr_write_longlong(m_dev, attr.c_str(),
 						      value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " +
-				attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " +
+						    attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return getLongValue(attr);
 }
@@ -327,8 +328,8 @@ bool DeviceGeneric::getBoolValue(string attr)
 		iio_device_attr_read_bool(m_dev, attr.c_str(),
 					  &value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return value;
 }
@@ -339,15 +340,15 @@ bool DeviceGeneric::getBoolValue(unsigned int chn_idx, string attr, bool output)
 	std::string dev_name = getName();
 
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no such channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	return chn->getBoolValue(attr);
@@ -359,9 +360,9 @@ bool DeviceGeneric::setBoolValue(bool value, string attr)
 	if (ContextImpl::iioDevHasAttribute(m_dev, attr)) {
 		iio_device_attr_write_bool(m_dev, attr.c_str(), value);
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return getBoolValue(attr);
 }
@@ -371,15 +372,15 @@ bool DeviceGeneric::setBoolValue(unsigned int chn_idx, bool value, string attr, 
 	unsigned int nb_channels = iio_device_get_channels_count(m_dev);
 	std::string dev_name = getName();
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no such channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	chn->setBoolValue(attr, value);
@@ -392,8 +393,8 @@ string DeviceGeneric::setStringValue(string attr, string value)
 	if (ContextImpl::iioDevHasAttribute(m_dev, attr)) {
 		iio_device_attr_write(m_dev, attr.c_str(), value.c_str());
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return getStringValue(attr);
 }
@@ -403,15 +404,15 @@ string DeviceGeneric::setStringValue(unsigned int chn_idx, string attr, string v
 	unsigned int nb_channels = iio_device_get_channels_count(m_dev);
 	std::string dev_name = getName();
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no such channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	chn->setStringValue(attr, value);
@@ -427,8 +428,9 @@ string DeviceGeneric::getStringValue(string attr)
 		iio_device_attr_read(m_dev, attr.c_str(),
 				     value, sizeof(value));
 	} else {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
+
 	}
 	return std::string(value);
 }
@@ -439,15 +441,15 @@ string DeviceGeneric::getStringValue(unsigned int chn_idx, string attr, bool out
 	std::string dev_name = getName();
 
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no such channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-				" has no " + attr +
-				" attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 
 	return chn->getStringValue(attr);
@@ -461,7 +463,7 @@ std::vector<std::string> DeviceGeneric::getAvailableAttributeValues(const string
 
 	dev_name = getName();
 	if (!ContextImpl::iioDevHasAttribute(m_dev, attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no " + attr + " attribute");
+		throw_exception(m2k_exception::make(dev_name + " has no " + attr + " attribute").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return std::vector<std::string>();
 	}
 
@@ -485,15 +487,15 @@ std::vector<std::string> DeviceGeneric::getAvailableAttributeValues(unsigned int
 	dev_name = getName();
 
 	if (chn_idx >= nb_channels) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name + " has no such channel");
+		throw_exception(m2k_exception::make(dev_name + " has no such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 		return std::vector<std::string>();
 	}
 
 	auto chn = getChannel(chn_idx, output);
 	if (!chn->hasAttribute(attr)) {
-		throw_exception(EXC_INVALID_PARAMETER, dev_name +
-						       " has no " + attr +
-						       " attribute for the selected channel");
+		throw_exception(m2k_exception::make(dev_name +
+						    " has no " + attr +
+						    " attribute for the selected channel").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return std::vector<std::string>();
 	}
 	return chn->getAvailableAttributeValues(attr);
@@ -503,8 +505,8 @@ void DeviceGeneric::writeRegister(uint32_t address, uint32_t value)
 {
 	int ret = iio_device_reg_write(m_dev, address, value);
 	if (ret) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: can't write register" +
-				std::string(std::strerror(-ret)));
+		throw_exception(m2k_exception::make("Device: can't write register" +
+						    std::string(std::strerror(-ret))).type(libm2k::EXC_INVALID_PARAMETER).iioCode(ret).build());
 	}
 }
 
@@ -542,7 +544,7 @@ void DeviceGeneric::convertChannelHostFormat(unsigned int chn_idx, int16_t *avg,
 	if (chn_idx < tmp.size()) {
 		tmp.at(chn_idx)->convert(avg, src);
 	} else {
-		throw_exception(EXC_OUT_OF_RANGE, "Device: No such channel");
+		throw_exception(m2k_exception::make("Device: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 }
 
@@ -552,14 +554,14 @@ void DeviceGeneric::convertChannelHostFormat(unsigned int chn_idx, double *avg, 
 	if (chn_idx < tmp.size()) {
 		tmp.at(chn_idx)->convert(avg, src);
 	} else {
-		throw_exception(EXC_OUT_OF_RANGE, "Device: No such channel");
+		throw_exception(m2k_exception::make("Device: No such channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 }
 
 void DeviceGeneric::setKernelBuffersCount(unsigned int count)
 {
 	if (!m_dev) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: no such device");
+		throw_exception(m2k_exception::make("Device: no such device").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	iio_device_set_kernel_buffers_count(m_dev, count);
 }
@@ -567,7 +569,7 @@ void DeviceGeneric::setKernelBuffersCount(unsigned int count)
 bool DeviceGeneric::isValidDmmChannel(unsigned int chnIdx)
 {
 	if (chnIdx >= m_channel_list_in.size()) {
-		throw_exception(EXC_OUT_OF_RANGE, "Device: no such DMM channel");
+		throw_exception(m2k_exception::make("Device: no such DMM channel").type(libm2k::EXC_OUT_OF_RANGE).build());
 	}
 
 	auto chn = m_channel_list_in.at(chnIdx);
@@ -589,8 +591,8 @@ std::pair<string, string> DeviceGeneric::getContextAttr(unsigned int attrIdx)
 	const char *value;
 	int ret = iio_context_get_attr(m_context, attrIdx, &name, &value);
 	if (ret < 0) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Can't get context attribute " +
-				std::to_string(attrIdx));
+		throw_exception(m2k_exception::make("Device: Can't get context attribute " +
+						    std::to_string(attrIdx)).type(libm2k::EXC_RUNTIME_ERROR).iioCode(ret).build());
 	}
 	pair.first = std::string(name);
 	pair.second = std::string(value);

--- a/src/utils/devicein.cpp
+++ b/src/utils/devicein.cpp
@@ -48,7 +48,7 @@ void DeviceIn::initializeBuffer(unsigned int nb_samples)
 void DeviceIn::cancelBuffer()
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: not buffer capable");
+		throw_exception(m2k_exception::make("Device: not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_buffer->cancelBuffer();
 }
@@ -62,7 +62,7 @@ DeviceIn::~DeviceIn()
 std::vector<unsigned short> DeviceIn::getSamplesShort(unsigned int nb_samples)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Cannot refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return std::vector<unsigned short>();
 	}
 	m_buffer->setChannels(m_channel_list);
@@ -73,7 +73,7 @@ std::vector<unsigned short> DeviceIn::getSamplesShort(unsigned int nb_samples)
 const unsigned short* DeviceIn::getSamplesP(unsigned int nb_samples)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 	m_buffer->setChannels(m_channel_list);
@@ -85,7 +85,7 @@ std::vector<std::vector<double> > DeviceIn::getSamples(unsigned int nb_samples,
 						       const std::function<double(int16_t, unsigned int)> &process)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Cannot refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 		std::vector<std::vector<double>>();
 	}
 	m_buffer->setChannels(m_channel_list);
@@ -95,7 +95,7 @@ std::vector<std::vector<double> > DeviceIn::getSamples(unsigned int nb_samples,
 void* DeviceIn::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 	m_buffer->setChannels(m_channel_list);
@@ -106,7 +106,7 @@ const double *DeviceIn::getSamplesInterleaved(unsigned int nb_samples,
 					      const std::function<double(int16_t, unsigned int)> &process)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 	m_buffer->setChannels(m_channel_list);
@@ -117,7 +117,7 @@ void DeviceIn::getSamples(std::vector<std::vector<double> > &data, unsigned int 
 			  const std::function<double(int16_t, unsigned int)> &process)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Cannot refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->getSamples(data, nb_samples, process);
@@ -126,7 +126,7 @@ void DeviceIn::getSamples(std::vector<std::vector<double> > &data, unsigned int 
 void DeviceIn::getSamples(std::vector<unsigned short> &data, unsigned int nb_samples)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Cannot refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->getSamples(data, nb_samples);
@@ -135,7 +135,7 @@ void DeviceIn::getSamples(std::vector<unsigned short> &data, unsigned int nb_sam
 const short *DeviceIn::getSamplesRawInterleaved(unsigned int nb_samples)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 		return nullptr;
 	}
 	m_buffer->setChannels(m_channel_list);
@@ -145,7 +145,7 @@ const short *DeviceIn::getSamplesRawInterleaved(unsigned int nb_samples)
 void DeviceIn::flushBuffer()
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: Can not refill; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot refill; device not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_buffer->flushBuffer();
 }

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -49,7 +49,7 @@ DeviceOut::~DeviceOut()
 void DeviceOut::initializeBuffer(unsigned int size, bool cyclic)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Cannot push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->initializeBuffer(size, cyclic, true);
 }
@@ -58,7 +58,7 @@ void DeviceOut::push(std::vector<short> const &data, unsigned int channel,
 		     bool cyclic, bool multiplex)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Cannot push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->push(data, channel, cyclic, multiplex);
@@ -68,7 +68,7 @@ void DeviceOut::push(std::vector<short> const &data, unsigned int channel,
 void DeviceOut::cancelBuffer()
 {
 	if (!m_buffer) {
-		throw_exception(EXC_INVALID_PARAMETER, "Device: not buffer capable");
+		throw_exception(m2k_exception::make("Device: not buffer capable").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	m_buffer->cancelBuffer();
 }
@@ -78,7 +78,7 @@ void DeviceOut::push(std::vector<unsigned short> const &data, unsigned int chann
 		     bool cyclic, bool multiplex)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Cannot push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->push(data, channel, cyclic, multiplex);
@@ -89,7 +89,7 @@ void DeviceOut::push(unsigned short *data, unsigned int channel, unsigned int nb
 		     bool cyclic, bool multiplex)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Can not push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->push(data, channel, nb_samples, cyclic, multiplex);
@@ -98,7 +98,7 @@ void DeviceOut::push(unsigned short *data, unsigned int channel, unsigned int nb
 void DeviceOut::push(std::vector<double> const &data, unsigned int channel, bool cyclic)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Cannot push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->push(data, channel, cyclic);
@@ -107,7 +107,7 @@ void DeviceOut::push(std::vector<double> const &data, unsigned int channel, bool
 void DeviceOut::push(double *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Can not push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->push(data, channel, nb_samples, cyclic);
@@ -116,7 +116,7 @@ void DeviceOut::push(double *data, unsigned int channel, unsigned int nb_samples
 void DeviceOut::push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic)
 {
 	if (!m_buffer) {
-		throw_exception(EXC_RUNTIME_ERROR, "Device: Can not push; device not buffer capable");
+		throw_exception(m2k_exception::make("Device: Cannot push; device not buffer capable").type(libm2k::EXC_RUNTIME_ERROR).build());
 	}
 	m_buffer->setChannels(m_channel_list);
 	m_buffer->push(data, channel, nb_samples, cyclic);
@@ -133,7 +133,7 @@ void DeviceOut::setKernelBuffersCount(unsigned int count)
 {
 	if (m_dev) {
 		if (iio_device_set_kernel_buffers_count(m_dev, count) != 0) {
-			throw_exception(EXC_RUNTIME_ERROR, "Device: Cannot set the number of kernel buffers");
+			throw_exception(m2k_exception::make("Device: Cannot set the number of kernel buffers").type(libm2k::EXC_RUNTIME_ERROR).build());
 		}
 	}
 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -70,7 +70,7 @@ std::vector<ini_device_struct> Utils::parseIniFile(std::string path)
 				}
 
 			} else {
-				throw_exception(EXC_INVALID_PARAMETER, "Invalid configuration file: " + path);
+				throw_exception(m2k_exception::make("Invalid configuration file: " + path).type(libm2k::EXC_INVALID_PARAMETER).build());
 			}
 		}
 		if (!device.key_val_pairs.empty()) {
@@ -191,7 +191,7 @@ std::string Utils::getFirmwareVersion(struct iio_context *ctx)
 			"fw_version");
 
 	if (!hw_fw_version) {
-		throw_exception(EXC_INVALID_PARAMETER, "Can't determine firmware version.");
+		throw_exception(m2k_exception::make("Can't determine firmware version.").type(libm2k::EXC_INVALID_PARAMETER).build());
 	}
 	return hw_fw_version;
 }


### PR DESCRIPTION
Create a general exception that contains a message, a type and an error code.
These modifications were added because of the necessity of handling different situation depending on the iio error code.

TODO: 
- [x] throw the iio error code for any possible situation 
- [x] verify Scopy compatibility