### PR TITLE
devicegeneric.cpp: Implement a busy retry when trying to write the kernel buffers count.

### DIFF
--- a/src/m2kcalibration_impl.cpp
+++ b/src/m2kcalibration_impl.cpp
@@ -124,17 +124,7 @@ void M2kCalibrationImpl::setAdcInCalibMode()
 
 	m_m2k_adc->loadNbKernelBuffers();
 	m_adc_kernel_buffers = m_m2k_adc->getKernelBuffersCount();
-
-	while (!ok) {
-		try {
-			m_m2k_adc->setKernelBuffersCount(1);
-			ok = true;
-		} catch (m2k_exception &e) {
-			if (e.iioCode() != -EBUSY) {
-				THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
-			}
-		}
-	}
+	m_m2k_adc->setKernelBuffersCount(1);
 }
 
 void M2kCalibrationImpl::setDacInCalibMode()
@@ -157,17 +147,8 @@ void M2kCalibrationImpl::setDacInCalibMode()
 	m_m2k_dac->loadNbKernelBuffers();
 	m_dac_a_kernel_buffers = m_m2k_dac->getKernelBuffersCount(0);
 	m_dac_b_kernel_buffers = m_m2k_dac->getKernelBuffersCount(1);
-	while (!ok) {
-		try {
-			m_m2k_dac->setKernelBuffersCount(0, 1);
-			m_m2k_dac->setKernelBuffersCount(1, 1);
-			ok = true;
-		} catch (m2k_exception &e) {
-			if (e.iioCode() != -EBUSY) {
-				THROW_M2K_EXCEPTION(e.what(), e.type(), e.iioCode());
-			}
-		}
-	}
+	m_m2k_dac->setKernelBuffersCount(0, 1);
+	m_m2k_dac->setKernelBuffersCount(1, 1);
 }
 
 void M2kCalibrationImpl::restoreAdcFromCalibMode()

--- a/src/utils/deviceout.cpp
+++ b/src/utils/deviceout.cpp
@@ -130,19 +130,6 @@ void DeviceOut::stop()
 	}
 }
 
