### PR TITLE
tools/m2kcli: added context component

### DIFF
--- a/tools/m2kcli/commands/context/context.cpp
+++ b/tools/m2kcli/commands/context/context.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2019 Analog Devices Inc.
+ *
+ * This file is part of libm2k
+ * (see http://www.github.com/analogdevicesinc/libm2k).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "context.h"
+#include <sstream>
+#include <algorithm>
+#include <libm2k/analog/dmm.hpp>
+#include <string>
+
+using namespace libm2k::cli;
+
+Context::Context(int argc, char **argv) : Command(argc, argv)
+{
+	if (context != nullptr) {
+		dmm = context->getDMM("ad9963");
+	}
+}
+
+bool Context::parseArguments(std::vector<std::pair<std::string, std::string>> &output)
+{
+	if (context == nullptr) {
+		std::cout << helpMessage;
+		return false;
+	}
+
+        int c, option_index = 0;
+        bool quiet = false;
+        while ((c = getopt_long(argc, argv, "hqifILmstlupv",
+                                options, &option_index)) != -1) {
+                switch (c) {
+                case 'h':
+                    std::cout << helpMessage;
+                    return quiet;
+                case 'q':
+                    quiet = true;
+                    break;
+                case 'i':
+                    handleContextInfo(output);
+                    break;
+                case 'f':
+                    handleFirmware(output);
+                    break;
+                case 'I':
+                    handleIIO(output);
+                    break;
+                case 'L':
+                    handleLinux(output);
+                    break;
+                case 'm':
+                    handleModel(output);
+                    break;
+                case 's':
+                    handleSerial(output);
+                    break;
+                case 't':
+                    handleTemperature(output);
+                    break;
+                case 'l':
+                    handleLibusb(output);
+                    break;
+                case 'u':
+                    handleUri(output);
+                    break;
+                case 'p':
+                    handleProduct(output);
+                    break;
+                case 'v':
+                    handleVendor(output);
+                    break;
+                default:
+                    break;
+                }
+        }
+        return quiet;
+}
+
+void Context::handleContextInfo(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("Firmware version"),
+                         context->getFirmwareVersion());
+        auto iio = context->getIioContextVersion();
+        addOutputMessage(output, ("IIO version"),
+                         iio.git_tag);
+        addOutputMessage(output, ("Linux"),
+                         context->getContextDescription());
+        addOutputMessage(output, ("Model"),
+                         context->getContextAttributeValue("hw_model"));
+        addOutputMessage(output, ("Product Name"),
+                         context->getContextAttributeValue("usb,product"));
+        addOutputMessage(output, ("Serial"),
+                         context->getSerialNumber());
+        auto temp = dmm->readChannel("temp0");
+        addOutputMessage(output, ("Temperature"),
+                         std::to_string(temp.value));
+        addOutputMessage(output, ("Vendor"),
+                         context->getContextAttributeValue("usb,vendor"));
+        addOutputMessage(output, ("uri"),
+                         context->getUri());
+        addOutputMessage(output, ("usb,libusb"),
+                         context->getContextAttributeValue("usb,libusb"));
+}
+
+void Context::handleFirmware(std::vector<std::pair<std::string, std::string>> &output)
+{
+	addOutputMessage(output, ("Firmware version"),
+			context->getFirmwareVersion());
+}
+
+void Context::handleIIO(std::vector<std::pair<std::string, std::string>> &output)
+{
+        auto iio = context->getIioContextVersion();
+        addOutputMessage(output, ("IIO version"),
+                         iio.git_tag);
+}
+
+void Context::handleLinux(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("Linux"),
+                         context->getContextDescription());
+}
+
+void Context::handleModel(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("Model"),
+                         context->getContextAttributeValue("hw_model"));
+}
+
+void Context::handleSerial(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("Serial"),
+                         context->getSerialNumber());
+}
+
+void  Context::handleTemperature(std::vector<std::pair<std::string, std::string>> &output)
+{
+        auto temp = dmm->readChannel("temp0");
+        addOutputMessage(output, ("Temperature"),
+                         std::to_string(temp.value));
+}
+
+void Context::handleLibusb(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("usb,libusb"),
+                         context->getContextAttributeValue("usb,libusb"));
+}
+
+void Context::handleUri(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("uri"),
+                         context->getUri());
+}
+
+void Context::handleProduct(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("Product Name"),
+                         context->getContextAttributeValue("usb,product"));
+}
+
+void Context::handleVendor(std::vector<std::pair<std::string, std::string>> &output)
+{
+        addOutputMessage(output, ("Vendor"),
+                         context->getContextAttributeValue("usb,vendor"));
+}
+
+const struct option Context::options[] = {
+        {"help",        no_argument,       nullptr, 'h'},
+        {"quiet",       no_argument,       nullptr, 'q'},
+        {"info",        no_argument,       nullptr, 'i'},
+        {"firmware",    no_argument,       nullptr, 'f'},
+        {"iio",         no_argument,       nullptr, 'I'},
+        {"linux",       no_argument,       nullptr, 'L'},
+        {"serial",      no_argument,       nullptr, 's'},
+        {"temperature", no_argument,       nullptr, 't'},
+        {"libusb",      no_argument,       nullptr, 'l'},
+        {"uri",         no_argument,       nullptr, 'u'},
+        {"product",     no_argument,       nullptr, 'p'},
+        {"vendor",      no_argument,       nullptr, 'v'},
+        {nullptr, 0,                       nullptr, 0},
+};
+
+const char *const Context::helpMessage = "Usage:\n"
+                                         "m2kcli context <uri>\n"
+                                         "                 [-h | --help]\n"
+                                         "                 [-q | --quiet]\n"
+                                         "                 [-i | --info]\n"
+                                         "                 [-f | --firmware]\n"
+                                         "                 [-I | --iio]\n"
+                                         "                 [-L | --linux]\n"
+                                         "                 [-s | --serial]\n"
+                                         "                 [-t | --temperature]\n"
+                                         "                 [-l | --libusb]\n"
+                                         "                 [-u | --uri]\n"
+                                         "                 [-p | --product]\n"
+                                         "                 [-v | --vendor]\n"
+                                         "\n"
+                                         "Positional arguments:\n"
+                                         "  uri                   describe the context location \n"
+                                         "                        auto | ip:192.168.2.1 | usb:XX.XX.X\n"
+                                         "Optional arguments:\n"
+                                         "  -h, --help            show this help message and exit\n"
+                                         "  -q, --quiet           return result only\n"
+                                         "  -i, --info            show context information\n"
+                                         "  -f, --firmware        show firmware version\n"
+                                         "  -I, --iio             show libiio version\n"
+                                         "  -L, --linux           show linux version\n"
+                                         "  -s, --serial          show serial number\n"
+                                         "  -t, --temperature     show device temperature\n"
+                                         "  -l, --libusb          show libusb version\n"
+                                         "  -u, --uri             show uri\n"
+                                         "  -p, --product         show product name\n"
+                                         "  -v, --vendor          show vendor\n";

