### PR TITLE
libm2k.i: Add definition for contexts info vector in the swig py bindings

### DIFF
--- a/bindings/libm2k.i
+++ b/bindings/libm2k.i
@@ -152,6 +152,7 @@ namespace std {
 	typedef std::vector<libm2k::M2K_TRIGGER_CONDITION_ANALOG> M2kConditionAnalog;
 	typedef std::vector<libm2k::M2K_TRIGGER_CONDITION_DIGITAL> M2kConditionDigital;
 	typedef std::vector<libm2k::M2K_TRIGGER_MODE> M2kModes;
+	typedef std::vector<struct libm2k::CONTEXT_INFO*> VectorCtxInfo;
 %}
 
 #ifdef COMMUNICATION
@@ -272,6 +273,7 @@ namespace std {
 %template(M2kConditionAnalog) std::vector<libm2k::M2K_TRIGGER_CONDITION_ANALOG>;
 %template(M2kConditionDigital) std::vector<libm2k::M2K_TRIGGER_CONDITION_DIGITAL>;
 %template(M2kModes) std::vector<libm2k::M2K_TRIGGER_MODE>;
+%template(VectorCtxInfo) std::vector<struct libm2k::CONTEXT_INFO*>;
 
 #ifdef SWIGPYTHON
 	%template(IioBuffers) std::vector<struct iio_buffer*>;


### PR DESCRIPTION

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>