### PR TITLE
Examples: Add reset() to examples, before calibrating the ADC and DAC.

### DIFF
--- a/bindings/python/examples/analog.py
+++ b/bindings/python/examples/analog.py
@@ -37,12 +37,17 @@ if ctx is None:
 	print("Connection Error: No ADALM2000 device available/connected to your PC.")
 	exit(1)
 
-ctx.calibrateADC()
-ctx.calibrateDAC()
 
 ain=ctx.getAnalogIn()
 aout=ctx.getAnalogOut()
 trig=ain.getTrigger()
+
+# Prevent bad initial config for ADC and DAC
+ain.reset()
+aout.reset()
+
+ctx.calibrateADC()
+ctx.calibrateDAC()
 
 ain.enableChannel(0,True)
 ain.enableChannel(1,True)

--- a/bindings/python/examples/analog_raw_bytes.py
+++ b/bindings/python/examples/analog_raw_bytes.py
@@ -20,12 +20,16 @@ if ctx is None:
 	print("Connection Error: No ADALM2000 device available/connected to your PC.")
 	exit(1)
 
-ctx.calibrateADC()
-ctx.calibrateDAC()
-
 ain=ctx.getAnalogIn()
 aout=ctx.getAnalogOut()
 trig=ain.getTrigger()
+
+# Prevent bad initial config for ADC and DAC
+ain.reset()
+aout.reset()
+
+ctx.calibrateADC()
+ctx.calibrateDAC()
 
 ain.enableChannel(0,True)
 ain.enableChannel(1,True)

--- a/bindings/python/examples/analogin_sync_2m2ks.py
+++ b/bindings/python/examples/analogin_sync_2m2ks.py
@@ -71,16 +71,30 @@ if ctx2 is None:
     print("Connection Error: No second ADALM2000 device available/connected to your PC.")
     exit(1)
 
-ctx.calibrateADC()
-ctx.calibrateDAC()
-ctx2.calibrateADC()
-ctx2.calibrateDAC()
-
 # Configure 1st context
 ain = ctx.getAnalogIn()
 aout = ctx.getAnalogOut()
 dig = ctx.getDigital()
 trig = ain.getTrigger()
+
+# Prevent bad initial config for ADC and DAC
+ain.reset()
+aout.reset()
+dig.reset()
+
+# Configure 2nd context
+ain2 = ctx2.getAnalogIn()
+dig2 = ctx2.getDigital()
+trig2 = dig2.getTrigger()
+
+# Prevent bad initial config for ADC and DAC
+ain2.reset()
+dig2.reset()
+
+ctx.calibrateADC()
+ctx.calibrateDAC()
+ctx2.calibrateADC()
+ctx2.calibrateDAC()
 
 if trig.hasExternalTriggerOut():
     trig.setAnalogExternalOutSelect(libm2k.SELECT_ANALOG_IN)  # Forward Analog trigger on TO pin
@@ -94,10 +108,6 @@ dig.setDirection(DIGITAL_CH, libm2k.DIO_OUTPUT)
 dig.enableChannel(DIGITAL_CH, True)
 dig.setValueRaw(DIGITAL_CH, libm2k.LOW)
 
-# Configure 2nd context
-ain2 = ctx2.getAnalogIn()
-dig2 = ctx2.getDigital()
-trig2 = dig2.getTrigger()
 ain2.enableChannel(0, True)
 ain2.enableChannel(1, True)
 ain2.setSampleRate(sampling_frequency_in)

--- a/bindings/python/examples/audio_flip.py
+++ b/bindings/python/examples/audio_flip.py
@@ -38,13 +38,18 @@ if ctx is None:
     print("Connection Error: No ADALM2000 device available/connected to your PC.")
     exit(1)
 
-ctx.calibrateADC()
-ctx.calibrateDAC()
-
 ain = ctx.getAnalogIn()
 aout = ctx.getAnalogOut()
 trig = ain.getTrigger()
 ps = ctx.getPowerSupply()
