### PR TITLE
M2kCalibration: Reduce the time spent on the calibration process.

### DIFF
--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -418,6 +418,12 @@ public:
 	 */
 	virtual void setKernelBuffersCount(unsigned int count) = 0;
 
+	/**
+	 * @brief Get the number of kernel buffers
+	 * @return the number of previously set kernel buffers (saved in this session)
+	 */
+	virtual unsigned int getKernelBuffersCount() const = 0;
+
 
 	/**
 	* @brief Get the hardware trigger handler

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -392,6 +392,13 @@ public:
 	 */
 	virtual void setKernelBuffersCount(unsigned int chnIdx, unsigned int count) = 0;
 
+	/**
+	 * @brief Get the number of kernel buffers
+	 * @param chnIdx The index corresponding to the channel
+	 * @return the number of previously set kernel buffers (saved in this session)
+	 */
+	virtual unsigned int getKernelBuffersCount(unsigned int chnIdx) const = 0;
+
 
 	/**
 	 * @brief Convert the volts value of a sample into raw

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -122,6 +122,7 @@ public:
 	void convertChannelHostFormat(unsigned int chn_idx, double *avg, int16_t *src);
 
 	void setKernelBuffersCount(unsigned int count) override;
+	unsigned int getKernelBuffersCount() const override;
 
 	libm2k::M2kHardwareTrigger* getTrigger() override;
 	struct IIO_OBJECTS getIioObjects() override;
@@ -135,6 +136,7 @@ public:
 
 	void deinitialize();
 	bool hasCalibbias();
+	void loadNbKernelBuffers();
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
@@ -153,6 +155,8 @@ private:
 	std::vector<double> m_adc_hw_vert_offset;
 	std::map<double, double> m_filter_compensation_table;
 	std::vector<bool> m_channels_enabled;
+	unsigned int m_nb_kernel_buffers;
+	bool m_data_available;
 
 	void syncDevice();
 

--- a/src/analog/m2kanalogout_impl.hpp
+++ b/src/analog/m2kanalogout_impl.hpp
@@ -75,6 +75,7 @@ public:
 	bool isChannelEnabled(unsigned int chnIdx) override;
 
 	void setKernelBuffersCount(unsigned int chnIdx, unsigned int count) override;
+	unsigned int getKernelBuffersCount(unsigned int chnIdx) const override;
 
 	short convertVoltsToRaw(unsigned int channel, double voltage) override;
 	double convertRawToVolts(unsigned int channel, short raw) override;
@@ -88,6 +89,8 @@ public:
 	std::string getChannelName(unsigned int channel) override;
 	double getMaximumSamplerate(unsigned int chn_idx) override;
 	void deinitialize();
+
+	void loadNbKernelBuffers();
 private:
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
 	std::vector<double> m_max_samplerate;

--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -92,8 +92,7 @@ bool M2kCalibrationImpl::isInitialized() const
 
 void M2kCalibrationImpl::setAdcInCalibMode()
 {
-	m_m2k_adc->setKernelBuffersCount(1);
-
+	bool ok = false;
 	// Make sure hardware triggers are disabled before calibrating
 	m_trigger0_mode = m_m2k_trigger->getAnalogMode(ANALOG_IN_CHANNEL_1);
 	m_trigger1_mode = m_m2k_trigger->getAnalogMode(ANALOG_IN_CHANNEL_2);
@@ -122,12 +121,25 @@ void M2kCalibrationImpl::setAdcInCalibMode()
 
 	m_m2k_adc->enableChannel(0, true);
 	m_m2k_adc->enableChannel(1, true);
+
+	m_m2k_adc->loadNbKernelBuffers();
+	m_adc_kernel_buffers = m_m2k_adc->getKernelBuffersCount();
+
+	while (!ok) {
+		try {
+			m_m2k_adc->setKernelBuffersCount(1);
+			ok = true;
+		} catch (m2k_exception &e) {
+			if (e.iioCode() != -EBUSY) {
+				THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
+			}
+		}
+	}
 }
 
 void M2kCalibrationImpl::setDacInCalibMode()
 {
-	m_m2k_dac->setKernelBuffersCount(0, 1);
-	m_m2k_dac->setKernelBuffersCount(1, 1);
+	bool ok = false;
 	dac_a_sampl_freq = m_m2k_dac->getSampleRate(0);
 	dac_a_oversampl = m_m2k_dac->getOversamplingRatio(0);
 	dac_b_sampl_freq = m_m2k_dac->getSampleRate(1);
@@ -141,11 +153,26 @@ void M2kCalibrationImpl::setDacInCalibMode()
 
 	m_m2k_dac->enableChannel(0, true);
 	m_m2k_dac->enableChannel(1, true);
+
+	m_m2k_dac->loadNbKernelBuffers();
+	m_dac_a_kernel_buffers = m_m2k_dac->getKernelBuffersCount(0);
+	m_dac_b_kernel_buffers = m_m2k_dac->getKernelBuffersCount(1);
+	while (!ok) {
+		try {
+			m_m2k_dac->setKernelBuffersCount(0, 1);
+			m_m2k_dac->setKernelBuffersCount(1, 1);
+			ok = true;
+		} catch (m2k_exception &e) {
+			if (e.iioCode() != -EBUSY) {
+				THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
+			}
+		}
+	}
 }
 
 void M2kCalibrationImpl::restoreAdcFromCalibMode()
 {
-	m_m2k_adc->setKernelBuffersCount(4);
+	m_m2k_adc->setKernelBuffersCount(m_adc_kernel_buffers);
 
 	m_m2k_trigger->setAnalogMode(ANALOG_IN_CHANNEL_1, m_trigger0_mode);
 	m_m2k_trigger->setAnalogMode(ANALOG_IN_CHANNEL_2, m_trigger1_mode);
@@ -166,8 +193,8 @@ void M2kCalibrationImpl::restoreAdcFromCalibMode()
 
 void M2kCalibrationImpl::restoreDacFromCalibMode()
 {
-	m_m2k_dac->setKernelBuffersCount(0, 4);
-	m_m2k_dac->setKernelBuffersCount(1, 4);
+	m_m2k_dac->setKernelBuffersCount(0, m_dac_a_kernel_buffers);
+	m_m2k_dac->setKernelBuffersCount(1, m_dac_b_kernel_buffers);
 	m_m2k_dac->setSampleRate(0, dac_a_sampl_freq);
 	m_m2k_dac->setOversamplingRatio(0, dac_a_oversampl);
 	m_m2k_dac->setSampleRate(1, dac_b_sampl_freq);

--- a/src/m2kcalibration_impl.hpp
+++ b/src/m2kcalibration_impl.hpp
@@ -112,6 +112,10 @@ private:
 	bool m_initialized;
 	int m_calibration_mode;
 
+	unsigned int m_adc_kernel_buffers;
+	unsigned int m_dac_a_kernel_buffers;
+	unsigned int m_dac_b_kernel_buffers;
+
 	std::vector<bool> m_adc_channels_enabled;
 	std::vector<bool> m_dac_channels_enabled;
 	double m_dac_default_vlsb;

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -621,8 +621,9 @@ void DeviceGeneric::setKernelBuffersCount(unsigned int count)
 	if (!m_dev) {
 		THROW_M2K_EXCEPTION("Device: no such device", libm2k::EXC_OUT_OF_RANGE);
 	}
-	if (iio_device_set_kernel_buffers_count(m_dev, count) != 0) {
-		THROW_M2K_EXCEPTION("Device: Cannot set the number of kernel buffers", libm2k::EXC_RUNTIME_ERROR);
+	int ret = iio_device_set_kernel_buffers_count(m_dev, count);
+	if (ret != 0) {
+		THROW_M2K_EXCEPTION("Device: Cannot set the number of kernel buffers", libm2k::EXC_RUNTIME_ERROR, ret);
 	}
 	const char *deviceName = iio_device_get_name(m_dev);
 	LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({deviceName}, "Set kernel buffers count: " + std::to_string(count)));
@@ -675,4 +676,12 @@ bool DeviceGeneric::hasGlobalAttribute(string attr)
 bool DeviceGeneric::hasBufferAttribute(string attr)
 {
 	return ContextImpl::iioDevBufferHasAttribute(m_dev, attr);
+}
+
+ssize_t DeviceGeneric::getSampleSize()
+{
+	if (!m_dev) {
+		THROW_M2K_EXCEPTION("Device: No available device", libm2k::EXC_INVALID_PARAMETER);
+	}
+	return iio_device_get_sample_size(m_dev);
 }

--- a/src/utils/devicegeneric.hpp
+++ b/src/utils/devicegeneric.hpp
@@ -108,6 +108,7 @@ public:
 	virtual bool hasGlobalAttribute(std::string attr);
 	virtual bool hasBufferAttribute(std::string attr);
 
+	virtual ssize_t getSampleSize();
 protected:
 	struct iio_context *m_context;
 	struct iio_device *m_dev;

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -133,8 +133,9 @@ void DeviceOut::stop()
 void DeviceOut::setKernelBuffersCount(unsigned int count)
 {
 	if (m_dev) {
-		if (iio_device_set_kernel_buffers_count(m_dev, count) != 0) {
-			THROW_M2K_EXCEPTION("Device: Cannot set the number of kernel buffers", libm2k::EXC_RUNTIME_ERROR);
+		int ret = iio_device_set_kernel_buffers_count(m_dev, count);
+		if (ret != 0) {
+			THROW_M2K_EXCEPTION("Device: Cannot set the number of kernel buffers", libm2k::EXC_RUNTIME_ERROR, ret);
 		}
 		const char *deviceName = iio_device_get_name(m_dev);
 		LIBM2K_LOG(INFO,


### PR DESCRIPTION
Fine tuning runs about 20 times. This creates the buffer, fills it and
destroys it right after. We reduce the amount of time spent here by
using the kernel buffers and the fact that the buffer is refilled instantly
after the buffer is created.

This reduces the calibration time with almost 1s.
Ran some tests to check calibration accuracy, results are the following:

> Test 1: Reset and get default values
2048 2048 1.0 1.0 2048 2048 0.718079 0.718079
CH0  0.028281165357529826
CH1  0.01082365587757312

>Test 2: Reading values after Scopy v1.2.0 did the calibration.
2011 2021 1.066284 1.075745 2072 2075 0.646606 0.639526
CH0  -0.005844470565028971
CH1  -0.0020493598085166514

>Test 1: Reset and get default values
2048 2048 1.0 1.0 2048 2048 0.718079 0.718079
CH0  0.02727925611781052
CH1  0.010535227460078176

>Test 3: Calibrate using the modified libm2k calibration and compare them with the previous results.
2010 2021 1.067749 1.076477 2074 2077 0.64624 0.638184
CH0  -0.0045085915787366265
CH1  0.002793201516793067

The difference between raw offsets of this version and the current master version are max 2. The readings for 0V output look good.
The test values are listed as follows:
ADC_CH0_Offset,  ADC_CH1_Offset,   ADC_CH0_Gain,     ADC_CH1_Gain,    DAC_CH0_Offset,  DAC_CH1_Offset,   DAC_CH0_Gain,     DAC_CH1_Gain

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>