### PR TITLE
update build tamplate and build installer for matlab 2022b

### DIFF
--- a/bindings/matlab/bsp.tmpl
+++ b/bindings/matlab/bsp.tmpl
@@ -6,7 +6,7 @@
     <param.company>Analog Devices, Inc</param.company>
     <param.summary>Bindings for the libm2k interface library</param.summary>
     <param.description>Bindings and examples for the libm2k interface library for the Analog Devices ADALM-M2000 hardware.</param.description>
-    <param.screenshot>__REPO-ROOT__/doc/ADI_Logo_AWP_Large.png</param.screenshot>
+    <param.screenshot>libm2k_logo.png</param.screenshot>
     <param.version>__VERSION__</param.version>
     <param.output>${PROJECT_ROOT}/AnalogDeviceslibm2kBindings.mltbx</param.output>
     <param.products.name>
@@ -31,7 +31,7 @@
       <item>9.0</item>
     </param.products.version>
     <param.platforms />
-    <param.guid>40075943-d2d1-4d90-8e59-b3eff5f58180</param.guid>
+    <param.guid>9f0bd333-fc8b-4cf0-be27-c48b576ae1c0</param.guid>
     <param.exclude.filters>%
 CI/*
 test/*

--- a/bindings/matlab/build_installer.m
+++ b/bindings/matlab/build_installer.m
@@ -1,6 +1,6 @@
 function build_installer()
 
-version = '22.1.1';
+version = '22.1.2';
 ml = ver('MATLAB');
 ml = ml.Release(2:end-1);
 arch = computer('arch');


### PR DESCRIPTION
generated new uuid for matlab bindings project in build template 
update build installer to match the correct version of matlab (Matlab 2022b) 