### PR TITLE
m2kcli: fix catching polymorphic type by value

### DIFF
--- a/tools/m2kcli/commands/communication/uart_terminal.cpp
+++ b/tools/m2kcli/commands/communication/uart_terminal.cpp
@@ -239,7 +239,7 @@ void UartTerminal::writeData() {
 			try {
 				auto escapeSequence = LinuxKeyEncoder::getLinuxCode(c);
 				uart_write(uartDescTx, escapeSequence.data(), escapeSequence.size());
-			} catch (std::runtime_error) {
+			} catch (std::runtime_error const&) {
 				continue;
 			}
 		} else if (LinuxKeyEncoder::isExitCode(c)) {
@@ -260,7 +260,7 @@ void UartTerminal::writeData() {
 				}
 				uart_write(uartDescTx, escapeSequence.data(), escapeSequence.size());
 
-			} catch (std::runtime_error) {
+			} catch (std::runtime_error const&) {
 				continue;
 			}
 #endif

--- a/tools/m2kcli/utils/validator.cpp
+++ b/tools/m2kcli/utils/validator.cpp
@@ -108,7 +108,7 @@ void Validator::validate(std::string strNumber, double &number)
 {
 	try {
 		number = std::stod(strNumber);
-	} catch (std::exception e) {
+	} catch (std::exception const& e) {
 		throw std::runtime_error("'" + strNumber + "' is not a number.\n");
 	}
 }
@@ -117,7 +117,7 @@ void Validator::validate(std::string strNumber, uint16_t &number)
 {
 	try {
 		number = std::stoi(strNumber);
-	} catch (std::exception e) {
+	} catch (std::exception const& e) {
 		throw std::runtime_error("'" + strNumber + "' is not a number.\n");
 	}
 }


### PR DESCRIPTION
Solve the following warnings.

tools/m2kcli/commands/communication/uart_terminal.cpp:263:39: warning: catching polymorphic type ‘class std::runtime_error’ by value [-Wcatch-value=]
  263 |                         } catch (std::runtime_error) {
      |                                       ^~~~~~~~~~~~~

tools/m2kcli/utils/validator.cpp:111:33: warning: catching polymorphic type ‘class std::exception’ by value [-Wcatch-value=]
  111 |         } catch (std::exception e) {

tools/m2kcli/utils/validator.cpp:120:33: warning: catching polymorphic type ‘class std::exception’ by value [-Wcatch-value=]
  120 |         } catch (std::exception e) {

Signed-off-by: Cosmin Tanislav <demonsingur@gmail.com>