### PR TITLE
M2KCalibration: use calibration done flags for firmware 0.25 and earlier

### DIFF
--- a/include/libm2k/m2kcalibration.hpp
+++ b/include/libm2k/m2kcalibration.hpp
@@ -50,6 +50,9 @@ public:
 	virtual double getAdcGain(unsigned int channel) = 0;
 	virtual double getDacGain(unsigned int channel) = 0;
 
+	virtual bool getAdcCalibrated() const = 0;
+	virtual bool getDacCalibrated() const = 0;
+
 
 	virtual bool resetCalibration() = 0;
 

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -539,6 +539,12 @@ bool M2kImpl::getLed()
 
 bool M2kImpl::isCalibrated()
 {
+	int diff = Utils::compareVersions(m_firmware_version, "v0.25");
+	if (diff <= 0) {
+		// for FW 0.25 and earlier we cannot conclude if the adc/dac was calibrated due to missing calibbias attribute
+		return m_calibration->getAdcCalibrated() && m_calibration->getDacCalibrated();
+	}
+
 	for (unsigned int i = 0; i < 2; i++) {
 		if (m_calibration->getAdcOffset(i) != defaultOffset || m_calibration->getDacOffset(i) != defaultOffset) {
 			return true;

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -347,6 +347,16 @@ void M2kCalibrationImpl::setAdcGain(unsigned int chn, double gain)
 	}
 }
 
+bool M2kCalibrationImpl::getAdcCalibrated() const
+{
+	return m_adc_calibrated;
+}
+
+bool M2kCalibrationImpl::getDacCalibrated() const
+{
+	return m_dac_calibrated;
+}
+
 void M2kCalibrationImpl::updateDacCorrections()
 {
 	m_ad5625_dev->setDoubleValue(0, m_dac_a_ch_offset, "raw", true);

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -74,6 +74,10 @@ public:
 	void setDacOffset(unsigned int chn, int offset);
 	void setAdcOffset(unsigned int chn, int offset);
 	void setAdcGain(unsigned int chn, double gain);
+
+	bool getAdcCalibrated() const override;
+	bool getDacCalibrated() const override;
+
 private:
 	bool m_cancel;
 


### PR DESCRIPTION
This is because for older firmware you cannot tell whether the voffset
has been calibrated or not. This causes an offset when using default values
even though isCalibrated returns true

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>