### PR TITLE
M2kAnalogIn: remove channel index from sample rate methods

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -310,15 +310,6 @@ public:
 
 
 	/**
-	* @brief Retrieve the sample rate of the given channel
-	*
-	* @param chn_idx The index corresponding to the channel
-	* @return The value of the sample rate
-	*/
-	virtual double getSampleRate(unsigned int chn_idx) = 0;
-
-
-	/**
 	 * @brief getAvailableSampleRates
 	 * @return The list of available samplerates for this device
 	 */
@@ -331,16 +322,6 @@ public:
 	* @return The value of the global sample rate
 	*/
 	virtual double setSampleRate(double samplerate) = 0;
-
-
-	/**
-	* @brief Set the sample rate of the given channel
-	*
-	* @param chn_idx The index corresponding to the channel
-	* @param samplerate A double value to set the sample rate to
-	* @return The value of the global sample rate
-	*/
-	virtual double setSampleRate(unsigned int chn_idx, double samplerate) = 0;
 
 
 	/**

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -694,29 +694,11 @@ double M2kAnalogInImpl::getSampleRate()
 	return m_m2k_adc->getDoubleValue("sampling_frequency");
 }
 
-double M2kAnalogInImpl::getSampleRate(unsigned int chn_idx)
-{
-	if (chn_idx >= getNbChannels()) {
-		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
-	}
-	return m_m2k_adc->getDoubleValue(chn_idx, "sampling_frequency");
-}
-
 double M2kAnalogInImpl::setSampleRate(double samplerate)
 {
 	m_samplerate = m_m2k_adc->setLongValue((int)samplerate, "sampling_frequency");
 	m_trigger->setCalibParameters(0, getScalingFactor(0), m_adc_hw_vert_offset.at(0));
 	m_trigger->setCalibParameters(1, getScalingFactor(1), m_adc_hw_vert_offset.at(1));
-	return m_samplerate;
-}
-
-double M2kAnalogInImpl::setSampleRate(unsigned int chn_idx, double samplerate)
-{
-	if (chn_idx >= getNbChannels()) {
-		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
-	}
-	m_samplerate = m_m2k_adc->setLongValue((int)samplerate, "sampling_frequency");
-	m_trigger->setCalibParameters(chn_idx, getScalingFactor(chn_idx), m_adc_hw_vert_offset.at(chn_idx));
 	return m_samplerate;
 }
 

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -76,10 +76,8 @@ public:
 	int setOversamplingRatio(unsigned int chn_idx, int oversampling) override;
 
 	double getSampleRate() override;
-	double getSampleRate(unsigned int chn_idx) override;
 	std::vector<double> getAvailableSampleRates() override;
 	double setSampleRate(double samplerate) override;
-	double setSampleRate(unsigned int chn_idx, double samplerate) override;
 
 	std::pair<double, double> getHysteresisRange(ANALOG_IN_CHANNEL chn) override;
 


### PR DESCRIPTION
now only uses setSampleRate(value) and getSampleRate()

Signed-off-by: Cristina Suteu <cristina.suteu@analog.com>