### PR TITLE
Fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     CHERE_INVOKING: 1
 
 cache:
-  - C:\projects\libm2k\deps\glog -> CI\appveyor\install_glog.bat
+  - C:\glog -> CI\appveyor\install_glog.bat
 
 install:
     # Download libiio
@@ -48,6 +48,7 @@ install:
 
 build_script:
     # Download glog
+    - cd c:\
     - C:\projects\libm2k\CI\appveyor\install_glog.bat "Release" "x64"
     - C:\projects\libm2k\CI\appveyor\install_glog.bat "Release" "Win32
 

--- a/bindings/csharp/CMakeLists.txt
+++ b/bindings/csharp/CMakeLists.txt
@@ -66,6 +66,12 @@ include_directories(
 
 add_library(${CSHARP_WRAPPER_DLL} SHARED ${SRC_WRAPPER_FILE})
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+	target_compile_options(${CSHARP_WRAPPER_DLL}
+			PRIVATE
+			-Wno-maybe-uninitialized)
+endif()
+
 target_include_directories(${CSHARP_WRAPPER_DLL} PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 #Link the required dependencies

--- a/bindings/libm2k.i
+++ b/bindings/libm2k.i
@@ -35,6 +35,8 @@
 %ignore getVoltageRawP;
 %rename(pushBytes) push(unsigned short*, unsigned int);
 
+%ignore buildLoggingMessage;
+
 #ifdef SWIGPYTHON
 %typemap(in) short * {
 	if (PyBytes_Check($input))

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -90,6 +90,16 @@ IF (NOT PYTHON_LINK)
 	ENDIF()
 ENDIF()
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+	target_compile_options(_${PROJECT_NAME}
+			PRIVATE
+			-Wno-deprecated-declarations)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+	target_compile_options(_${PROJECT_NAME}
+			PRIVATE
+			-Wno-unused-but-set-variable)
+endif()
+
 target_include_directories(_${PROJECT_NAME} PRIVATE
 	${Python_INCLUDE_DIRS}
 	${CMAKE_SOURCE_DIR}/include)

--- a/examples/analog/stream_test_adc.cpp
+++ b/examples/analog/stream_test_adc.cpp
@@ -156,7 +156,7 @@ void analyze_thread(M2kAnalogIn *ain, unsigned int channel) {
 	int samp_cnt = 0;		// count the samples between zero crossings
 	int prev_samp_cnt = 0;		// the previous count
 	int nb_crossings = 0;
-	double last_sample;
+	double last_sample = 0;
 	bool stable = true;
 
 

--- a/include/libm2k/logger.hpp
+++ b/include/libm2k/logger.hpp
@@ -32,15 +32,15 @@
 #define LIBM2K_ATTRIBUTE_READ "read"
 
 namespace libm2k {
-    static std::string buildLoggingMessage(const std::vector<const char *> &info, const std::string &message)
-    {
-        std::stringstream ss;
-        for (auto val : info) {
-            ss << "[" << val << "]";
+        static const inline std::string buildLoggingMessage(const std::vector<const char *> &info, const std::string &message)
+        {
+                std::stringstream ss;
+                for (auto val : info) {
+                    ss << "[" << val << "]";
+                }
+                ss << " " << message;
+                return ss.str();
         }
-        ss << " " << message;
-        return ss.str();
-    }
 }
 
 #ifdef LIBM2K_ENABLE_LOG

--- a/include/libm2k/m2kexceptions.hpp
+++ b/include/libm2k/m2kexceptions.hpp
@@ -30,7 +30,7 @@
 #include <iostream>
 
 #ifndef UNUSED
-#define UNUSED
+#define UNUSED(VAR) (void)(VAR)
 #endif // UNUSED
 
 #if _EXCEPTIONS || defined(__cpp_exceptions)
@@ -114,7 +114,7 @@ private:
 	m2k_exception m2KException;
 };
 
-static void throw_exception(const m2k_exception &exception)
+static inline void throw_exception(const m2k_exception &exception)
 {
 #if _EXCEPTIONS || defined(__cpp_exceptions)
 	throw exception;

--- a/include/libm2k/m2kexceptions.hpp
+++ b/include/libm2k/m2kexceptions.hpp
@@ -29,6 +29,10 @@
 #include <string>
 #include <iostream>
 
+#ifndef UNUSED
+#define UNUSED
+#endif // UNUSED
+
 #if _EXCEPTIONS || defined(__cpp_exceptions)
 	#define exception_type std::exception
 	#if defined(_MSC_VER) || (__APPLE__)
@@ -115,6 +119,7 @@ static void throw_exception(const m2k_exception &exception)
 #if _EXCEPTIONS || defined(__cpp_exceptions)
 	throw exception;
 #endif
+}
 
 #define THROW_M2K_EXCEPTION_2(m, t) do { \
 	LIBM2K_LOG(ERROR, m); \
@@ -127,8 +132,7 @@ static void throw_exception(const m2k_exception &exception)
 
 
 #define GET_THROW_MACRO(_1, _2, _3, NAME, ...) NAME
-#define THROW_M2K_EXCEPTION(...) GET_THROW_MACRO(__VA_ARGS__, THROW_M2K_EXCEPTION_3, THROW_M2K_EXCEPTION_2)(__VA_ARGS__)
-}
+#define THROW_M2K_EXCEPTION(...) GET_THROW_MACRO(__VA_ARGS__, THROW_M2K_EXCEPTION_3, THROW_M2K_EXCEPTION_2, UNUSED)(__VA_ARGS__)
 }
 
 #endif // M2KEXCEPTIONS_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,22 @@ if (MSVC)
 	add_definitions("/wd4250 /wd4251 /wd4275")
 endif()
 
+if(NOT MSVC)
+	target_compile_options(${PROJECT_NAME}
+			PRIVATE
+			-Wall
+			-Wextra)
+	if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+		target_compile_options(${PROJECT_NAME}
+				PRIVATE
+				-Wreturn-stack-address)
+	elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+		target_compile_options(${PROJECT_NAME}
+				PRIVATE
+				-Wreturn-local-addr)
+	endif()
+endif()
+
 target_include_directories(${PROJECT_NAME}
     PUBLIC
         $<INSTALL_INTERFACE:include>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,9 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE LIBM2K_EXPORTS)
 if (ENABLE_LOG)
 	target_compile_definitions(${PROJECT_NAME} PUBLIC LIBM2K_ENABLE_LOG)
 endif()
+if (MSVC)
+	add_definitions("/wd4250 /wd4251 /wd4275")
+endif()
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC

--- a/src/analog/dmm_impl.cpp
+++ b/src/analog/dmm_impl.cpp
@@ -33,6 +33,7 @@ using namespace libm2k::utils;
 
 DMMImpl::DMMImpl(struct iio_context *ctx, std::string dev, bool sync)
 {
+	UNUSED(sync);
 	m_device_in_list.push_back(new DeviceIn(ctx, dev));
 	m_dev_name = dev;
 	bool output = false;

--- a/src/analog/generic/genericanalogin_impl.cpp
+++ b/src/analog/generic/genericanalogin_impl.cpp
@@ -52,6 +52,7 @@ std::shared_ptr<DeviceIn> GenericAnalogInImpl::getAdcDevice(unsigned int index)
 
 double GenericAnalogInImpl::processSample(int16_t sample, unsigned int channel)
 {
+	UNUSED(channel);
 	return sample;
 }
 
@@ -96,8 +97,10 @@ std::vector<double> GenericAnalogInImpl::getAvailableSampleRates()
 		try {
 			auto value = std::stod(s);
 			return value;
-		} catch (std::exception &e) {
+		} catch (std::exception&) {
 			THROW_M2K_EXCEPTION("Can't determine available sampling frequencies.", libm2k::EXC_RUNTIME_ERROR);
+			return {};
+
 		}
 	});
 	return values;
@@ -114,8 +117,9 @@ std::vector<double> GenericAnalogInImpl::getAvailableSampleRates(unsigned int ch
 		try {
 			auto value = std::stod(s);
 			return value;
-		} catch (std::exception &e) {
+		} catch (std::exception&) {
 			THROW_M2K_EXCEPTION("Can't determine available sampling frequencies.", libm2k::EXC_RUNTIME_ERROR);
+			return {};
 		}
 	});
 	return values;

