### PR TITLE
M2kAnalogIn: Add isPushDone method.

### DIFF
--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -394,6 +394,21 @@ public:
 
 
 	/**
+	 * @brief Check if the generation of the signal (only for non-cyclic buffer) is done
+	 * @param chnIdx The index corresponding to the channel
+	 * @return True if the push process is done, false otherwise
+	 *
+	 * @note This function takes the number of kernel buffers into consideration.
+	 * @note If a new session is started without unplugging the board and the number of kernel buffers was modified in the previous session
+	 * @note (default value = 4) a DAC calibration must be performed before calling isPushDone in order to compute the
+	 * @note current number of kernel buffers or call again the function setKernelBuffersCount.
+	 *
+	 * @note Available only in firmware versions newer than 0.23.
+	 */
+	virtual bool isPushDone(unsigned int chnIdx) const = 0;
+
+
+	/**
 	 * @brief Set the kernel buffers to a specific value
 	 * @param chnIdx The index corresponding to the channel
 	 * @param count the number of kernel buffers

--- a/src/analog/m2kanalogout_impl.cpp
+++ b/src/analog/m2kanalogout_impl.cpp
@@ -597,7 +597,20 @@ bool M2kAnalogOutImpl::isChannelEnabled(unsigned int chnIdx)
 	return getDacDevice(chnIdx)->isChannelEnabled(0, true);
 }
 
-DeviceOut* M2kAnalogOutImpl::getDacDevice(unsigned int chnIdx)
+bool M2kAnalogOutImpl::isPushDone(unsigned int chnIdx) const
+{
+	bool isBufferEmpty = true;
+	if (m_dma_data_available) {
+		unsigned int unusedBufferSpace, maxBufferSpace;
+		unsigned int bufferSize = getDacDevice(chnIdx)->getNbSamples();
+		unusedBufferSpace = getDacDevice(chnIdx)->getBufferLongValue("data_available");
+		maxBufferSpace = 2u * bufferSize * (m_nb_kernel_buffers.at(chnIdx) - 1);
+		isBufferEmpty &= (maxBufferSpace == unusedBufferSpace);
+	}
+	return isBufferEmpty;
+}
+
+DeviceOut* M2kAnalogOutImpl::getDacDevice(unsigned int chnIdx) const
 {
 	if (chnIdx >= m_dac_devices.size()) {
 		THROW_M2K_EXCEPTION("Analog Out: No such channel", libm2k::EXC_OUT_OF_RANGE);

--- a/src/analog/m2kanalogout_impl.hpp
+++ b/src/analog/m2kanalogout_impl.hpp
@@ -73,6 +73,7 @@ public:
 
 	void enableChannel(unsigned int chnIdx, bool enable) override;
 	bool isChannelEnabled(unsigned int chnIdx) override;
+	bool isPushDone(unsigned int chnIdx) const override;
 
 	void setKernelBuffersCount(unsigned int chnIdx, unsigned int count) override;
 	unsigned int getKernelBuffersCount(unsigned int chnIdx) const override;
@@ -105,7 +106,7 @@ private:
 	bool m_dma_data_available;
 	std::vector<unsigned int> m_nb_kernel_buffers;
 
-	DeviceOut* getDacDevice(unsigned int chnIdx);
+	DeviceOut* getDacDevice(unsigned int chnIdx) const;
 	void syncDevice();
 	double convRawToVolts(short raw, double vlsb, double filterCompensation);
 };

--- a/src/utils/buffer.cpp
+++ b/src/utils/buffer.cpp
@@ -555,6 +555,11 @@ void Buffer::setCyclic(bool enable)
 	m_cyclic = enable;
 }
 
+unsigned int Buffer::getNbSamples() const
+{
+	return m_last_nb_samples;
+}
+
 struct iio_buffer* Buffer::getBuffer()
 {
 	return m_buffer;

--- a/src/utils/buffer.hpp
+++ b/src/utils/buffer.hpp
@@ -71,6 +71,7 @@ public:
 	void setCyclic(bool enable);
 	void cancelBuffer();
 	void flushBuffer();
+	unsigned int getNbSamples() const;
 
 	struct iio_buffer* getBuffer();
 private:

--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -685,3 +685,11 @@ ssize_t DeviceGeneric::getSampleSize()
 	}
 	return iio_device_get_sample_size(m_dev);
 }
+
+unsigned int DeviceGeneric::getNbSamples() const
+{
+	if (m_buffer) {
+		return m_buffer->getNbSamples();
+	}
+	return 0;
+}

--- a/src/utils/devicegeneric.hpp
+++ b/src/utils/devicegeneric.hpp
@@ -109,6 +109,7 @@ public:
 	virtual bool hasBufferAttribute(std::string attr);
 
 	virtual ssize_t getSampleSize();
+	virtual unsigned int getNbSamples() const;
 protected:
 	struct iio_context *m_context;
 	struct iio_device *m_dev;


### PR DESCRIPTION
Check if the generation of the signal (only for non-cyclic buffer) is done.
Buffer: Add getNbSamples().
DeviceGeneric Add getNbSamples():

Fixes: #156.