### PR TITLE
m2k_impl.cpp: initialize timeout to "no timeout" instead of UINT_MAX …

### DIFF
--- a/src/m2k_impl.cpp
+++ b/src/m2k_impl.cpp
@@ -52,7 +52,7 @@ M2kImpl::M2kImpl(std::string uri, iio_context* ctx, std::string name, bool sync)
 	m_sync(sync)
 {
 	initialize();
-	setTimeout(UINT_MAX);
+	setTimeout(0);
 
 	for (auto ain : m_instancesAnalogIn) {
 		delete ain;


### PR DESCRIPTION
…timeout

When using "UINT_MAX" timeout, an overflow occurs when using local backend
of libiio. Even if this didn't happen, initializing with infinite timeout
is the correct implementation.

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>