### PR TITLE
utils.cpp: Fix undefined behaviour in std::sort on MacOS.

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -253,7 +253,9 @@ int Utils::compareVersions(std::string v1, std::string v2)
 }
 
 bool Utils::compareNatural(const std::string& a, const std::string& b){
-	if (a.empty()) {
+	if (a == b) {
+		return (a < b);
+	} else if (a.empty()) {
 		return true;
 	} else if (b.empty()) {
 		return false;


### PR DESCRIPTION
LLVM/clang allows std::sort to compare the same element with itself.
The previous implementation returned both false and true when comparing
two identical elements (depending on position). This goes against the
"strict weak ordering" policy mandatory for std::sort.

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>