### PR TITLE
udev add uaccess tag

### DIFF
--- a/53-adi-m2k-usb.rules
+++ b/53-adi-m2k-usb.rules
@@ -1,6 +1,6 @@
 # allow "plugdev" group read/write access to ADI M2K devices
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b672", MODE="0664", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b675", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b672", MODE="0664", GROUP="plugdev" TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b675", MODE="0664", GROUP="plugdev" TAG+="uaccess"
 # tell the ModemManager (part of the NetworkManager suite) that the device is not a modem, 
 # and don't send AT commands to it
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0456", ATTRS{idProduct}=="b672", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
The modern way to allow console users access to USB gadgets is the uaccess tag.
This patch adds the udev uaccess tag.
See https://wiki.debian.org/USB/GadgetSetup
and the lintian check: https://lintian.debian.org/tags/udev-rule-missing-uaccess