### PR TITLE
libm2k.iss.cmakein: Copy the C++ -> C# wrapper DLL into System32 when

### DIFF
--- a/libm2k.iss.cmakein
+++ b/libm2k.iss.cmakein
@@ -107,10 +107,10 @@ Source: "C:\libiio-win32\libserialport-0.dll"; DestDir: "{sys}"; Tasks: install_
 Source: "C:\libiio-win64\libserialport-0.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Tasks: install_libiio_force install_libiio;
 
 Source: "C:\projects\libm2k\build-win32\libm2k-sharp.dll"; DestDir: "{cf}\libm2k"; Check: not Is64BitInstallMode; Flags: replacesameversion
-Source: "C:\projects\libm2k\build-win32\libm2k-sharp-cxx-wrap.dll"; DestDir: "{cf}\libm2k"; Check: not Is64BitInstallMode; Flags: replacesameversion
+Source: "C:\projects\libm2k\build-win32\libm2k-sharp-cxx-wrap.dll"; DestDir: "{sys}"; Check: not Is64BitInstallMode; Flags: replacesameversion
 
 Source: "C:\projects\libm2k\build-win64\libm2k-sharp.dll"; DestDir: "{cf}\libm2k"; Check: Is64BitInstallMode; Flags: replacesameversion
-Source: "C:\projects\libm2k\build-win64\libm2k-sharp-cxx-wrap.dll"; DestDir: "{cf}\libm2k"; Check: Is64BitInstallMode; Flags: replacesameversion
+Source: "C:\projects\libm2k\build-win64\libm2k-sharp-cxx-wrap.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: replacesameversion
 
 Source: "C:\projects\libm2k\build-win32\libm2k_lv.dll"; DestDir: "{sys}"; Flags: 32bit replacesameversion; Tasks: install_labview_wrapper;
 Source: "C:\projects\libm2k\build-win64\libm2k_lv.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: replacesameversion; Tasks: install_labview_wrapper;


### PR DESCRIPTION
installing.

The libm2k-sharp.dll is added as a reference to a C# project, so the
compiler will manually copy it to the build directory.
But the libm2k-sharp-cxx-wrap.dll needs to be copied manually in the
build directory, and can't be added as a reference to a C# project.
This raises lots of issues. If we place it in the system folder, any DLL
that needs it, will find it in the Path.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>