### PR TITLE
Matlab bindings: Fix ADC acquisition.

### DIFF
--- a/bindings/libm2k.i
+++ b/bindings/libm2k.i
@@ -33,6 +33,8 @@
 %ignore pushBytes;
 %ignore getVoltageP;
 %ignore getVoltageRawP;
+%ignore getSamplesRawInterleaved_matlab;
+%ignore getSamplesInterleaved_matlab;
 %rename(pushBytes) push(unsigned short*, unsigned int);
 
 %ignore buildLoggingMessage;

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -107,7 +107,7 @@ public:
 	* @note Due to a hardware limitation, the number of samples must
 	* be a multiple of 4 and greater than 16.
 	*/
-	virtual const double* getSamplesInterleaved(unsigned int nb_samples) = 0;
+	virtual const double* getSamplesInterleaved(unsigned int nb_samples_per_channel) = 0;
 
 
 	/**
@@ -122,7 +122,8 @@ public:
 	* @note Due to a hardware limitation, the number of samples must
 	* be a multiple of 4 and greater than 16.
 	*/
-	virtual const short* getSamplesRawInterleaved(unsigned int nb_samples) = 0;
+	virtual const short* getSamplesRawInterleaved(unsigned int nb_samples_per_channel) = 0;
+
 
 	/**
 	* @brief Retrieve a specific number of samples from both channels

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -124,6 +124,39 @@ public:
 	*/
 	virtual const short* getSamplesRawInterleaved(unsigned int nb_samples) = 0;
 
+	/**
+	* @brief Retrieve a specific number of samples from both channels
+	*
+	* @param nb_samples The number of samples that will be retrieved
+	* @return A pointer to the interleaved samples
+	*
+	* @note MATLAB specific API wrapper
+	* @note Before the acquisition, both channels will be automatically enabled
+	* @note The data array will contain samples from both channels
+	* @note The data array will contain nb_samples/2 for each channel
+	* @note After the acquisition is finished, the channels will return to their initial state
+	* @note Due to a hardware limitation, the number of samples must
+	* be a multiple of 4 and greater than 16.
+	*/
+	virtual const double* getSamplesInterleaved_matlab(unsigned int nb_samples) = 0;
+
+
+	/**
+	* @brief Retrieve a specific number of raw samples from both channels
+	*
+	* @param nb_samples The number of samples that will be retrieved
+	* @return A pointer to the interleaved raw samples
+	*
+	* @note MATLAB specific API wrapper
+	* @note Before the acquisition, both channels will be automatically enabled
+	* @note The data array will contain samples from both channels
+	* @note The data array will contain nb_samples/2 for each channel
+	* @note After the acquisition is finished, the channels will return to their initial state
+	* @note Due to a hardware limitation, the number of samples must
+	* be a multiple of 4 and greater than 16.
+	*/
+	virtual const short* getSamplesRawInterleaved_matlab(unsigned int nb_samples) = 0;
+
 
 	/**
 	* @brief Retrieve the average raw value of the given channel

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -396,9 +396,9 @@ bool M2kAnalogInImpl::hasCalibbias()
 	return m_calibbias_available;
 }
 
-const double* M2kAnalogInImpl::getSamplesInterleaved(unsigned int nb_samples)
+const double* M2kAnalogInImpl::getSamplesInterleaved(unsigned int nb_samples_per_channel)
 {
-	return this->getSamplesInterleaved(nb_samples, true);
+	return this->getSamplesInterleaved(nb_samples_per_channel, true);
 }
 
 const double *M2kAnalogInImpl::getSamplesInterleaved(unsigned int nb_samples, bool processed)
@@ -421,12 +421,12 @@ const double *M2kAnalogInImpl::getSamplesInterleaved(unsigned int nb_samples, bo
 	return samps;
 }
 
-const short *M2kAnalogInImpl::getSamplesRawInterleaved(unsigned int nb_samples)
+const short *M2kAnalogInImpl::getSamplesRawInterleaved(unsigned int nb_samples_per_channel)
 {
 	LIBM2K_LOG(INFO, "[BEGIN] M2kAnalogIn getSamplesRawInterleaved");
 	m_samplerate = getSampleRate();
 	handleChannelsEnableState(true);
-	auto samps = m_m2k_adc->getSamplesRawInterleaved(nb_samples);
+	auto samps = m_m2k_adc->getSamplesRawInterleaved(nb_samples_per_channel);
 	handleChannelsEnableState(false);
 	LIBM2K_LOG(INFO, "[END] M2kAnalogIn getSamplesRawInterleaved");
 	return samps;

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -432,6 +432,16 @@ const short *M2kAnalogInImpl::getSamplesRawInterleaved(unsigned int nb_samples)
 	return samps;
 }
 
+const double *M2kAnalogInImpl::getSamplesInterleaved_matlab(unsigned int nb_samples)
+{
+	return this->getSamplesInterleaved(nb_samples / getNbChannels(), true);
+}
+
+const short *M2kAnalogInImpl::getSamplesRawInterleaved_matlab(unsigned int nb_samples)
+{
+	return this->getSamplesRawInterleaved(nb_samples / getNbChannels());
+}
+
 double M2kAnalogInImpl::processSample(int16_t sample, unsigned int channel)
 {
 	if (channel >= getNbChannels()) {

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -47,6 +47,8 @@ public:
 
 	const double* getSamplesInterleaved(unsigned int nb_samples) override;
 	const short* getSamplesRawInterleaved(unsigned int nb_samples) override;
+	const double* getSamplesInterleaved_matlab(unsigned int nb_samples) override;
+	const short* getSamplesRawInterleaved_matlab(unsigned int nb_samples) override;
 
 	short getVoltageRaw(unsigned int ch) override;
 	double getVoltage(unsigned int ch) override;

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -45,8 +45,9 @@ public:
 	std::vector<std::vector<double>> getSamples(unsigned int nb_samples) override;
 	std::vector<std::vector<double>> getSamplesRaw(unsigned int nb_samples) override;
 
-	const double* getSamplesInterleaved(unsigned int nb_samples) override;
-	const short* getSamplesRawInterleaved(unsigned int nb_samples) override;
+	const double* getSamplesInterleaved(unsigned int nb_samples_per_channel) override;
+	const short* getSamplesRawInterleaved(unsigned int nb_samples_per_channel) override;
+
 	const double* getSamplesInterleaved_matlab(unsigned int nb_samples) override;
 	const short* getSamplesRawInterleaved_matlab(unsigned int nb_samples) override;
 


### PR DESCRIPTION
Due to some known limitation, the MATLAB wrappers need to request the
total number of samples, instead of requesting number of samples per channel.
We added 2 new API methods only for the MATLAB wrappers. This way, the
behaviour until now for all the other bindings available won't be affected.