### PR TITLE
M2kDigital: fix reset

### DIFF
--- a/src/digital/m2kdigital_impl.cpp
+++ b/src/digital/m2kdigital_impl.cpp
@@ -115,6 +115,7 @@ void M2kDigitalImpl::reset()
 {
 	cancelAcquisition();
 	cancelBufferOut();
+	stopBufferOut();
 	for (unsigned int i = 0; i < m_dev_generic->getNbChannels(false); i++) {
 		/* Disable all the TX channels */
 


### PR DESCRIPTION
added stopBufferOut() to reset()

This ensures the number of kernel buffers can be set when calling the reset method for the digital object. 

Signed-off-by: cristina-suteu <cristina.suteu@analog.com>