--- a/tools/m2kcli/commands/context/context.h
+++ b/tools/m2kcli/commands/context/context.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 Analog Devices Inc.
+ *
+ * This file is part of libm2k
+ * (see http://www.github.com/analogdevicesinc/libm2k).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef M2KCLI_CONTEXT_H
+#define M2KCLI_CONTEXT_H
+
+#include <libm2k/m2k.hpp>
+#include <libm2k/context.hpp>
+#include "commands/command_in.h"
+
+class DMM;
+
+namespace libm2k {
+namespace cli {
+
+
+
+class Context : public Command {
+public:
+	Context(int argc, char **argv);
+
+	bool parseArguments(std::vector<std::pair<std::string, std::string>> &output) override;
+
+private:
+
+	libm2k::analog::DMM* dmm;
+    
+	static const struct option options[];
+
+	void handleContextInfo(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleFirmware(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleIIO(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleLinux(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleModel(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleSerial(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleTemperature(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleLibusb(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleUri(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleProduct(std::vector<std::pair<std::string, std::string>> &output);
+
+	void handleVendor(std::vector<std::pair<std::string, std::string>> &output);
+
+	static const char *const helpMessage;
+};
+}
+}
+
+
+#endif //M2KCLI_CONTEXT_H

--- a/tools/m2kcli/main.cpp
+++ b/tools/m2kcli/main.cpp
@@ -29,33 +29,35 @@
 #include "commands/communication/i2c.h"
 #include "commands/communication/uart.h"
 #include "commands/communication/uart_terminal.h"
+#include "commands/context/context.h"
 #include <libm2k/contextbuilder.hpp>
 #include <csignal>
 #include <thread>
 
 static const char *const helpMessage = "Usage:\n"
-				       "m2kcli [-h | --help] [-v | --version]\n"
-				       "       <command> [<args>]\n"
-				       "\n"
-				       "Control the ADALM2000\n"
-				       "\n"
-				       "Optional arguments:\n"
-				       "  -h, --help            show this help message and exit\n"
-				       "  -v, --version         show the libm2k version and exit\n"
-				       "  -s, --scan            retrieve all available USB URIs\n"
-				       "  -i, --identify <uri>  identify the m2k based on its URI\n"
-				       "\n"
-				       "Commands:\n"
-				       "  These commands represent the components of the ADALM2000\n"
-				       "\n"
-				       "    analog-in           control the analogical input component\n"
-				       "    analog-out          control the analogical output component\n"
-				       "    digital             control the digital component\n"
-				       "    power-supply        control the power supply\n"
-				       "    spi			control the functionality of spi\n"
-				       "    i2c			control the functionality of i2c\n"
-				       "    uart		control the functionality of uart\n"
-				       "    uart-terminal	control the functionality of uart streaming\n";
+                                       "m2kcli [-h | --help] [-v | --version]\n"
+                                       "       <command> [<args>]\n"
+                                       "\n"
+                                       "Control the ADALM2000\n"
+                                       "\n"
+                                       "Optional arguments:\n"
+                                       "  -h, --help            show this help message and exit\n"
+                                       "  -v, --version         show the libm2k version and exit\n"
+                                       "  -s, --scan            retrieve all available USB URIs\n"
+                                       "  -i, --identify <uri>  identify the m2k based on its URI\n"
+                                       "\n"
+                                       "Commands:\n"
+                                       "  These commands represent the components of the ADALM2000\n"
+                                       "\n"
+                                       "    context             control the context component\n"
+                                       "    analog-in           control the analogical input component\n"
+                                       "    analog-out          control the analogical output component\n"
+                                       "    digital             control the digital component\n"
+                                       "    power-supply        control the power supply\n"
+                                       "    spi			control the functionality of spi\n"
+                                       "    i2c			control the functionality of i2c\n"
+                                       "    uart		control the functionality of uart\n"
+                                       "    uart-terminal	control the functionality of uart streaming\n";
 
 libm2k::cli::Command *command;
 void destroy(int sigNumber);
@@ -112,34 +114,37 @@ int main(int argc, char **argv)
 			return 0;
 		}
 
-		if (std::string(argv[1]) == "analog-in") {
-			auto *analogIn = new libm2k::cli::AnalogIn(argc, argv);
-			command = analogIn;
-		} else if (std::string(argv[1]) == "analog-out") {
-			auto *analogOut = new libm2k::cli::AnalogOut(argc, argv);
-			command = analogOut;
-		} else if (std::string(argv[1]) == "digital") {
-			auto *digital = new libm2k::cli::Digital(argc, argv);
-			command = digital;
-		} else if (std::string(argv[1]) == "power-supply") {
-			auto *powerSupply = new libm2k::cli::PowerSupply(argc, argv);
-			command = powerSupply;
-		} else if (std::string(argv[1]) == "spi") {
-			auto *spi = new libm2k::cli::Spi(argc, argv);
-			command = spi;
-		} else if (std::string(argv[1]) == "i2c") {
-			auto *i2c = new libm2k::cli::I2c(argc, argv);
-			command = i2c;
-		} else if (std::string(argv[1]) == "uart") {
-			auto *uart = new libm2k::cli::Uart(argc, argv);
-			command = uart;
-		} else if (std::string(argv[1]) == "uart-terminal") {
-			auto *uartTerminal = new libm2k::cli::UartTerminal(argc, argv);
-			command = uartTerminal;
-		} else {
-			throw std::runtime_error("m2kcli: '" + std::string(argv[1]) +
-						 "' is not a m2kcli command. See 'm2kcli --help'.\n");
-		}
+                if (std::string(argv[1]) == "context") {
+                    auto *context = new libm2k::cli::Context(argc, argv);
+                    command = context;
+                } else if (std::string(argv[1]) == "analog-in") {
+                    auto *analogIn = new libm2k::cli::AnalogIn(argc, argv);
+                    command = analogIn;
+                } else if (std::string(argv[1]) == "analog-out") {
+                    auto *analogOut = new libm2k::cli::AnalogOut(argc, argv);
+                    command = analogOut;
+                } else if (std::string(argv[1]) == "digital") {
+                    auto *digital = new libm2k::cli::Digital(argc, argv);
+                    command = digital;
+                } else if (std::string(argv[1]) == "power-supply") {
+                    auto *powerSupply = new libm2k::cli::PowerSupply(argc, argv);
+                    command = powerSupply;
+                } else if (std::string(argv[1]) == "spi") {
+                    auto *spi = new libm2k::cli::Spi(argc, argv);
+                    command = spi;
+                } else if (std::string(argv[1]) == "i2c") {
+                    auto *i2c = new libm2k::cli::I2c(argc, argv);
+                    command = i2c;
+                } else if (std::string(argv[1]) == "uart") {
+                    auto *uart = new libm2k::cli::Uart(argc, argv);
+                    command = uart;
+                } else if (std::string(argv[1]) == "uart-terminal") {
+                    auto *uartTerminal = new libm2k::cli::UartTerminal(argc, argv);
+                    command = uartTerminal;
+                } else {
+                    throw std::runtime_error("m2kcli: '" + std::string(argv[1]) +
+                            "' is not a m2kcli command. See 'm2kcli --help'.\n");
+                }
 		quiet = command->parseArguments(output);
 	}
 	catch (std::runtime_error &e) {


### PR DESCRIPTION
added context component which retrieves the following context attributes:
- firmware version
- iio version
- linux version
- hardware model
- product name 
- serial number
- device temperature
- vendor
- uri
- libusb version

Signed-off-by: cristina-suteu <cristina.suteu@analog.com>