--- a/src/analog/generic/genericanalogout_impl.cpp
+++ b/src/analog/generic/genericanalogout_impl.cpp
@@ -84,8 +84,9 @@ std::vector<double> GenericAnalogOutImpl::getAvailableSampleRates()
 		try {
 			auto value = std::stod(s);
 			return value;
-		} catch (std::exception &e) {
+		} catch (std::exception&) {
 			THROW_M2K_EXCEPTION("Can't determine available sampling frequencies.", libm2k::EXC_RUNTIME_ERROR);
+			return {};
 		}
 	});
 	return values;

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -23,6 +23,7 @@
 #include <libm2k/m2kexceptions.hpp>
 #include <libm2k/logger.hpp>
 #include <algorithm>
+#include <cstring>
 #include "utils/channel.hpp"
 
 using namespace libm2k;
@@ -491,7 +492,9 @@ std::vector<short> M2kAnalogInImpl::getVoltageRaw()
 const short *M2kAnalogInImpl::getVoltageRawP()
 {
 	std::vector<short> avgs = getVoltageRaw();
-	return avgs.data();
+	auto *values = new short[avgs.size()];
+	std::memcpy(values, avgs.data(), avgs.size() * sizeof(short));
+	return values;
 }
 
 double M2kAnalogInImpl::getVoltage(unsigned int ch)
@@ -556,7 +559,9 @@ std::vector<double> M2kAnalogInImpl::getVoltage()
 const double *M2kAnalogInImpl::getVoltageP()
 {
 	std::vector<double> avgs = getVoltage();
-	return avgs.data();
+	auto *values = new double[avgs.size()];
+	std::memcpy(values, avgs.data(), avgs.size() * sizeof(double));
+	return values;
 }
 
 double M2kAnalogInImpl::getScalingFactor(ANALOG_IN_CHANNEL ch)

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -249,6 +249,7 @@ void M2kAnalogInImpl::handleChannelsEnableState(bool before_refill)
 {
 	if (before_refill) {
 		bool anyChannelEnabled = false;
+		m_channels_enabled.clear();
 		for (unsigned int i = 0; i < getNbChannels(); i++) {
 			bool en  = isChannelEnabled(i);
 			m_channels_enabled.push_back(en);

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -142,7 +142,7 @@ void M2kAnalogInImpl::syncDevice()
 
 void M2kAnalogInImpl::setAdcCalibGain(ANALOG_IN_CHANNEL channel, double gain)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	m_adc_calib_gain.at(channel) = gain;
@@ -151,7 +151,7 @@ void M2kAnalogInImpl::setAdcCalibGain(ANALOG_IN_CHANNEL channel, double gain)
 
 void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int raw_offset)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	const int rawVertOffset = m_adc_hw_offset_raw.at(channel) - m_adc_calib_offset.at(channel);
@@ -443,7 +443,7 @@ short M2kAnalogInImpl::getVoltageRaw(ANALOG_IN_CHANNEL ch)
 	M2K_TRIGGER_MODE mode;
 	bool enabled;
 
-	if (ch >= getNbChannels()) {
+	if (static_cast<unsigned int>(ch) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 		return -1;
 	}
@@ -510,7 +510,7 @@ double M2kAnalogInImpl::getVoltage(ANALOG_IN_CHANNEL ch)
 	M2K_TRIGGER_MODE mode;
 	bool enabled;
 
-	if (ch >= getNbChannels()) {
+	if (static_cast<unsigned int>(ch) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 		return -1;
 	}
@@ -561,7 +561,7 @@ const double *M2kAnalogInImpl::getVoltageP()
 
 double M2kAnalogInImpl::getScalingFactor(ANALOG_IN_CHANNEL ch)
 {
-	if (ch >= getNbChannels()) {
+	if (static_cast<unsigned int>(ch) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	return (0.78 / ((1u << 11u) * 1.3 *
@@ -581,7 +581,7 @@ double M2kAnalogInImpl::getScalingFactor(unsigned int ch)
 
 std::pair<double, double> M2kAnalogInImpl::getHysteresisRange(ANALOG_IN_CHANNEL chn)
 {
-	if (chn >= getNbChannels()) {
+	if (static_cast<unsigned int>(chn) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	std::pair<double, double> m2k_range = getRangeLimits(getRange(chn));
@@ -592,7 +592,7 @@ void M2kAnalogInImpl::setRange(ANALOG_IN_CHANNEL channel, M2K_RANGE range)
 {
 	const char *str_gain_mode;
 
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	m_input_range[channel] = range;
@@ -609,7 +609,7 @@ void M2kAnalogInImpl::setRange(ANALOG_IN_CHANNEL channel, M2K_RANGE range)
 
 void M2kAnalogInImpl::setRange(ANALOG_IN_CHANNEL channel, double min, double max)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	if ((min >= HIGH_MIN) && (max <= HIGH_MAX)) {
@@ -621,7 +621,7 @@ void M2kAnalogInImpl::setRange(ANALOG_IN_CHANNEL channel, double min, double max
 
 M2K_RANGE M2kAnalogInImpl::getRange(ANALOG_IN_CHANNEL channel)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	return m_input_range[channel];
@@ -629,7 +629,7 @@ M2K_RANGE M2kAnalogInImpl::getRange(ANALOG_IN_CHANNEL channel)
 
 M2K_RANGE M2kAnalogInImpl::getRangeDevice(ANALOG_IN_CHANNEL channel)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	M2K_RANGE range = PLUS_MINUS_25V;
@@ -668,7 +668,7 @@ std::vector<std::pair<std::string, std::pair<double, double>>> M2kAnalogInImpl::
 
 void M2kAnalogInImpl::setVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	int raw_vert_offset = convertVoltsToRawVerticalOffset(channel, vertOffset);
@@ -680,7 +680,7 @@ void M2kAnalogInImpl::setVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOf
 
 double M2kAnalogInImpl::getVerticalOffset(ANALOG_IN_CHANNEL channel)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	return m_adc_hw_vert_offset.at(channel);
@@ -774,9 +774,10 @@ std::vector<double> M2kAnalogInImpl::getAvailableSampleRates()
 		try {
 			auto value = std::stod(s);
 			return value;
-		} catch (std::exception &e) {
-			THROW_M2K_EXCEPTION("Can't determine available sampling frequencies.", libm2k::EXC_RUNTIME_ERROR);
-		}
+		} catch (std::exception&) {
+            THROW_M2K_EXCEPTION("Can't determine available sampling frequencies.", libm2k::EXC_RUNTIME_ERROR);
+            return {};
+        }
 	});
 	return values;
 }
@@ -802,9 +803,9 @@ void M2kAnalogInImpl::convertChannelHostFormat(unsigned int chn_idx, double *avg
 	m_m2k_adc->convertChannelHostFormat(chn_idx, avg, src, false);
 }
 
-const int M2kAnalogInImpl::convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset)
+int M2kAnalogInImpl::convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	double gain = 1.3;
@@ -813,9 +814,9 @@ const int M2kAnalogInImpl::convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL cha
         return static_cast<int>(vertOffset * (1u << 12u) * hw_range_gain * gain / 2.693 / vref);
 }
 
-const double M2kAnalogInImpl::convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset)
+double M2kAnalogInImpl::convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	double gain = 1.3;
@@ -826,7 +827,7 @@ const double M2kAnalogInImpl::convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL 
 
 int M2kAnalogInImpl::getRawVerticalOffset(ANALOG_IN_CHANNEL channel)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	return m_adc_hw_offset_raw.at(channel) - m_adc_calib_offset.at(channel);
@@ -834,7 +835,7 @@ int M2kAnalogInImpl::getRawVerticalOffset(ANALOG_IN_CHANNEL channel)
 
 void M2kAnalogInImpl::setRawVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	double vertOffset = convertRawToVoltsVerticalOffset(channel, rawVertOffset);
@@ -846,7 +847,7 @@ void M2kAnalogInImpl::setRawVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVer
 
 void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset, int vert_offset)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	double vertOffset = convertRawToVoltsVerticalOffset(channel, vert_offset);
@@ -864,15 +865,34 @@ void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_off
 	m_trigger->setCalibParameters(channel, getScalingFactor(channel), m_adc_hw_vert_offset.at(channel));
 }
 
+void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset, double vert_offset)
+{
+    if (static_cast<unsigned int>(channel) >= getNbChannels()) {
+        THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
+    }
+    m_adc_hw_vert_offset.at(channel) = vert_offset;
+
+    if (m_calibbias_available) {
+        m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, calib_offset, "calibbias", false);
+    } else {
+        m_adc_calib_offset.at(channel) = calib_offset;
+    }
+
+    const int hw_offset_raw = convertVoltsToRaw(channel, vert_offset) + m_adc_calib_offset.at(channel);
+    m_adc_hw_offset_raw.at(channel) = m_ad5625_dev->setLongValue(channel + 2, hw_offset_raw, "raw", true);
+
+    m_trigger->setCalibParameters(channel, getScalingFactor(channel), m_adc_hw_vert_offset.at(channel));
+}
+
 int M2kAnalogInImpl::getAdcCalibOffset(ANALOG_IN_CHANNEL channel)
 {
-	if (channel >= getNbChannels()) {
+	if (static_cast<unsigned int>(channel) >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	if (m_calibbias_available) {
 		return m_m2k_adc->getLongValue(channel, "calibbias", false);
 	} else {
 		auto adc_hw_offset = m_ad5625_dev->getLongValue(channel + 2, "raw", true);
-		return (adc_hw_offset - m_adc_hw_vert_offset.at(channel));
+		return (adc_hw_offset - convertVoltsToRawVerticalOffset(channel, m_adc_hw_vert_offset.at(channel)));
 	}
 }

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -81,8 +81,18 @@ public:
 
 	std::pair<double, double> getHysteresisRange(ANALOG_IN_CHANNEL chn) override;
 
+	/**
+	 * The calibration offset is store in the same register with the vertical offset as a sum (CalibOff + VertOff)
+	 * The calibration offset is always represented as an integer raw value
+	 * The vertical offset is store as an integer raw value, but it can be converted to a voltage representation
+	 * There are several ways to set these coefficients
+	 * */
+	 // set the calibration offset - use the current vertical offset
 	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset);
+	// set both the calibration offset and the vertical offset (raw value)
 	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset, int vert_offset);
+	// set both the calibration offset and the vertical offset (value in volts)
+	void setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_offset, double vert_offset);
 
 	double setCalibscale(unsigned int index, double calibscale);
 	double getCalibscale(unsigned int index);
@@ -161,8 +171,8 @@ private:
 
 	double processSample(int16_t sample, unsigned int channel);
 
-	const int convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset);
-	const double convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset);
+	int convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset);
+	double convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset);
 };
 }
 }

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -118,9 +118,9 @@ public:
 
 	void cancelAcquisition() override;
 
