### PR TITLE
DeviceGeneric.cpp: If the previous call failed, allow more time to settle.

### DIFF
--- a/src/utils/devicegeneric.cpp
+++ b/src/utils/devicegeneric.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <sstream>
 #include <iterator>
+#include <thread>
 
 using namespace std;
 using namespace libm2k::utils;
@@ -644,6 +645,9 @@ void DeviceGeneric::setKernelBuffersCount(unsigned int count)
 		retry++;
 		if (ret != -EBUSY) {
 			ok = true;
+		} else {
+			// If the call failed, allow more time to settle
+			std::this_thread::sleep_for(std::chrono::milliseconds(5));
 		}
 	}
 	if (ret != 0) {


### PR DESCRIPTION
Failure means that the buffer was not yet destroyed, so the next call will probably fail as well if we don't delay the process.