+
+# Prevent bad initial config for ADC and DAC
+ain.reset()
+aout.reset()
+ps.reset()
+
+ctx.calibrateADC()
+ctx.calibrateDAC()
 
 ps.enableChannel(0, True)  # Consider using for microphone power,
 ps.pushChannel(0, 4.0)  # unfortunately DC blocking cap takes forever to charge

--- a/bindings/python/examples/digital.py
+++ b/bindings/python/examples/digital.py
@@ -31,6 +31,7 @@ if ctx is None:
 	exit(1)
 
 dig=ctx.getDigital()
+dig.reset()
 
 dig.setSampleRateIn(10000)
 dig.setSampleRateOut(10000)

--- a/bindings/python/examples/digitalin_sync_2m2ks.py
+++ b/bindings/python/examples/digitalin_sync_2m2ks.py
@@ -72,6 +72,7 @@ ctx2.calibrateDAC()
 
 # Configure 1st M2K context
 dig = ctx.getDigital()
+dig.reset()
 dig.setDirection(DIGITAL_CH_TRIG, libm2k.DIO_OUTPUT)  # DIO pin which the digital interface
 dig.enableChannel(DIGITAL_CH_TRIG, False)
 dig.setValueRaw(DIGITAL_CH_TRIG, libm2k.LOW)
@@ -92,6 +93,7 @@ if trig.hasExternalTriggerOut():
 
 # Configure 2nd M2K context
 dig2 = ctx2.getDigital()
+dig2.reset()
 dig2.setDirection(DIGITAL_CH_TRIG, libm2k.DIO_INPUT)  # DIO pin on which the trigger signal is read
 dig2.enableChannel(DIGITAL_CH_TRIG, False)
 dig2.setDirection(DIGITAL_CH_READ, libm2k.DIO_INPUT)  # DIO pin on which the clock signal is read

--- a/bindings/python/examples/external_clocksource.py
+++ b/bindings/python/examples/external_clocksource.py
@@ -53,10 +53,15 @@ def generate_clock_signal(number_of_samples):
 # Context setup
 
 ctx = libm2k.m2kOpen()
-ctx.calibrateDAC()
-ctx.calibrateADC()
 aout = ctx.getAnalogOut()
 dig = ctx.getDigital()
+
+# Prevent bad initial config
+dig.reset()
+aout.reset()
+
+ctx.calibrateDAC()
+ctx.calibrateADC()
 
 # AnalogOut setup
 

--- a/bindings/python/examples/mixed_signal_view.py
+++ b/bindings/python/examples/mixed_signal_view.py
@@ -61,11 +61,15 @@ def main():
         print("Mixed Signal not available")
         exit(1)
 
-    context.calibrateDAC()
-
     analog_in = context.getAnalogIn()
     digital = context.getDigital()
     trigger = analog_in.getTrigger()
+
+    # Prevent bad initial config
+    analog_in.reset()
+    digital.reset()
+
+    context.calibrateDAC()
 
     analog_in.enableChannel(libm2k.CHANNEL_1, True)
     analog_in.enableChannel(libm2k.CHANNEL_2, True)

--- a/bindings/python/examples/powersupply.py
+++ b/bindings/python/examples/powersupply.py
@@ -32,6 +32,7 @@ if ctx is None:
 
 ctx.calibrateADC()
 ps=ctx.getPowerSupply()
+ps.reset()
 ps.enableChannel(0,True)
 ps.pushChannel(0,1.7)
 ain=ctx.getAnalogIn()

--- a/bindings/python/examples/voltmeter.py
+++ b/bindings/python/examples/voltmeter.py
@@ -29,8 +29,12 @@ if ctx is None:
 	print("Connection Error: No ADALM2000 device available/connected to your PC.")
 	exit(1)
 
-ctx.calibrateADC()
 ain=ctx.getAnalogIn()
+
+# Prevent bad initial config
+ain.reset()
+
+ctx.calibrateADC()
 ain.enableChannel(channel,True)
 print(ain.getVoltage()[channel])
 