-	void getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples);
+	void getSamples(std::vector<std::vector<double> > &data, unsigned int nb_samples) override;
 
-	std::string getChannelName(unsigned int channel);
+	std::string getChannelName(unsigned int channel) override;
 	double getMaximumSamplerate() override;
 
 	void deinitialize();

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -595,8 +595,9 @@ std::vector<double> M2kAnalogOutImpl::getAvailableSampleRates(unsigned int chnId
 		try {
 			auto value = std::stod(s);
 			return value;
-		} catch (std::exception &e) {
+		} catch (std::exception&) {
 			THROW_M2K_EXCEPTION("Can't determine available sampling frequencies.", libm2k::EXC_RUNTIME_ERROR);
+			return {};
 		}
 	});
 	return values;

--- a/src/analog/m2kanalogout_impl.hpp
+++ b/src/analog/m2kanalogout_impl.hpp
@@ -24,68 +24,68 @@ public:
 	M2kAnalogOutImpl(struct iio_context*, std::vector<std::string> dac_devs, bool sync);
 	virtual ~M2kAnalogOutImpl();
 
-	void reset();
-	std::vector<int> getOversamplingRatio();
+	void reset() override;
+	std::vector<int> getOversamplingRatio() override;
 
-	int getOversamplingRatio(unsigned int chn);
-	std::vector<int> setOversamplingRatio(std::vector<int> oversampling_ratio);
-	int setOversamplingRatio(unsigned int chn, int oversampling_ratio);
+	int getOversamplingRatio(unsigned int chn) override;
+	std::vector<int> setOversamplingRatio(std::vector<int> oversampling_ratio) override;
+	int setOversamplingRatio(unsigned int chn, int oversampling_ratio) override;
 
-	std::vector<double> getSampleRate();
-	double getSampleRate(unsigned int chn);
-	std::vector<double> getAvailableSampleRates(unsigned int chn);
-	std::vector<double> setSampleRate(std::vector<double> samplerates);
-	double setSampleRate(unsigned int chn, double samplerate);
+	std::vector<double> getSampleRate() override;
+	double getSampleRate(unsigned int chn) override;
+	std::vector<double> getAvailableSampleRates(unsigned int chn) override;
+	std::vector<double> setSampleRate(std::vector<double> samplerates) override;
+	double setSampleRate(unsigned int chn, double samplerate) override;
 
-	void setSyncedDma(bool en, int chn = -1);
-	bool getSyncedDma(int chn = -1);
-	void setSyncedStartDma(bool en, int chn = -1);
-	bool getSyncedStartDma(int chn = -1);
+	void setSyncedDma(bool en, int chn = -1) override;
+	bool getSyncedDma(int chn = -1) override;
+	void setSyncedStartDma(bool en, int chn = -1) override;
+	bool getSyncedStartDma(int chn = -1) override;
 
-	void setCyclic(bool en);
-	void setCyclic(unsigned int chn, bool en);
-	bool getCyclic(unsigned int chn);
+	void setCyclic(bool en) override;
+	void setCyclic(unsigned int chn, bool en) override;
+	bool getCyclic(unsigned int chn) override;
 
 	double setCalibscale(unsigned int index, double calibscale);
 	double getCalibscale(unsigned int index);
 
-	double getScalingFactor(unsigned int chn);
+	double getScalingFactor(unsigned int chn) override;
 
-	double getFilterCompensation(double samplerate);
+	double getFilterCompensation(double samplerate) override;
 
 	short convVoltsToRaw(double voltage, double vlsb, double filterCompensation);
 
