### PR TITLE
DeviceGeneric: Retry kernel buffers count writing before throwing an error.

### DIFF
--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -92,7 +92,6 @@ bool M2kCalibrationImpl::isInitialized() const
 
 void M2kCalibrationImpl::setAdcInCalibMode()
 {
-	bool ok = false;
 	// Make sure hardware triggers are disabled before calibrating
 	m_trigger0_mode = m_m2k_trigger->getAnalogMode(ANALOG_IN_CHANNEL_1);
 	m_trigger1_mode = m_m2k_trigger->getAnalogMode(ANALOG_IN_CHANNEL_2);
@@ -125,21 +124,17 @@ void M2kCalibrationImpl::setAdcInCalibMode()
 	m_m2k_adc->loadNbKernelBuffers();
 	m_adc_kernel_buffers = m_m2k_adc->getKernelBuffersCount();
 
-	while (!ok) {
-		try {
-			m_m2k_adc->setKernelBuffersCount(1);
-			ok = true;
-		} catch (m2k_exception &e) {
-			if (e.iioCode() != -EBUSY) {
-				THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
-			}
+	try {
+		m_m2k_adc->setKernelBuffersCount(1);
+	} catch (m2k_exception &e) {
+		if (e.iioCode() != -EBUSY) {
+			THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
 		}
 	}
 }
 
 void M2kCalibrationImpl::setDacInCalibMode()
 {
-	bool ok = false;
 	dac_a_sampl_freq = m_m2k_dac->getSampleRate(0);
 	dac_a_oversampl = m_m2k_dac->getOversamplingRatio(0);
 	dac_b_sampl_freq = m_m2k_dac->getSampleRate(1);
@@ -157,22 +152,25 @@ void M2kCalibrationImpl::setDacInCalibMode()
 	m_m2k_dac->loadNbKernelBuffers();
 	m_dac_a_kernel_buffers = m_m2k_dac->getKernelBuffersCount(0);
 	m_dac_b_kernel_buffers = m_m2k_dac->getKernelBuffersCount(1);
-	while (!ok) {
-		try {
-			m_m2k_dac->setKernelBuffersCount(0, 1);
-			m_m2k_dac->setKernelBuffersCount(1, 1);
-			ok = true;
-		} catch (m2k_exception &e) {
-			if (e.iioCode() != -EBUSY) {
-				THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
-			}
+	try {
+		m_m2k_dac->setKernelBuffersCount(0, 1);
+		m_m2k_dac->setKernelBuffersCount(1, 1);
+	} catch (m2k_exception &e) {
+		if (e.iioCode() != -EBUSY) {
+			THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
 		}
 	}
 }
 
 void M2kCalibrationImpl::restoreAdcFromCalibMode()
 {
-	m_m2k_adc->setKernelBuffersCount(m_adc_kernel_buffers);
+	try {
+		m_m2k_adc->setKernelBuffersCount(m_adc_kernel_buffers);
+	} catch (m2k_exception &e) {
+		if (e.iioCode() != -EBUSY) {
+			THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
+		}
+	}
 
 	m_m2k_trigger->setAnalogMode(ANALOG_IN_CHANNEL_1, m_trigger0_mode);
 	m_m2k_trigger->setAnalogMode(ANALOG_IN_CHANNEL_2, m_trigger1_mode);
@@ -193,8 +191,14 @@ void M2kCalibrationImpl::restoreAdcFromCalibMode()
 
 void M2kCalibrationImpl::restoreDacFromCalibMode()
 {
-	m_m2k_dac->setKernelBuffersCount(0, m_dac_a_kernel_buffers);
-	m_m2k_dac->setKernelBuffersCount(1, m_dac_b_kernel_buffers);
+	try {
+		m_m2k_dac->setKernelBuffersCount(0, m_dac_a_kernel_buffers);
+		m_m2k_dac->setKernelBuffersCount(1, m_dac_b_kernel_buffers);
+	} catch (m2k_exception &e) {
+		if (e.iioCode() != -EBUSY) {
+			THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
+		}
+	}
 	m_m2k_dac->setSampleRate(0, dac_a_sampl_freq);
 	m_m2k_dac->setOversamplingRatio(0, dac_a_oversampl);
 	m_m2k_dac->setSampleRate(1, dac_b_sampl_freq);

--- a/src/utils/devicegeneric.hpp
+++ b/src/utils/devicegeneric.hpp
@@ -117,6 +117,7 @@ protected:
 	std::vector<Channel*> m_channel_list_out;
 	Buffer* m_buffer;
 	const char *m_dev_name;
+	static int MAX_RETRIES;
 };
 }
 }

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -132,8 +132,16 @@ void DeviceOut::stop()
 
 void DeviceOut::setKernelBuffersCount(unsigned int count)
 {
+	int retry = 0;
+	int ret = 0;
 	if (m_dev) {
-		int ret = iio_device_set_kernel_buffers_count(m_dev, count);
+		while (retry < DeviceGeneric::MAX_RETRIES) {
+			ret = iio_device_set_kernel_buffers_count(m_dev, count);
+			if (ret == 0) {
+				break;
+			}
+			retry++;
+		}
 		if (ret != 0) {
 			THROW_M2K_EXCEPTION("Device: Cannot set the number of kernel buffers", libm2k::EXC_RUNTIME_ERROR, ret);
 		}


### PR DESCRIPTION
Writing the kernel buffers count can fail if the iio_buffer is not properly removed. The setter will retry to write it a couple of times.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>