### PR TITLE
M2kAnalogIn: enable all channels before initializing the buffer

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -231,7 +231,9 @@ libm2k::M2kHardwareTrigger *M2kAnalogInImpl::getTrigger()
 
 void M2kAnalogInImpl::startAcquisition(unsigned int nb_samples)
 {
+	handleChannelsEnableState(true);
 	m_m2k_adc->initializeBuffer(nb_samples);
+	handleChannelsEnableState(false);
 }
 
 void M2kAnalogInImpl::stopAcquisition()


### PR DESCRIPTION
Thix fixes a bug that happend when `startAcquisition` is used, that caused invalid data to be captured.

﻿Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>
