### PR TITLE
Calibration: Call stopAcquisition after every getSamplesRaw

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -579,6 +579,7 @@ void M2kAnalogInImpl::setRange(ANALOG_IN_CHANNEL channel, M2K_RANGE range)
 	}
 
 	m_m2k_fabric->setStringValue(channel, "gain", std::string(str_gain_mode));
+	setVerticalOffset(channel,m_adc_hw_vert_offset[channel]);
 	m_trigger->setCalibParameters(channel, getScalingFactor(channel), m_adc_hw_vert_offset.at(channel));
 }
 

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -209,6 +209,8 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 
 	const unsigned int num_samples = 1e5;
 	ch_data = m_m2k_adc->getSamplesRaw(num_samples);
+	m_m2k_adc->stopAcquisition();
+
 	if (ch_data.size() == 0) {
 		return false;
 	}
@@ -254,6 +256,8 @@ bool M2kCalibrationImpl::calibrateADCgain()
 	setCalibrationMode(ADC_REF1);
 
 	ch_data = m_m2k_adc->getSamplesRaw(num_samples);
+	m_m2k_adc->stopAcquisition();
+
 	if (ch_data.size() == 0) {
 		return false;
 	}
@@ -419,6 +423,8 @@ bool M2kCalibrationImpl::fine_tune(size_t span, int16_t centerVal0, int16_t cent
 		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
 		ch_data = m_m2k_adc->getSamplesRaw(num_samples);
+		m_m2k_adc->stopAcquisition();
+
 		if (ch_data.size() == 0) {
 			goto out_cleanup;
 		}
@@ -558,6 +564,8 @@ bool M2kCalibrationImpl::calibrateDACoffset()
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	ch_data = m_m2k_adc->getSamplesRaw(num_samples);
+	m_m2k_adc->stopAcquisition();
+
 	if (ch_data.size() == 0) {
 		return false;
 	}
@@ -627,6 +635,8 @@ bool M2kCalibrationImpl::calibrateDACgain()
 
 	const unsigned int num_samples = 15e4;
 	ch_data = m_m2k_adc->getSamplesRaw(num_samples);
+	m_m2k_adc->stopAcquisition();
+
 	if (ch_data.size() == 0) {
 		return false;
 	}
@@ -687,7 +697,6 @@ bool M2kCalibrationImpl::calibrateADC()
 	updateAdcCorrections();
 	restoreAdcFromCalibMode();
 	m_adc_calibrated = true;
-	m_m2k_adc->stopAcquisition();
 	return true;
 calibration_fail:
 	m_cancel=false;
@@ -728,7 +737,6 @@ bool M2kCalibrationImpl::calibrateDAC()
 	restoreAdcFromCalibMode();
 
 	m_dac_calibrated = true;
-	m_m2k_adc->stopAcquisition();
 	return true;
 calibration_fail:
 	m_cancel=false;

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -84,8 +84,8 @@ private:
 
 	int m_adc_ch0_offset;
 	int m_adc_ch1_offset;
-	int m_adc_ch0_vert_offset;
-	int m_adc_ch1_vert_offset;
+	double m_adc_ch0_vert_offset;
+	double m_adc_ch1_vert_offset;
 	int m_dac_a_ch_offset;
 	int m_dac_b_ch_offset;
 	double m_adc_ch0_gain;


### PR DESCRIPTION
Previously stopAcquisition was only after calibrating ADC and DAC
alltogether. This causes the calibration to use continous buffer values
between calibration steps. ADC read does about 22 reads (one for offset
20 for fine tuning the offset and another one for gain), while DAC
calibration makes use of the ADC to calibrate offset and gain with one
read each. The buffers were continous to some measure due to the kernel
buffer configuration. By stopping the acquistion - we destroy the buffers
and force a reacquistion. This should give out better calibration values.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>