### PR TITLE
GenericAnalogIn: Check if 'sampling_frequency' is a channel attribute.

### DIFF
--- a/src/analog/generic/genericanalogin_impl.cpp
+++ b/src/analog/generic/genericanalogin_impl.cpp
@@ -23,6 +23,7 @@
 #include "genericanalogin_impl.hpp"
 #include <libm2k/m2kexceptions.hpp>
 #include "libm2k/utils/utils.hpp"
+#include "utils/channel.hpp"
 #include <iio.h>
 #include <iostream>
 #include <algorithm>
@@ -91,7 +92,12 @@ std::vector<double> GenericAnalogInImpl::getAvailableSampleRates()
 	std::vector<std::string> stringValues;
 	std::vector<double> values;
 
-	stringValues = getAdcDevice(0)->getAvailableAttributeValues("sampling_frequency");
+	if (getAdcDevice(0)->hasGlobalAttribute("sampling_frequency")) {
+		stringValues = getAdcDevice(0)->getAvailableAttributeValues("sampling_frequency");
+	} else {
+		stringValues = getAdcDevice(0)->getChannel(0, false)->getAvailableAttributeValues("sampling_frequency");
+	}
+
 	std::transform(stringValues.begin(), stringValues.end(), std::back_inserter(values),
 		       [] (std::string &s) -> double {
 		try {

--- a/src/utils/channel.cpp
+++ b/src/utils/channel.cpp
@@ -378,6 +378,11 @@ std::vector<std::string> Channel::getAvailableAttributeValues(const std::string 
 	std::vector<std::string> values;
 	std::string valuesAsString;
 
+	if (!hasAttribute(attr)) {
+		THROW_M2K_EXCEPTION(std::string(m_channel_id) + " has no " + attr + " attribute", libm2k::EXC_INVALID_PARAMETER);
+		return std::vector<std::string>();
+	}
+
 	__try {
 		valuesAsString = getStringValue(std::string(attr + "_available"));
 		std::istringstream iss(valuesAsString);


### PR DESCRIPTION
An iio device samples using only one samplerate. Sometimes the 'sampling_frequency' attribute is located inside all channels, these sharing it.

Signed-off-by: Teo Perisanu <Teo.Perisanu@analog.com>