### PR TITLE
M2kPowerSupply: Add a boolean "calibrated" flag to the push and read methods.

### DIFF
--- a/include/libm2k/analog/m2kpowersupply.hpp
+++ b/include/libm2k/analog/m2kpowersupply.hpp
@@ -74,9 +74,12 @@ public:
 	* @brief Retrieve the value of a given channel
 	*
 	* @param chn The index corresponding to the channel
+	* @param calibrated Read values are converted using the calibration
+	* coefficients from the IIO context by default; This boolean flag
+	* specifies whether the coefficients should be used.
 	* @return double The voltage transmitted by the given channel
 	*/
-	virtual double readChannel(unsigned int chn) = 0;
+	virtual double readChannel(unsigned int chn, bool calibrated = true) = 0;
 
 
 	/**
@@ -84,8 +87,11 @@ public:
 	*
 	* @param chn The index corresponding to the channel
 	* @param value The voltage (up to 5V)
+	* @param calibrated Written values are converted using the calibration
+	* coefficients from the IIO context by default; This boolean flag
+	* specifies whether the coefficients should be used.
 	*/
-	virtual void pushChannel(unsigned int chn, double value) = 0;
+	virtual void pushChannel(unsigned int chn, double value, bool calibrated = true) = 0;
 
 
 	/**

--- a/src/analog/m2kpowersupply_impl.cpp
+++ b/src/analog/m2kpowersupply_impl.cpp
@@ -218,24 +218,26 @@ void M2kPowerSupplyImpl::enableAll(bool en)
 	UNUSED(en);
 }
 
-double M2kPowerSupplyImpl::readChannel(unsigned int idx)
+double M2kPowerSupplyImpl::readChannel(unsigned int idx, bool calibrated)
 {
 	LIBM2K_LOG(INFO, "[BEGIN] M2kPowerSupply readChannel");
 	double val = 0;
-	double offset = 0;
-	double gain = 0;
+	double offset = 0.0;
+	double gain = 1.0;
 	double value = 0;
 
 	if (idx >= m_read_channel_idx.size()) {
 		THROW_M2K_EXCEPTION("M2k PowerSupply: No such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 
-	if (idx == 0) {
-		offset = getCalibrationCoefficient("offset_pos_dac");
-		gain = getCalibrationCoefficient("gain_pos_dac");
-	} else {
-		offset = getCalibrationCoefficient("offset_neg_dac");
-		gain = getCalibrationCoefficient("gain_neg_dac");
+	if (calibrated) {
+		if (idx == 0) {
+			offset = getCalibrationCoefficient("offset_pos_dac");
+			gain = getCalibrationCoefficient("gain_pos_dac");
+		} else {
+			offset = getCalibrationCoefficient("offset_neg_dac");
+			gain = getCalibrationCoefficient("gain_neg_dac");
+		}
 	}
 
 	//voltage2 and v1
@@ -247,11 +249,11 @@ double M2kPowerSupplyImpl::readChannel(unsigned int idx)
 	return value;
 }
 
-void M2kPowerSupplyImpl::pushChannel(unsigned int chnIdx, double value)
+void M2kPowerSupplyImpl::pushChannel(unsigned int chnIdx, double value, bool calibrated)
 {
 	LIBM2K_LOG(INFO, "[BEGIN] M2kPowerSupply pushChannel");
-	double offset = 0;
-	double gain = 0;
+	double offset = 0.0;
+	double gain = 1.0;
 	double val;
 
 	if (chnIdx >= m_write_channel_idx.size()) {
@@ -262,12 +264,14 @@ void M2kPowerSupplyImpl::pushChannel(unsigned int chnIdx, double value)
 		THROW_M2K_EXCEPTION("M2K power supplies are limited to 5V", libm2k::EXC_INVALID_PARAMETER);
 	}
 
-	if (chnIdx == 0) {
-		offset = getCalibrationCoefficient("offset_pos_dac");
-		gain = getCalibrationCoefficient("gain_pos_dac");
-	} else {
-		offset = getCalibrationCoefficient("offset_neg_dac");
-		gain = getCalibrationCoefficient("gain_neg_dac");
+	if (calibrated) {
+		if (chnIdx == 0) {
+			offset = getCalibrationCoefficient("offset_pos_dac");
+			gain = getCalibrationCoefficient("gain_pos_dac");
+		} else {
+			offset = getCalibrationCoefficient("offset_neg_dac");
+			gain = getCalibrationCoefficient("gain_neg_dac");
+		}
 	}
 
 	val = (value * gain + offset) * m_write_coefficients.at(chnIdx);

--- a/src/analog/m2kpowersupply_impl.hpp
+++ b/src/analog/m2kpowersupply_impl.hpp
@@ -84,9 +84,12 @@ public:
 	* @brief Retrieve the value of a given channel
 	*
 	* @param chn The index corresponding to the channel
+	* @param calibrated Read values are converted using the calibration
+	* coefficients from the IIO context by default; This boolean flag
+	* specifies whether the coefficients should be used.
 	* @return double The voltage transmitted by the given channel
 	*/
-	double readChannel(unsigned int chn);
+	double readChannel(unsigned int chn, bool calibrated);
 
 
 	/**
@@ -94,8 +97,11 @@ public:
 	*
 	* @param chn The index corresponding to the channel
 	* @param value The voltage (up to 5V)
+	* @param calibrated Written values are converted using the calibration
+	* coefficients from the IIO context by default; This boolean flag
+	* specifies whether the coefficients should be used.
 	*/
-	void pushChannel(unsigned int chn, double value);
+	void pushChannel(unsigned int chn, double value, bool calibrated);
 
 
 	/**


### PR DESCRIPTION
This will specify whether the calibration coefficients should be used in the raw/volts conversion.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>