-void DeviceOut::setKernelBuffersCount(unsigned int count)
-{
-	if (m_dev) {
-		int ret = iio_device_set_kernel_buffers_count(m_dev, count);
-		if (ret != 0) {
-			THROW_M2K_EXCEPTION("Device: Cannot set the number of kernel buffers", libm2k::EXC_RUNTIME_ERROR, ret);
-		}
-		const char *deviceName = iio_device_get_name(m_dev);
-		LIBM2K_LOG(INFO,
-                   libm2k::buildLoggingMessage({deviceName}, ("Set kernel buffers count: " + std::to_string(count)).c_str()));
-	}
-}
-
 struct libm2k::IIO_OBJECTS DeviceOut::getIioObjects()
 {
 	IIO_OBJECTS iio_object = {};

--- a/src/utils/deviceout.hpp
+++ b/src/utils/deviceout.hpp
@@ -56,7 +56,6 @@ public:
 	void push(short *data, unsigned int channel, unsigned int nb_samples, bool cyclic = true);
 	void stop();
 	void cancelBuffer();
-	void setKernelBuffersCount(unsigned int count);
 	struct IIO_OBJECTS getIioObjects();
 
 private:

--- a/tests/analog_functions.py
+++ b/tests/analog_functions.py
@@ -1268,3 +1268,17 @@ def test_timeout(ctx, ain, aout, trig, channel, dir_name, file, csv_path):
         plt.close()
     aout.stop()
     return offset, average, t_occ
+
+def test_kernel_buffers(ain, trig, nb_kernel_buffers):
+    error = False
+    reset.analog_in(ain)
+    reset.trigger(trig)
+
+    ain.setSampleRate(1000000)
+    ain.startAcquisition(10000)
+    ain.stopAcquisition()
+    try:
+        ain.setKernelBuffersCount(nb_kernel_buffers)
+    except:
+        error = True
+    return error

--- a/tests/digital_functions.py
+++ b/tests/digital_functions.py
@@ -320,3 +320,16 @@ def save_data_to_csv(csv_vals, csv_file):
     df = DataFrame(csv_vals)
     df.to_csv(csv_file)
     return
+
+def test_kernel_buffers(dig, nb_kernel_buffers):
+    error = False
+    dig.reset()
+
+    dig.startAcquisition(16)
+    data = dig.getSamples(16)
+    dig.stopAcquisition()
+    try:
+        dig.setKernelBuffersCountIn(nb_kernel_buffers)
+    except:
+        error = True
+    return error

--- a/tests/m2k_analog_test.py
+++ b/tests/m2k_analog_test.py
@@ -4,7 +4,7 @@ import libm2k
 
 from shapefile import shape_gen, ref_shape_gen, shape_name
 from analog_functions import test_amplitude, test_shape, phase_diff_ch0_ch1, test_offset, test_analog_trigger, \
-    test_voltmeter_functionality
+    test_voltmeter_functionality, test_kernel_buffers
 from analog_functions import noncyclic_buffer_test, set_samplerates_for_shapetest, set_trig_for_cyclicbuffer_test, \
     test_calibration
 from analog_functions import compare_in_out_frequency, test_oversampling_ratio, channels_diff_in_samples, test_timeout, \
@@ -44,6 +44,13 @@ class A_AnalogTests(unittest.TestCase):
         calibration = test_calibration(ctx)
         with self.subTest(msg='Test if ADC and DAC were succesfully calibrated'):
             self.assertEqual(calibration, (True, True), 'Calibration failed')
+
+    def test_kernel_buffers(self):
+        # Verifies if the kernel buffer count can be set without throwing runtime error (busy retry works)
+        test_err = test_kernel_buffers(ain, trig, 4)
+        with self.subTest(
+            msg='Set kernel buffers count on AIN without raising an error '):
+            self.assertEqual(test_err, False, 'Error occured')
 
     def test_shapes_ch0(self):
         # Verifies that all the elements of a correlation vector  returned by test_shape() are greater than 0.85. A

--- a/tests/m2k_digital_test.py
+++ b/tests/m2k_digital_test.py
@@ -1,7 +1,7 @@
 import unittest
 import libm2k
 from digital_functions import dig_reset, set_digital_trigger, check_digital_channels_state, check_digital_output, \
-    check_digital_trigger, check_open_drain_mode
+    check_digital_trigger, check_open_drain_mode, test_kernel_buffers
 from digital_functions import test_digital_cyclic_buffer
 from open_context import dig, d_trig
 import logger
@@ -44,3 +44,9 @@ class D_DigitalTests(unittest.TestCase):
             with self.subTest(i):
                 self.assertEqual(test_digital_cyclic_buffer(dig, d_trig, i), 0, "Channel: " + str(i))
 
+    def test_kernel_buffers(self):
+        # Verifies if the kernel buffer count can be set without throwing runtime error (busy retry works)
+        test_err = test_kernel_buffers(dig, 4)
+        with self.subTest(
+            msg='Set kernel buffers count on Digital In without raising an error '):
+            self.assertEqual(test_err, False, 'Error occured')

--- a/tests/main.py
+++ b/tests/main.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
         print(" ===== tests ====== \n")
         print("test_1_analog_objects\n"
               "test_2_calibration\n"
+              "test_kernel_buffers"
               "test_amplitude\n"
               "test_analog_trigger_ch0\n"
               "test_analog_trigger_ch1\n"
@@ -89,6 +90,7 @@ if __name__ == "__main__":
         print("test_digital_output_channels\n")
         print("test_trig_conditions\n")
         print("test_cyclic_buffer\n")
+        print("test_kernel_buffers\n")
 
         exit()
     elif len(sys.argv) > 1 and "nofiles" in sys.argv:


### PR DESCRIPTION
Calling set_kernel_buffers_count() right after destroying a buffer might
return EBUSY because the file descriptor is still in use.
