### PR TITLE
M2kAnalogOut: Add warning for small buffers.

### DIFF
--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -219,7 +219,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel won't be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	* @throw EXC_OUT_OF_RANGE No such channel
 	*/
 	virtual void pushBytes(unsigned int chnIdx, double *data, unsigned int nb_samples) = 0;
@@ -235,7 +236,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel won't be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	* @throw EXC_OUT_OF_RANGE No such channel
 	*/
 	virtual void pushRawBytes(unsigned int chnIdx, short *data, unsigned int nb_samples) = 0;
@@ -251,7 +253,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel will be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	*/
 	virtual void pushInterleaved(double *data, unsigned int nb_channels, unsigned int nb_samples) = 0;
 
@@ -266,7 +269,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel will be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	*/
 	virtual void pushRawInterleaved(short *data, unsigned int nb_channels, unsigned int nb_samples) = 0;
 
@@ -280,7 +284,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel won't be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	* @throw EXC_OUT_OF_RANGE No such channel
 	*/
 	virtual void push(unsigned int chnIdx, std::vector<double> const &data) = 0;
@@ -295,7 +300,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel won't be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	* @throw EXC_OUT_OF_RANGE No such channel
 	*/
 	virtual void pushRaw(unsigned int chnIdx, std::vector<short> const &data) = 0;
@@ -310,7 +316,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel won't be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	*/
 	virtual void push(std::vector<std::vector<double>> const &data) = 0;
 
@@ -324,7 +331,8 @@ public:
 	* @note Streaming data is possible - required multiple kernel buffers
 	* @note The given channel won't be synchronized with the other channel
 	* @note Due to a hardware limitation, the number of samples per channel must
-	* be a multiple of 4 and greater than 16
+	* be a multiple of 4 and greater than 16 (non-cyclic buffers) or 1024 (cyclic buffers)
+	* @note The samples in the buffer can be repeated until the buffer reaches the size requirements
 	*/
 	virtual void pushRaw(std::vector<std::vector<short>> const &data) = 0;
 

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -84,6 +84,9 @@ void Buffer::initializeBuffer(unsigned int size, bool cyclic, bool output)
                                                                       " samples)"));
 		LIBM2K_LOG_IF(WARNING, size % 4 != 0 || size < 16,
                       libm2k::buildLoggingMessage({m_dev_name}, "Incorrect number of samples"));
+
+		LIBM2K_LOG_IF(WARNING, output && cyclic && size < 1024,
+                      libm2k::buildLoggingMessage({m_dev_name}, "Cyclic buffer too small. The length of the buffer should be greater than 1024"));
 	}
 }
 


### PR DESCRIPTION
Due to a hardware limitation, in cyclic mode the length of the buffers should be greater than 1024.
Add info in the documentation.
Add warning for the end-user.

Fixes #161 