### PR TITLE
General: Replace "std:stod" with string streams

### DIFF
--- a/include/libm2k/utils/utils.hpp
+++ b/include/libm2k/utils/utils.hpp
@@ -71,6 +71,7 @@ namespace utils {
 		static std::vector<std::string> split(std::string, std::string);
 		static int compareVersions(std::string v1, std::string v2);
 		static bool compareNatural(const std::string &a, const std::string &b);
+		static double safeStod(const std::string& to_convert);
 	private:
 		static std::string parseIniSection(std::string line);
 		static std::pair<std::string, std::vector<std::string>>

--- a/src/analog/m2kpowersupply_impl.cpp
+++ b/src/analog/m2kpowersupply_impl.cpp
@@ -24,6 +24,7 @@
 #include <libm2k/m2kexceptions.hpp>
 #include <libm2k/logger.hpp>
 #include "utils/channel.hpp"
+#include <libm2k/utils/utils.hpp>
 #include <iio.h>
 
 using namespace libm2k::analog;
@@ -194,7 +195,8 @@ void M2kPowerSupplyImpl::loadCalibrationCoefficients()
 		__try {
 			auto pair = m_generic_device->getContextAttr(i);
 			calib_pair.first = std::string(pair.first.c_str() + 4);
-			calib_pair.second = std::stod(pair.second);
+			calib_pair.second = Utils::safeStod(pair.second);
+
 			m_calib_coefficients.push_back(calib_pair);
 		} __catch (exception_type &) {
 			continue;

--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -559,24 +559,24 @@ bool M2kImpl::hasContextCalibration()
 	auto it = splitValues.begin();
 	while (it != splitValues.end()) {
 		try {
-			temperature = std::stod(*it);
+			temperature = Utils::safeStod(*it);
 			auto parameters = std::make_shared<struct CALIBRATION_PARAMETERS>();
 			it = std::next(it);
 			parameters->adc_offset_ch_1 = std::stoi(*it);
 			it = std::next(it);
 			parameters->adc_offset_ch_2 = std::stoi(*it);
 			it = std::next(it);
-			parameters->adc_gain_ch_1 = std::stod(*it);
+			parameters->adc_gain_ch_1 = Utils::safeStod(*it);
 			it = std::next(it);
-			parameters->adc_gain_ch_2 = std::stod(*it);
+			parameters->adc_gain_ch_2 = Utils::safeStod(*it);
 			it = std::next(it);
 			parameters->dac_a_offset = std::stoi(*it);
 			it = std::next(it);
 			parameters->dac_b_offset = std::stoi(*it);
 			it = std::next(it);
-			parameters->dac_a_gain = std::stod(*it);
+			parameters->dac_a_gain = Utils::safeStod(*it);
 			it = std::next(it);
-			parameters->dac_b_gain = std::stod(*it);
+			parameters->dac_b_gain = Utils::safeStod(*it);
 			it = std::next(it);
 
 			m_calibration_lut.insert({temperature, parameters});

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -28,9 +28,9 @@
 #include <algorithm>
 #include <thread>
 #include <chrono>
-#include <iostream>
 #include <cctype>
 #include <sstream>
+#include <locale>
 
 using namespace std;
 using namespace libm2k::utils;
@@ -282,4 +282,13 @@ bool Utils::compareNatural(const std::string& a, const std::string& b){
 	std::getline(string_stream_a, a_new);
 	std::getline(string_stream_b, b_new);
 	return (compareNatural(a_new, b_new));
+}
+
+double Utils::safeStod(const std::string& to_convert)
+{
+	double converted_value = 0.0;
+	std::istringstream in_s(to_convert);
+	in_s.imbue(std::locale("C"));
+	in_s >> converted_value;
+	return converted_value;
 }


### PR DESCRIPTION
Use imbue to associate a locale to the stream and stream buffer.

std::stod behaviour changes based on the system locale, we made these
changes to avoid wrong parameter conversion.

- [x] Verify: https://github.com/analogdevicesinc/libm2k/blob/master/bindings/python/calibration/generate_temperature_calib_lut.py
Check if the generated calibration parameters file depends on the system locale (42.5 degrees or 42,5 degrees affect the way values are loaded into the library)

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>