### PR TITLE
M2kImpl: block the digital/analog interface until started

### DIFF
--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -339,9 +339,11 @@ void M2kImpl::startMixedSignalAcquisition(unsigned int nb_samples)
 		m_trigger->setDigitalSource(SRC_ANALOG_IN);
 	} else if (!hasDigitalTrigger) {
 		// analog trigger
+		m_trigger->setAnalogSource(NO_SOURCE);
 		m_trigger->setDigitalSource(SRC_ANALOG_IN);
 	} else if (!hasAnalogTrigger) {
 		// digital trigger
+		m_trigger->setDigitalSource(SRC_DISABLED);
 		m_trigger->setAnalogSource(SRC_DIGITAL_IN);
 	}
 
@@ -360,6 +362,10 @@ void M2kImpl::startMixedSignalAcquisition(unsigned int nb_samples)
 	if (!hasAnalogTrigger && !hasDigitalTrigger) {
 		m_trigger->setAnalogMode(CHANNEL_1, ALWAYS);
 		m_trigger->setAnalogSource(CHANNEL_1);
+	} else if (!hasDigitalTrigger) {
+		m_trigger->setAnalogSource(analogSource);
+	} else if (!hasAnalogTrigger) {
+		m_trigger->setDigitalSource(digitalSource);
 	}
 }
 


### PR DESCRIPTION
For the case where there is a trigger either on the analog interface or digital interface, we need to disable the triggering interface in order to block the acquisition. When both analog and digital interfaces are started we then release the corresponding trigger. Otherwise there will be a larger delay due to the analog acquisition being started much sooner than the digital acquisition.

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>