-	void pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples);
-	void pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples);
+	void pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples) override;
+	void pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples) override;
 
-	void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples);
-	void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples);
+	void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples) override;
+	void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples) override;
 
 	void setDacCalibVlsb(unsigned int chn, double vlsb);
 
-	void push(unsigned int chnIdx, std::vector<double> const &data);
-	void pushRaw(unsigned int chnIdx, std::vector<short> const &data);
-	void push(std::vector<std::vector<double>> const &data);
-	void pushRaw(std::vector<std::vector<short>> const &data);
+	void push(unsigned int chnIdx, std::vector<double> const &data) override;
+	void pushRaw(unsigned int chnIdx, std::vector<short> const &data) override;
+	void push(std::vector<std::vector<double>> const &data) override;
+	void pushRaw(std::vector<std::vector<short>> const &data) override;
 
-	void stop();
-	void stop(unsigned int chn);
+	void stop() override;
+	void stop(unsigned int chn) override;
 
-	void enableChannel(unsigned int chnIdx, bool enable);
-	bool isChannelEnabled(unsigned int chnIdx);
+	void enableChannel(unsigned int chnIdx, bool enable) override;
+	bool isChannelEnabled(unsigned int chnIdx) override;
 
-	void setKernelBuffersCount(unsigned int chnIdx, unsigned int count);
+	void setKernelBuffersCount(unsigned int chnIdx, unsigned int count) override;
 
-	short convertVoltsToRaw(unsigned int channel, double voltage);
-	double convertRawToVolts(unsigned int channel, short raw);
+	short convertVoltsToRaw(unsigned int channel, double voltage) override;
+	double convertRawToVolts(unsigned int channel, short raw) override;
 
-	struct IIO_OBJECTS getIioObjects();
+	struct IIO_OBJECTS getIioObjects() override;
 
-	void cancelBuffer();
-	void cancelBuffer(unsigned int chn);
+	void cancelBuffer() override;
+	void cancelBuffer(unsigned int chn) override;
 
-	unsigned int getNbChannels();
-	std::string getChannelName(unsigned int channel);
+	unsigned int getNbChannels() override;
+	std::string getChannelName(unsigned int channel) override;
 	double getMaximumSamplerate(unsigned int chn_idx) override;
 	void deinitialize();
 private:

--- a/src/analog/m2kpowersupply_impl.cpp
+++ b/src/analog/m2kpowersupply_impl.cpp
@@ -215,7 +215,7 @@ double M2kPowerSupplyImpl::getCalibrationCoefficient(std::string key)
 
 void M2kPowerSupplyImpl::enableAll(bool en)
 {
-
+	UNUSED(en);
 }
 
 double M2kPowerSupplyImpl::readChannel(unsigned int idx)

