### PR TITLE
ContextBuilder: Make sure iio_context_destroy is called by the object  that  has ownership over the created iio_context.

### DIFF
--- a/include/libm2k/contextbuilder.hpp
+++ b/include/libm2k/contextbuilder.hpp
@@ -110,7 +110,8 @@ private:
 	static Context* buildContext(ContextTypes type,
 		std::string uri,
 		struct iio_context *ctx,
-		bool sync);
+		bool sync,
+		bool ownsContext = false);
 	static bool m_disable_logging;
 
 };

--- a/src/context_impl.cpp
+++ b/src/context_impl.cpp
@@ -40,6 +40,7 @@ ContextImpl::ContextImpl(std::string uri, struct iio_context *ctx, std::string n
 	m_context = ctx;
 	m_uri = uri;
 	m_sync = sync;
+	m_ownsContext = false;
 
 	/* Initialize the DMM list */
 	scanAllDMM();
@@ -54,7 +55,7 @@ ContextImpl::~ContextImpl()
 	}
 	m_instancesDMM.clear();
 
-	if (m_context) {
+	if (m_context && m_ownsContext) {
 		iio_context_destroy(m_context);
 	}
 }
@@ -453,4 +454,9 @@ struct iio_context *ContextImpl::getIioContext()
 void ContextImpl::setTimeout(unsigned int timeout)
 {
 	iio_context_set_timeout(m_context, timeout);
+}
+
+void ContextImpl::setContextOwnership(bool ownsContext)
+{
+        m_ownsContext = ownsContext;
 }

--- a/src/context_impl.hpp
+++ b/src/context_impl.hpp
@@ -90,6 +90,7 @@ public:
 	const struct libm2k::IIO_CONTEXT_VERSION getIioContextVersion() override;
 	struct iio_context *getIioContext() override;
 	void setTimeout(unsigned int timeout) override;
+	void setContextOwnership(bool ownsContext);
 
 protected:
 	struct iio_context* m_context;
@@ -109,6 +110,7 @@ private:
 	std::string m_uri;
 	std::string m_name;
 	bool m_sync;
+	bool m_ownsContext;
 };
 }
 }


### PR DESCRIPTION

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>