--- a/examples/analog/analog_in_out.cpp
+++ b/examples/analog/analog_in_out.cpp
@@ -52,14 +52,18 @@ int main(int argc, char* argv[])
 		return 1;
 	}
 
-	ctx->calibrateADC();
-	ctx->calibrateDAC();
-
 	M2kAnalogIn *ain = ctx->getAnalogIn();
 	M2kAnalogOut *aout = ctx->getAnalogOut();
 #ifdef TRIGGERING
 	M2kHardwareTrigger *trig = ain->getTrigger();
 #endif
+
+	// Prevent bad initial config
+	ain->reset();
+	aout->reset();
+
+	ctx->calibrateADC();
+	ctx->calibrateDAC();
 
 	// Setup analog in
 	ain->enableChannel(0, true);

--- a/examples/analog/stream_test_adc.cpp
+++ b/examples/analog/stream_test_adc.cpp
@@ -316,12 +316,16 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	ctx->calibrateADC();
-	ctx->calibrateDAC();
-
 	M2kAnalogIn *ain = ctx->getAnalogIn();
 	M2kAnalogOut *aout = ctx->getAnalogOut();
 	M2kHardwareTrigger *trig = ain->getTrigger();
+
+	// Prevent bad initial config
+	ain->reset();
+	aout->reset();
+
+	ctx->calibrateADC();
+	ctx->calibrateDAC();
 
 	/* Always use MAX_SR_IN, adjust the samplerate using oversampling_ratio (sr_divider) */
 	ain->setSampleRate(MAX_SAMPLE_RATE_IN);

--- a/examples/analog/stream_test_dac.cpp
+++ b/examples/analog/stream_test_dac.cpp
@@ -158,9 +158,12 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	ctx->calibrateDAC();
-
 	M2kAnalogOut *aout = ctx->getAnalogOut();
+
+	// Prevent bad initial config
+	aout->reset();
+
+	ctx->calibrateDAC();
 
 	aout->setSampleRate(0, MAX_SAMPLE_RATE_OUT);
 	aout->setSampleRate(1, MAX_SAMPLE_RATE_OUT);

--- a/examples/analog/streaming_one_channel.cpp
+++ b/examples/analog/streaming_one_channel.cpp
@@ -22,9 +22,12 @@ int main()
 		return 1;
 	}
 
-	context->calibrateDAC();
-
 	M2kAnalogOut *analogOut = context->getAnalogOut();
+
+	// Prevent bad initial config
+	analogOut->reset();
+
+	context->calibrateDAC();
 
 	analogOut->setKernelBuffersCount(0, buffersCount);
 	analogOut->setKernelBuffersCount(1, buffersCount);

--- a/examples/analog/streaming_synchronized.cpp
+++ b/examples/analog/streaming_synchronized.cpp
@@ -20,9 +20,12 @@ int main()
 		return 1;
 	}
 
-	context->calibrateDAC();
-
 	M2kAnalogOut *analogOut = context->getAnalogOut();
+
+	// Prevent bad initial config
+	analogOut->reset();
+
+	context->calibrateDAC();
 
 	analogOut->setKernelBuffersCount(0, 32);
 	analogOut->setKernelBuffersCount(1, 20);

--- a/examples/analog/sync_stream_diff_frequencies.cpp
+++ b/examples/analog/sync_stream_diff_frequencies.cpp
@@ -36,9 +36,12 @@ int main()
 		return 1;
 	}
 
-	context->calibrateDAC();
-
 	M2kAnalogOut *analogOut = context->getAnalogOut();
+
+	// Prevent bad initial config
+	analogOut->reset();
+
+	context->calibrateDAC();
 
 	analogOut->setKernelBuffersCount(0, kernelBuffers[0]);
 	analogOut->setKernelBuffersCount(1, kernelBuffers[1]);


### PR DESCRIPTION
Some examples don't handle all the possible attributes (oversampling_ratio).
If the analogIn or analogOut object are not reset before using, the
result might be wrong.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>