--- a/src/context_impl.cpp
+++ b/src/context_impl.cpp
@@ -36,6 +36,7 @@ using namespace libm2k::utils;
 
 ContextImpl::ContextImpl(std::string uri, struct iio_context *ctx, std::string name, bool sync)
 {
+	UNUSED(name);
 	m_context = ctx;
 	m_uri = uri;
 	m_sync = sync;

--- a/src/context_impl.hpp
+++ b/src/context_impl.hpp
@@ -57,39 +57,39 @@ class M2k;
 class ContextImpl : public virtual Context {
 public:
 	ContextImpl(std::string uri, struct iio_context*, std::string name, bool sync);
-	~ContextImpl();
+	~ContextImpl() override;
 
-	void reset();
-	void deinitialize();
+	void reset() override;
+	void deinitialize() override;
 
 	void scanAllDMM();
 
-	std::string getUri();
+	std::string getUri() override;
 
-	libm2k::analog::DMM* getDMM(unsigned int);
-	libm2k::analog::DMM* getDMM(std::string);
-	std::vector<libm2k::analog::DMM*> getAllDmm();
+	libm2k::analog::DMM* getDMM(unsigned int) override;
+	libm2k::analog::DMM* getDMM(std::string) override;
+	std::vector<libm2k::analog::DMM*> getAllDmm() override;
 
-	std::vector<std::string> getAvailableContextAttributes();
-	std::string getContextAttributeValue(std::string attr);
-	std::string getContextDescription();
-	std::string getSerialNumber();
-	std::unordered_set<std::string> getAllDevices() const;
+	std::vector<std::string> getAvailableContextAttributes() override;
+	std::string getContextAttributeValue(std::string attr) override;
+	std::string getContextDescription() override;
+	std::string getSerialNumber() override;
+	std::unordered_set<std::string> getAllDevices() const override;
 	void logAllAttributes() const override;
 
-	libm2k::context::M2k* toM2k();
-	libm2k::context::Generic* toGeneric();
-	libm2k::context::Lidar* toLidar();
+	libm2k::context::M2k* toM2k() override;
+	libm2k::context::Generic* toGeneric() override;
+	libm2k::context::Lidar* toLidar() override;
 
 	static bool iioChannelHasAttribute(iio_channel *chn, const std::string &attr);
 	static bool iioDevHasAttribute(iio_device *dev, const std::string &attr);
 	static bool iioDevBufferHasAttribute(iio_device *dev, const std::string &attr);
 
-	unsigned int getDmmCount();
-	std::string getFirmwareVersion();
+	unsigned int getDmmCount() override;
+	std::string getFirmwareVersion() override;
 	const struct libm2k::IIO_CONTEXT_VERSION getIioContextVersion() override;
 	struct iio_context *getIioContext() override;
-	void setTimeout(unsigned int timeout);
+	void setTimeout(unsigned int timeout) override;
 
 protected:
 	struct iio_context* m_context;

--- a/src/digital/m2kdigital_impl.cpp
+++ b/src/digital/m2kdigital_impl.cpp
@@ -44,7 +44,7 @@ M2kDigitalImpl::M2kDigitalImpl(struct iio_context *ctx, std::string logic_dev, b
 	LIBM2K_LOG(INFO, "[BEGIN] Initialize M2kDigital");
 	__try {
 		m_dev_generic = make_shared<DeviceGeneric>(ctx, logic_dev);
-	} __catch (exception_type &e) {
+	} __catch (exception_type&) {
 		m_dev_generic = nullptr;
 		THROW_M2K_EXCEPTION("M2K Digital: No generic digital device was found.", libm2k::EXC_INVALID_PARAMETER);
 	}
@@ -56,7 +56,7 @@ M2kDigitalImpl::M2kDigitalImpl(struct iio_context *ctx, std::string logic_dev, b
 	if (m_dev_name_write != "") {
 		__try {
 			m_dev_write = make_shared<DeviceOut>(ctx, m_dev_name_write);
-		} __catch (exception_type &e) {
+		} __catch (exception_type&) {
 			m_dev_write = nullptr;
 			THROW_M2K_EXCEPTION("M2K Digital: No device was found for writing", libm2k::EXC_INVALID_PARAMETER);
 		}
@@ -65,7 +65,7 @@ M2kDigitalImpl::M2kDigitalImpl(struct iio_context *ctx, std::string logic_dev, b
 	if (m_dev_name_read != "") {
 		__try {
 			m_dev_read = make_shared<DeviceIn>(ctx, m_dev_name_read);
-		} __catch (exception_type &e) {
+		} __catch (exception_type&) {
 			m_dev_read = nullptr;
 			THROW_M2K_EXCEPTION("M2K Digital: No device was found for reading", libm2k::EXC_INVALID_PARAMETER);
 		}
@@ -166,7 +166,7 @@ void M2kDigitalImpl::setDirection(unsigned int index, DIO_DIRECTION dir)
 
 void M2kDigitalImpl::setDirection(DIO_CHANNEL index, DIO_DIRECTION dir)
 {
-	if (index < m_dev_generic->getNbChannels(false)) {
+	if (static_cast<unsigned int>(index) < m_dev_generic->getNbChannels(false)) {
 		std::string dir_str = "";
 		if (dir == 0) {
 			dir_str = "in";
@@ -182,7 +182,7 @@ void M2kDigitalImpl::setDirection(DIO_CHANNEL index, DIO_DIRECTION dir)
 
 DIO_DIRECTION M2kDigitalImpl::getDirection(DIO_CHANNEL index)
 {
-	if (index >= m_dev_generic->getNbChannels(false)) {
+	if (static_cast<unsigned int>(index) >= m_dev_generic->getNbChannels(false)) {
 		THROW_M2K_EXCEPTION("M2kDigital: No such digital channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 
@@ -195,11 +195,10 @@ DIO_DIRECTION M2kDigitalImpl::getDirection(DIO_CHANNEL index)
 
 void M2kDigitalImpl::setValueRaw(DIO_CHANNEL index, DIO_LEVEL level)
 {
-	if (index >= m_dev_generic->getNbChannels(false)) {
+	if (static_cast<unsigned int>(index) >= m_dev_generic->getNbChannels(false)) {
 		THROW_M2K_EXCEPTION("M2kDigital: No such digital channel", libm2k::EXC_OUT_OF_RANGE);
 	}
-	long long val = static_cast<long long>(level);
-	m_dev_generic->setDoubleValue(index, val, "raw");
+	m_dev_generic->setDoubleValue(index, static_cast<double>(level), "raw");
 }
 
 void M2kDigitalImpl::setValueRaw(unsigned int index, DIO_LEVEL level)
@@ -216,11 +215,10 @@ void M2kDigitalImpl::setValueRaw(DIO_CHANNEL index, bool level)
 
 DIO_LEVEL M2kDigitalImpl::getValueRaw(DIO_CHANNEL index)
 {
-	if (index >= m_dev_generic->getNbChannels(false)) {
+	if (static_cast<unsigned int>(index) >= m_dev_generic->getNbChannels(false)) {
 		THROW_M2K_EXCEPTION("M2kDigital: No such digital channel", libm2k::EXC_OUT_OF_RANGE);
 	}
-	long long val;
-	val = m_dev_generic->getDoubleValue(index, "raw");
+	auto val = m_dev_generic->getLongValue(index, "raw");
 	return static_cast<DIO_LEVEL>(val);
 }
 
@@ -320,7 +318,7 @@ void M2kDigitalImpl::enableChannel(unsigned int index, bool enable)
 
 void M2kDigitalImpl::enableChannel(DIO_CHANNEL index, bool enable)
 {
-	if (index < m_dev_write->getNbChannels(true)) {
+	if (static_cast<unsigned int>(index) < m_dev_write->getNbChannels(true)) {
 		m_dev_write->enableChannel(index, enable, true);
 		m_tx_channels_enabled.at(index) = enable;
 	} else {

--- a/src/digital/m2kdigital_impl.hpp
+++ b/src/digital/m2kdigital_impl.hpp
@@ -41,63 +41,63 @@ public:
 	M2kDigitalImpl(struct iio_context* ctx, std::string logic_dev, bool sync, M2kHardwareTrigger *trigger);
 	virtual ~M2kDigitalImpl();
 
-	void reset();
+	void reset() override;
 
-	void setDirection(unsigned short mask);
-	void setDirection(unsigned int index, DIO_DIRECTION dir);
-	void setDirection(unsigned int index, bool dir);
-	void setDirection(DIO_CHANNEL index, bool dir);
-	void setDirection(DIO_CHANNEL index, DIO_DIRECTION dir);
-	DIO_DIRECTION getDirection(DIO_CHANNEL index);
+	void setDirection(unsigned short mask) override;
+	void setDirection(unsigned int index, DIO_DIRECTION dir) override;
+	void setDirection(unsigned int index, bool dir) override;
+	void setDirection(DIO_CHANNEL index, bool dir) override;
+	void setDirection(DIO_CHANNEL index, DIO_DIRECTION dir) override;
+	DIO_DIRECTION getDirection(DIO_CHANNEL index) override;
 
-	void push(std::vector<unsigned short> const &data);
-	void push(unsigned short *data, unsigned int nb_samples);
+	void push(std::vector<unsigned short> const &data) override;
+	void push(unsigned short *data, unsigned int nb_samples) override;
 
-	void setValueRaw(DIO_CHANNEL index, DIO_LEVEL level);
-	void setValueRaw(unsigned int index, DIO_LEVEL level);
-	void setValueRaw(DIO_CHANNEL index, bool level);
-	DIO_LEVEL getValueRaw(DIO_CHANNEL index);
-	DIO_LEVEL getValueRaw(unsigned int index);
+	void setValueRaw(DIO_CHANNEL index, DIO_LEVEL level) override;
+	void setValueRaw(unsigned int index, DIO_LEVEL level) override;
+	void setValueRaw(DIO_CHANNEL index, bool level) override;
+	DIO_LEVEL getValueRaw(DIO_CHANNEL index) override;
+	DIO_LEVEL getValueRaw(unsigned int index) override;
 
-	void stopBufferOut();
+	void stopBufferOut() override;
 	void startAcquisition(unsigned int nb_samples) override;
-	void stopAcquisition();
+	void stopAcquisition() override;
 
-	std::vector<unsigned short> getSamples(unsigned int nb_samples);
-	const unsigned short *getSamplesP(unsigned int nb_samples);
+	std::vector<unsigned short> getSamples(unsigned int nb_samples) override;
+	const unsigned short *getSamplesP(unsigned int nb_samples) override;
 
-	void enableChannel(unsigned int index, bool enable);
-	void enableChannel(DIO_CHANNEL index, bool enable);
-	void enableAllOut(bool enable);
-	bool anyChannelEnabled(DIO_DIRECTION dir);
+	void enableChannel(unsigned int index, bool enable) override;
+	void enableChannel(DIO_CHANNEL index, bool enable) override;
+	void enableAllOut(bool enable) override;
+	bool anyChannelEnabled(DIO_DIRECTION dir) override;
 
-	void setOutputMode(DIO_CHANNEL chn, DIO_MODE mode);
-	void setOutputMode(unsigned int chn, DIO_MODE mode);
-	DIO_MODE getOutputMode(DIO_CHANNEL chn);
-	DIO_MODE getOutputMode(unsigned int chn);
+	void setOutputMode(DIO_CHANNEL chn, DIO_MODE mode) override;
+	void setOutputMode(unsigned int chn, DIO_MODE mode) override;
+	DIO_MODE getOutputMode(DIO_CHANNEL chn) override;
+	DIO_MODE getOutputMode(unsigned int chn) override;
 
-	double setSampleRateIn(double samplerate);
-	double setSampleRateOut(double samplerate);
-	double getSampleRateIn();
-	double getSampleRateOut();
+	double setSampleRateIn(double samplerate) override;
+	double setSampleRateOut(double samplerate) override;
+	double getSampleRateIn() override;
+	double getSampleRateOut() override;
 
-	bool getCyclic();
-	void setCyclic(bool cyclic);
+	bool getCyclic() override;
+	void setCyclic(bool cyclic) override;
 
-	libm2k::M2kHardwareTrigger* getTrigger();
+	libm2k::M2kHardwareTrigger* getTrigger() override;
 
-	void setKernelBuffersCountIn(unsigned int count);
-	void setKernelBuffersCountOut(unsigned int count);
+	void setKernelBuffersCountIn(unsigned int count) override;
+	void setKernelBuffersCountOut(unsigned int count) override;
 
-	struct IIO_OBJECTS getIioObjects();
+	struct IIO_OBJECTS getIioObjects() override;
 
-	void cancelAcquisition();
-	void cancelBufferOut();
+	void cancelAcquisition() override;
+	void cancelBufferOut() override;
 
-	unsigned int getNbChannelsIn();
-	unsigned int getNbChannelsOut();
+	unsigned int getNbChannelsIn() override;
+	unsigned int getNbChannelsOut() override;
 
-	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples);
+	void getSamples(std::vector<unsigned short> &data, unsigned int nb_samples) override;
 
 	bool hasRateMux();
 	void setRateMux() override;

--- a/src/lidar_impl.cpp
+++ b/src/lidar_impl.cpp
@@ -106,11 +106,11 @@ double LidarImpl::tilt_volts_to_raw_convert(double value, bool inverse) {
 }
 
 void LidarImpl::setApdBias(unsigned int bias) {
-	afe_dev->setLongValue(0, adp_bias_volts_to_raw_convert(bias, false), "raw", true);
+	afe_dev->setLongValue(0, static_cast<long long>(adp_bias_volts_to_raw_convert(bias, false)), "raw", true);
 }
 
 void LidarImpl::setTiltVoltage(unsigned int voltage) {
-	afe_dev->setLongValue(1, tilt_volts_to_raw_convert(voltage, false), "raw", true);
+	afe_dev->setLongValue(1, static_cast<long long>(tilt_volts_to_raw_convert(voltage, false)), "raw", true);
 }
 
 void LidarImpl::laserEnable() {

--- a/src/m2k_impl.hpp
+++ b/src/m2k_impl.hpp
@@ -33,51 +33,53 @@ class M2kCalibration;
 namespace context {
 class M2kImpl : public M2k, public ContextImpl
 {
+
 public:
 	M2kImpl(std::string uri, iio_context* ctx, std::string name, bool sync);
 
-	virtual ~M2kImpl();
-	void reset();
-	void deinitialize();
+	~M2kImpl() override;
+	void reset() override;
+	void deinitialize() override;
 
 	void scanAllAnalogIn();
 	void scanAllAnalogOut();
 	void scanAllPowerSupply();
 	void scanAllDigital();
 
-	bool calibrate();
-	bool calibrateADC();
-	bool calibrateDAC();
-	bool resetCalibration();
+	bool calibrate() override;
+	bool calibrateADC() override;
+	bool calibrateDAC() override;
+	bool resetCalibration() override;
 	double calibrateFromContext() override;
 
-	libm2k::digital::M2kDigital* getDigital();
-	libm2k::analog::M2kPowerSupply* getPowerSupply();
-	libm2k::analog::M2kAnalogIn* getAnalogIn();
-	libm2k::analog::M2kAnalogIn* getAnalogIn(std::string dev_name);
-	libm2k::analog::M2kAnalogOut* getAnalogOut();
-	std::vector<libm2k::analog::M2kAnalogIn*> getAllAnalogIn();
-	std::vector<libm2k::analog::M2kAnalogOut*> getAllAnalogOut();
+	libm2k::digital::M2kDigital* getDigital() override;
+	libm2k::analog::M2kPowerSupply* getPowerSupply() override;
+	libm2k::analog::M2kAnalogIn* getAnalogIn() override;
+	libm2k::analog::M2kAnalogIn* getAnalogIn(std::string dev_name) override;
+	libm2k::analog::M2kAnalogOut* getAnalogOut() override;
+	std::vector<libm2k::analog::M2kAnalogIn*> getAllAnalogIn() override;
+	std::vector<libm2k::analog::M2kAnalogOut*> getAllAnalogOut() override;
 
 	bool hasMixedSignal() override;
 	void startMixedSignalAcquisition(unsigned int nb_samples) override;
 	void stopMixedSignalAcquisition() override;
 
-	int getDacCalibrationOffset(unsigned int chn);
-	double getDacCalibrationGain(unsigned int chn);
-	int getAdcCalibrationOffset(unsigned int chn);
-	double getAdcCalibrationGain(unsigned int chn);
-	void setDacCalibrationOffset(unsigned int chn, int offset);
-	void setDacCalibrationGain(unsigned int chn, double gain);
-	void setAdcCalibrationOffset(unsigned int chn, int offset);
-	void setAdcCalibrationGain(unsigned int chn, double gain);
+	int getDacCalibrationOffset(unsigned int chn) override;
+	double getDacCalibrationGain(unsigned int chn) override;
+	int getAdcCalibrationOffset(unsigned int chn) override;
+	double getAdcCalibrationGain(unsigned int chn) override;
+	void setDacCalibrationOffset(unsigned int chn, int offset) override;
+	void setDacCalibrationGain(unsigned int chn, double gain) override;
+	void setAdcCalibrationOffset(unsigned int chn, int offset) override;
+	void setAdcCalibrationGain(unsigned int chn, double gain) override;
 
 	bool hasContextCalibration() override;
 	std::map<double, std::shared_ptr<struct CALIBRATION_PARAMETERS>> &getLUT() override;
 	bool isCalibrated() override;
 
-	void setLed(bool on);
-	bool getLed();
+	void setLed(bool on) override;
+	bool getLed() override;
+
 
 private:
 	M2kCalibration* m_calibration;

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -209,7 +209,7 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 	// Allow some time for the voltage to settle
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-	const unsigned int num_samples = 1e5;
+	const unsigned int num_samples = 100000u;
 	ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 	m_m2k_adc->stopAcquisition();
 
@@ -217,8 +217,8 @@ bool M2kCalibrationImpl::calibrateADCoffset()
 		return false;
 	}
 
-	int16_t ch0_avg = Utils::average(ch_data.at(0).data(), num_samples);
-	int16_t ch1_avg = Utils::average(ch_data.at(1).data(), num_samples);
+	int16_t ch0_avg = static_cast<int16_t>(Utils::average(ch_data.at(0).data(), num_samples));
+	int16_t ch1_avg = static_cast<int16_t>(Utils::average(ch_data.at(1).data(), num_samples));
 
 	// Convert from raw format to signed raw
 	int16_t tmp;
@@ -246,7 +246,7 @@ bool M2kCalibrationImpl::calibrateADCgain()
 {
 	int16_t tmp;
 	double vref1 = 0.46172;
-	const unsigned int num_samples = 15e4;
+	const unsigned int num_samples = 150000u;
 	double avg0, avg1;
 	bool calibrated = false;
 	std::vector<std::vector<double>> ch_data = {};
@@ -267,13 +267,13 @@ bool M2kCalibrationImpl::calibrateADCgain()
 	avg0 = Utils::average(ch_data.at(0).data(), num_samples);
 	avg1 = Utils::average(ch_data.at(1).data(), num_samples);
 
-	tmp = avg0;
+	tmp = static_cast<int16_t>(avg0);
 	m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_1, &avg0, &tmp);
-	tmp = avg1;
+	tmp = static_cast<int16_t >(avg1);
 	m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_2, &avg1, &tmp);
 
-	avg0 = m_m2k_adc->convRawToVolts(avg0, 1, 1);
-	avg1 = m_m2k_adc->convRawToVolts(avg1, 1, 1);
+	avg0 = m_m2k_adc->convRawToVolts(static_cast<int>(avg0), 1, 1);
+	avg1 = m_m2k_adc->convRawToVolts(static_cast<int>(avg1), 1, 1);
 
 	m_adc_ch0_gain = vref1 / avg0;
 	m_adc_ch1_gain = vref1 / avg1;
@@ -421,8 +421,8 @@ bool M2kCalibrationImpl::fine_tune(size_t span, int16_t centerVal0, int16_t cent
 	unsigned int i, i0 = 0, i1 = 0;
 	bool ret = true;
 
-	offset0 = centerVal0 - span / 2;
-	offset1 = centerVal1 - span / 2;
+	offset0 = centerVal0 - static_cast<int16_t>(span) / 2;
+	offset1 = centerVal1 - static_cast<int16_t>(span) / 2;
 	for (i = 0; i < span + 1; i++) {
 		candidateOffsets0[i] = offset0;
 		candidateOffsets1[i] = offset1;
@@ -481,7 +481,7 @@ int M2kCalibrationImpl::getDacOffset(unsigned int channel)
 		THROW_M2K_EXCEPTION("No such DAC channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 
-	double offset = m_ad5625_dev->getDoubleValue(channel, "raw", true);
+	int offset = m_ad5625_dev->getLongValue(channel, "raw", true);
 	if (channel == 0) {
 		m_dac_a_ch_offset = offset;
 	} else {
@@ -538,7 +538,7 @@ bool M2kCalibrationImpl::calibrateDACoffset()
 {
 	int16_t tmp;
 	bool calibrated = false;
-	const unsigned int num_samples = 1e5;
+	const unsigned int num_samples = 100000u;
 	std::vector<std::vector<double>> ch_data = {};
 
 	if (!m_initialized) {
@@ -582,8 +582,8 @@ bool M2kCalibrationImpl::calibrateDACoffset()
 		return false;
 	}
 
-	int16_t ch0_avg = Utils::average(ch_data.at(0).data(), num_samples);
-	int16_t ch1_avg = Utils::average(ch_data.at(1).data(), num_samples);
+	int16_t ch0_avg = static_cast<int16_t>(Utils::average(ch_data.at(0).data(), num_samples));
+	int16_t ch1_avg = static_cast<int16_t>(Utils::average(ch_data.at(1).data(), num_samples));
 
 	tmp = ch0_avg;
 	m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_1, &ch0_avg, &tmp);
@@ -645,7 +645,7 @@ bool M2kCalibrationImpl::calibrateDACgain()
 	// Allow some time for the voltage to settle
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-	const unsigned int num_samples = 15e4;
+	const unsigned int num_samples = 150000u;
 	ch_data = m_m2k_adc->getSamplesRaw(num_samples);
 	m_m2k_adc->stopAcquisition();
 
@@ -653,8 +653,8 @@ bool M2kCalibrationImpl::calibrateDACgain()
 		return false;
 	}
 
-	int16_t ch0_avg = Utils::average(ch_data.at(0).data(), num_samples);
-	int16_t ch1_avg = Utils::average(ch_data.at(1).data(), num_samples);
+	int16_t ch0_avg = static_cast<int16_t>(Utils::average(ch_data.at(0).data(), num_samples));
+	int16_t ch1_avg = static_cast<int16_t>(Utils::average(ch_data.at(1).data(), num_samples));
 
 	tmp = ch0_avg;
 	m_m2k_adc->convertChannelHostFormat(ANALOG_IN_CHANNEL_1, &ch0_avg, &tmp);

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -101,11 +101,11 @@ private:
 	M2K_TRIGGER_MODE m_trigger1_mode;
 	M2K_TRIGGER_SOURCE_ANALOG m_trigger_src;
 	double adc_sampl_freq;
-	double adc_oversampl;
+	int adc_oversampl;
 	double dac_a_sampl_freq;
-	double dac_a_oversampl;
+	int dac_a_oversampl;
 	double dac_b_sampl_freq;
-	double dac_b_oversampl;
+	int dac_b_oversampl;
 
 	bool m_adc_calibrated;
 	bool m_dac_calibrated;

--- a/src/m2khardwaretrigger_impl.cpp
+++ b/src/m2khardwaretrigger_impl.cpp
@@ -344,7 +344,7 @@ void M2kHardwareTriggerImpl::setAnalogLevel(unsigned int chnIdx, double v_level)
 		THROW_M2K_EXCEPTION("Channel index is out of range", libm2k::EXC_OUT_OF_RANGE);
 	}
 
-	int raw = (v_level + m_offset.at(chnIdx)) / m_scaling.at(chnIdx);
+	int raw = static_cast<int>((v_level + m_offset.at(chnIdx)) / m_scaling.at(chnIdx));
 	setAnalogLevelRaw(chnIdx, raw);
 }
 
@@ -364,7 +364,7 @@ void M2kHardwareTriggerImpl::setAnalogHysteresis(unsigned int chnIdx, double hys
 		THROW_M2K_EXCEPTION("Channel index is out of range", libm2k::EXC_OUT_OF_RANGE);
 	}
 
-	int hysteresis_raw = hysteresis / m_scaling.at(chnIdx);
+	int hysteresis_raw = static_cast<int>(hysteresis / m_scaling.at(chnIdx));
 	m_analog_channels[chnIdx]->setLongValue("trigger_hysteresis", static_cast<long long>(hysteresis_raw));
 }
 
@@ -428,7 +428,7 @@ M2K_TRIGGER_SOURCE_ANALOG M2kHardwareTriggerImpl::getAnalogSource()
 
 void M2kHardwareTriggerImpl::setAnalogSource(M2K_TRIGGER_SOURCE_ANALOG src)
 {
-	if (src >= m_trigger_source.size()) {
+	if (static_cast<unsigned int>(src) >= m_trigger_source.size()) {
 		THROW_M2K_EXCEPTION("M2kHardwareTrigger: "
 				    "the provided analog source is not supported on "
 				    "the current board; Check the firmware version.", libm2k::EXC_INVALID_PARAMETER);

--- a/src/m2khardwaretrigger_v0.24_impl.cpp
+++ b/src/m2khardwaretrigger_v0.24_impl.cpp
@@ -71,6 +71,7 @@ typedef std::pair<Channel *, std::string> channel_pair;
 M2kHardwareTriggerV024Impl::M2kHardwareTriggerV024Impl(struct iio_context *ctx, bool init) :
 	M2kHardwareTriggerImpl(ctx, "m2k-adc-trigger")
 {
+	UNUSED(init);
 }
 
 M2kHardwareTriggerV024Impl::~M2kHardwareTriggerV024Impl()
@@ -97,6 +98,7 @@ void M2kHardwareTriggerV024Impl::setAnalogExternalOutSelect(M2K_TRIGGER_OUT_SELE
 
 void M2kHardwareTrigger::setAnalogExternalOutSelect(M2K_TRIGGER_OUT_SELECT output_select)
 {
+	UNUSED(output_select);
 	THROW_M2K_EXCEPTION("M2kHardwareTrigger: "
 			    "the analog external output is not configurable on "
 			    "the current board; Check the firmware version.",
@@ -169,6 +171,7 @@ void M2kHardwareTriggerV024Impl::setDigitalSource(M2K_TRIGGER_SOURCE_DIGITAL ext
 
 void M2kHardwareTrigger::setDigitalSource(M2K_TRIGGER_SOURCE_DIGITAL external_src)
 {
+	UNUSED(external_src);
 	THROW_M2K_EXCEPTION("M2kHardwareTrigger: "
 			    "the digital external source is not configurable on "
 			    "the current board; Check the firmware version.",

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -383,7 +383,7 @@ std::vector<std::string> Channel::getAvailableAttributeValues(const std::string 
 		std::istringstream iss(valuesAsString);
 		values = std::vector<std::string>(std::istream_iterator<std::string>{iss},
 						  std::istream_iterator<std::string>());
-	} __catch (exception_type &e) {
+	} __catch (exception_type&) {
 		values.push_back(getStringValue(attr));
 	}
 	return values;

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -73,7 +73,7 @@ DeviceGeneric::DeviceGeneric(struct iio_context* context, std::string dev_name)
 		if (is_buffer_capable) {
                         __try {
                                 m_buffer = new Buffer(m_dev);
-                        } __catch (exception_type &e) {
+                        } __catch (exception_type &) {
                                 delete m_buffer;
                                 m_buffer = nullptr;
                         }
@@ -263,7 +263,7 @@ int DeviceGeneric::getLongValue(std::string attr)
 		THROW_M2K_EXCEPTION(dev_name + " has no " + attr + " attribute", libm2k::EXC_INVALID_PARAMETER);
 	}
 	LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name, attr.c_str(), LIBM2K_ATTRIBUTE_READ}, std::to_string(value)));
-	return value;
+	return static_cast<int>(value);
 }
 
 int DeviceGeneric::getLongValue(unsigned int chn_idx, std::string attr, bool output)
@@ -280,7 +280,7 @@ int DeviceGeneric::getLongValue(unsigned int chn_idx, std::string attr, bool out
 		THROW_M2K_EXCEPTION(dev_name + " has no " + attr + " attribute for the selected channel", libm2k::EXC_INVALID_PARAMETER);
 	}
 
-	return chn->getLongValue(attr);
+	return  static_cast<int>(chn->getLongValue(attr));
 }
 
 int DeviceGeneric::getBufferLongValue(std::string attr)
@@ -296,10 +296,10 @@ int DeviceGeneric::getBufferLongValue(std::string attr)
 	}
 	LIBM2K_LOG(INFO,
                libm2k::buildLoggingMessage({m_dev_name, "buffer", attr.c_str(), LIBM2K_ATTRIBUTE_READ}, std::to_string(value)));
-	return value;
+	return  static_cast<int>(value);
 }
 
-int DeviceGeneric::setLongValue(int value, std::string attr)
+int DeviceGeneric::setLongValue(long long value, std::string attr)
 {
 	std::string dev_name = iio_device_get_name(m_dev);
 	if (ContextImpl::iioDevHasAttribute(m_dev, attr)) {
@@ -312,7 +312,7 @@ int DeviceGeneric::setLongValue(int value, std::string attr)
 	return getLongValue(attr);
 }
 
-int DeviceGeneric::setLongValue(unsigned int chn_idx, int value, std::string attr, bool output)
+int DeviceGeneric::setLongValue(unsigned int chn_idx, long long value, std::string attr, bool output)
 {
 	unsigned int nb_channels = iio_device_get_channels_count(m_dev);
 	std::string dev_name = getName();
@@ -329,7 +329,7 @@ int DeviceGeneric::setLongValue(unsigned int chn_idx, int value, std::string att
 	}
 
 	chn->setLongValue(attr, value);
-	return chn->getLongValue(attr);
+	return  static_cast<int>(chn->getLongValue(attr));
 }
 
 int DeviceGeneric::setBufferLongValue(int value, std::string attr)
@@ -527,7 +527,7 @@ std::vector<std::string> DeviceGeneric::getAvailableAttributeValues(const string
 		std::istringstream iss(valuesAsString);
 		values = std::vector<std::string>(std::istream_iterator<std::string>{iss},
 						  std::istream_iterator<std::string>());
-	} __catch (exception_type &e) {
+	} __catch (exception_type&) {
 		values.push_back(getStringValue(attr));
 	}
 	return values;

--- a/src/utils/devicegeneric.hpp
+++ b/src/utils/devicegeneric.hpp
@@ -71,8 +71,8 @@ public:
 	virtual int getLongValue(std::string attr);
 	virtual int getLongValue(unsigned int, std::string attr, bool output=false);
 	virtual int getBufferLongValue(std::string attr);
-	virtual int setLongValue(int value, std::string attr);
-	virtual int setLongValue(unsigned int chn_idx, int value, std::string attr, bool output=false);
+	virtual int setLongValue(long long value, std::string attr);
+	virtual int setLongValue(unsigned int chn_idx, long long value, std::string attr, bool output=false);
 	virtual int setBufferLongValue(int value, std::string attr);
 
 	virtual bool getBoolValue(std::string attr);

--- a/tools/communication/src/utils/util.cpp
+++ b/tools/communication/src/utils/util.cpp
@@ -31,7 +31,7 @@ void setInputChannel(unsigned int channelIndex, libm2k::digital::M2kDigital *m2K
 unsigned int getValidSampleRate(unsigned int frequency, unsigned int samplesPerCycle)
 {
 	unsigned int maxSampleRate = 100000000;
-	if (frequency >= maxSampleRate || frequency < 0) {
+	if (frequency >= maxSampleRate) {
 		return maxSampleRate;
 	}
 	unsigned int tempSampleRate = frequency * samplesPerCycle;

--- a/tools/m2kcli/commands/command.h
+++ b/tools/m2kcli/commands/command.h
@@ -34,6 +34,7 @@ namespace cli {
 class Command {
 public:
 	Command() = default;
+	virtual ~Command() = default;
 
 	Command(int argc, char **argv);
 

--- a/tools/m2kcli/commands/command_in.h
+++ b/tools/m2kcli/commands/command_in.h
@@ -28,6 +28,9 @@ namespace libm2k {
 namespace cli {
 
 class CommandIn : virtual public Command {
+public:
+	virtual ~CommandIn() = default;
+
 protected:
 	static void printSamplesCsvFormat(std::vector<uint16_t> &samples, unsigned int nb_samples);
 

--- a/tools/m2kcli/commands/digital/generation_controller/digital_out_generator.h
+++ b/tools/m2kcli/commands/digital/generation_controller/digital_out_generator.h
@@ -28,6 +28,9 @@
 #include "utils/command_out_generator.h"
 
 class DigitalOutGenerator : virtual public CommandOutGenerator {
+public:
+	virtual ~DigitalOutGenerator() = default;
+
 protected:
 	DigitalOutGenerator(libm2k::digital::M2kDigital *digital, unsigned int bufferSize, std::vector<unsigned int> &channels,
 			    bool cyclic);

--- a/tools/m2kcli/utils/command_out_generator.h
+++ b/tools/m2kcli/utils/command_out_generator.h
@@ -27,6 +27,8 @@ class CommandOutGenerator {
 public:
 	virtual void generate(bool &keepReading) = 0;
 
+	virtual ~CommandOutGenerator() = default;
+
 protected:
 	virtual void getSamples(bool &keepReading) = 0;
 };


### PR DESCRIPTION
Should clean a bunch of warnings. Some appear due to clang being more aggressive on what's enabled by default.
Also fixes #196.

https://github.com/analogdevicesinc/libm2k/blob/master/src/analog/m2kanalogin_impl.cpp#L474

```cpp
const short *M2kAnalogInImpl::getVoltageRawP()
{
	std::vector<short> avgs = getVoltageRaw();
	return avgs.data();
}
```

- [x] `warning: address of stack memory associated with local variable 'avgs' returned [-Wreturn-stack-address]` . This is undefined behaviour. Is the std::vector<short> a 1 element vector containing an average value?

Can this return a `short` value representing the average or a `short *` containing an array of averages maybe through a smart ptr?
```cpp
memcpy(return value, avgs.data(), ...)
```
The problem also appears in the `double` version of this method.

- [x] can I add -Wreturn-stack-address to be threated as an error?