### PR TITLE
appveyor: Build the latest libiio version.

### DIFF
--- a/CI/appveyor/build_appveyor_msvc.sh
+++ b/CI/appveyor/build_appveyor_msvc.sh
@@ -3,6 +3,8 @@
 set -e
 MCS_EXECUTABLE_PATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319"
 OLD_PATH="$PATH"
+DEST_LIBIIO="/c/libiio"
+TOP_DIR="/c/projects/libm2k"
 
 __build_libm2k() {
 	local PLATFORM="$1"
@@ -12,16 +14,16 @@ __build_libm2k() {
 	local PLAT_NAME="${5:-$PLATFORM}"
 
 	# Create the official build directory for this platform
-	mkdir -p "/c/projects/libm2k/build-$PLATFORM/dist"
+	mkdir -p "${TOP_DIR}/build-$PLATFORM/dist"
 
 	# Create and clear up the temporary build directory for this platform
-	rm -rf "/c/projects/libm2k/tmp-build-$PLATFORM"
-	mkdir -p "/c/projects/libm2k/tmp-build-$PLATFORM"
+	rm -rf "${TOP_DIR}/tmp-build-$PLATFORM"
+	mkdir -p "${TOP_DIR}/tmp-build-$PLATFORM"
 	export PATH="$PY_PATH;$PY_PATH/libs;$OLD_PATH"
-	cd /c/projects/libm2k/tmp-build-"$PLATFORM"
+	cd ${TOP_DIR}/tmp-build-"$PLATFORM"
 	cmake -G "$GENERATOR" \
-        -DIIO_LIBRARIES:FILEPATH=/c/libiio-"$PLATFORM"/libiio.lib \
-        -DIIO_INCLUDE_DIRS:PATH=/c/libiio-"$PLATFORM" \
+	-DIIO_LIBRARIES:FILEPATH="$DEST_LIBIIO"-"$PLATFORM"/libiio.lib \
+	-DIIO_INCLUDE_DIRS:PATH="$DEST_LIBIIO"-"$PLATFORM" \
         -DCMAKE_CONFIGURATION_TYPES=RELEASE \
         -DSWIG_DIR=/c/swig/Lib \
         -DSWIG_EXECUTABLE=/c/swig/swig.exe \
@@ -31,22 +33,22 @@ __build_libm2k() {
         -DPython_EXECUTABLE="$PY_PATH/python.exe" \
         -DBUILD_EXAMPLES=ON \
         -DENABLE_CSHARP=ON \
-	 -DENABLE_LABVIEW=ON \
+	-DENABLE_LABVIEW=ON \
         ..
 	cmake --build . --config Release
 
 	"$PY_PATH/python.exe" -m pip install --user --upgrade setuptools wheel
 	SETUPTOOLS_USE_DISTUTILS=stdlib "$PY_PATH/python.exe" setup.py bdist_wininst
 	"$PY_PATH/python.exe" setup.py sdist bdist_wheel --plat-name "$PLAT_NAME" --python-tag py"$PY_VERSION"
-    cp dist/libm2k-*.exe "/c/projects/libm2k/build-$PLATFORM/dist/libm2k-py$PY_VERSION-$PLATFORM.exe"
-	cp dist/libm2k-*.whl "/c/projects/libm2k/build-$PLATFORM/dist/"
+	cp dist/libm2k-*.exe "${TOP_DIR}/build-$PLATFORM/dist/libm2k-py$PY_VERSION-$PLATFORM.exe"
+	cp dist/libm2k-*.whl "${TOP_DIR}/build-$PLATFORM/dist/"
 }
 
 __mv_to_build_dir() {
 	local PLATFORM="$1"
 
-	DST_FOLDER="/c/projects/libm2k/build-$PLATFORM/"
-	cd "/c/projects/libm2k/tmp-build-$PLATFORM"
+	DST_FOLDER="${TOP_DIR}/build-$PLATFORM/"
+	cd "${TOP_DIR}/tmp-build-$PLATFORM"
 	cp *.dll $DST_FOLDER
 	cp *.exe $DST_FOLDER
 	cp *.lib $DST_FOLDER

--- a/CI/appveyor/install_deps_msvc.sh
+++ b/CI/appveyor/install_deps_msvc.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+DEST_LIBIIO="/c/libiio"
+SRC_LIBIIO="/c/projects/libiio"
+DEPS_LIBIIO="/c/libs"
+TOP_DIR=$(pwd)
+
+
+__build_libiio() {
+	local PLATFORM="$1"
+	local VERSION="$2"
+	local CONFIGURATION="$3"
+	local GENERATOR="$4"
+
+	# Create the build directory for this platform
+	mkdir -p "$SRC_LIBIIO/build-$PLATFORM"
+	cd "$SRC_LIBIIO/build-$PLATFORM"
+
+	cmake -G "$GENERATOR" -DCMAKE_CONFIGURATION_TYPES="$CONFIGURATION" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DCSHARP_BINDINGS:BOOL=OFF -DPYTHON_BINDINGS:BOOL=OFF -DLIBXML2_LIBRARIES="$DEPS_LIBIIO/$VERSION/libxml2.lib" -DLIBUSB_LIBRARIES="$DEPS_LIBIIO/$VERSION/libusb-1.0.lib" ..
+	cmake --build . --config "$CONFIGURATION"
+
+	__mv_to_build_dir $PLATFORM $VERSION $CONFIGURATION
+}
+
+__mv_to_build_dir() {
+	local PLATFORM="$1"
+	local VERSION="$2"
+	local CONFIGURATION="$3"
+
+	DST_FOLDER="$DEST_LIBIIO-$PLATFORM/"
+	mkdir -p "$DST_FOLDER"
+	cd "$SRC_LIBIIO/build-$PLATFORM"
+	cp $CONFIGURATION/*.dll $DST_FOLDER
+	cp tests/$CONFIGURATION/*.exe $DST_FOLDER
+	cp $CONFIGURATION/*.lib $DST_FOLDER
+	cp *.iss $DST_FOLDER
+	cp $DEPS_LIBIIO/$VERSION/*.dll $DST_FOLDER
+	cd ..
+	cp iio.h $DST_FOLDER
+}
+
+git clone https://github.com/analogdevicesinc/libiio "$SRC_LIBIIO"
+cd "$SRC_LIBIIO"
+git checkout 52e6dc3
+git submodule update --init
+
+
+__build_libiio win64 64 RELEASE "Visual Studio 15 Win64"
+__build_libiio win32 32 RELEASE "Visual Studio 15"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,22 +18,14 @@ cache:
   - C:\glog -> CI\appveyor\install_glog.bat
 
 install:
-    # Download libiio
+    #Download libiio deps
+    - echo "Downloading deps..."
     - cd c:\
-    - appveyor DownloadFile https://ci.appveyor.com/api/projects/analogdevicesinc/libiio/artifacts/libiio.zip?branch=master
-    - 7z x libiio*.zip > nul
-    - mkdir libiio-win64
-    - mkdir libiio-win32
-    - mkdir libiio-mingw-win64
-    - mkdir libiio-mingw-win32
-    - mv libiio-*/MS64/* libiio-win64/
-    - cp libiio-*/include/* libiio-win64/
-    - mv libiio-*/MS32/* libiio-win32/
-    - cp libiio-*/include/* libiio-win32/
-    - mv libiio-*/MinGW32/* libiio-mingw-win32/
-    - cp libiio-*/include/* libiio-mingw-win32/
-    - mv libiio-*/MinGW64/* libiio-mingw-win64/
-    - cp libiio-*/include/* libiio-mingw-win64/
+    - appveyor DownloadFile http://swdownloads.analog.com/cse/build/libiio-win-deps.zip
+    - 7z x -y "c:\libiio-win-deps.zip"
+
+    # Build and install libiio
+    - bash -c "/c/projects/libm2k/CI/appveyor/install_deps_msvc.sh"
 
     # Download SWIG
     - cd c:\
@@ -56,6 +48,10 @@ build_script:
     #Create the installer
     - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x86\Microsoft.VC141.CRT\msvcp140.dll" c:\projects\libm2k\build-win32
     - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x64\Microsoft.VC141.CRT\msvcp140.dll" c:\projects\libm2k\build-win64
+    - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x86\Microsoft.VC141.CRT\vcruntime140.dll" c:\projects\libm2k\build-win32
+    - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x64\Microsoft.VC141.CRT\vcruntime140.dll" c:\projects\libm2k\build-win64
+    - copy "c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x86\Microsoft.VC120.CRT\msvcr120.dll" c:\projects\libm2k\build-win32
+    - copy "c:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x64\Microsoft.VC120.CRT\msvcr120.dll" c:\projects\libm2k\build-win64
     - ISCC c:\projects\libm2k\build-win64\libm2k.iss
     - appveyor PushArtifact C:\libm2k-system-setup.exe
 
@@ -70,12 +66,12 @@ build_script:
     - copy build-win32\libm2k-sharp.dll c:\libm2k-win32\
     - copy build-win32\libm2k-sharp-cxx-wrap.dll c:\libm2k-win32\
     - copy build-win32\*.exe c:\libm2k-win32\
+    - copy build-win32\msvc*.dll c:\libm2k-win32\
+    - copy build-win32\vcruntime*.dll c:\libm2k-win32\
     - copy build-win32\dist\*.exe c:\libm2k-win32\dist\
     - copy build-win32\dist\*.whl c:\libm2k-win32\dist\
     - copy c:\libiio-win32\*.dll c:\libm2k-win32\
     - copy c:\glog\build_0_4_0-Win32\Release\glog.dll c:\libm2k-win32\
-    #- $Fullname = Get-ChildItem -Path "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\*\x86" -Filter msvcp140.dll -Recurse |  %{echo $_.FullName}
-    - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x86\Microsoft.VC141.CRT\msvcp140.dll" c:\libm2k-win32\
     - 7z a "c:\libm2k-win32.zip" c:\libm2k-win32
     - ps: Get-ChildItem c:\libm2k-win32\dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
     - appveyor PushArtifact c:\libm2k-win32.zip
@@ -88,12 +84,13 @@ build_script:
     - copy build-win64\libm2k-sharp.dll c:\libm2k-win64\
     - copy build-win64\libm2k-sharp-cxx-wrap.dll c:\libm2k-win64\
     - copy build-win64\*.exe c:\libm2k-win64\
+    - copy build-win64\msvc*.dll c:\libm2k-win64\
+    - copy build-win64\vcruntime*.dll c:\libm2k-win64\
     - copy build-win64\dist\*.exe c:\libm2k-win64\dist\
     - copy build-win64\dist\*.whl c:\libm2k-win64\dist\
     - copy c:\libiio-win64\*.dll c:\libm2k-win64\
     - copy c:\glog\build_0_4_0-x64\Release\glog.dll c:\libm2k-win64\
-    #- $Fullname = Get-ChildItem -Path "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\*\x64" -Filter msvcp140.dll -Recurse |  %{echo $_.FullName}
-    - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC\14.16.27012\x64\Microsoft.VC141.CRT\msvcp140.dll" c:\libm2k-win64\
+
     - 7z a "c:\libm2k-win64.zip" c:\libm2k-win64
     - ps: Get-ChildItem c:\libm2k-win64\dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
     - appveyor PushArtifact c:\libm2k-win64.zip


### PR DESCRIPTION
Lock the libiio version at hash 52e6dc3 for now.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>