### PR TITLE
ContextBuilder: solve context close bug using reference count

### DIFF
--- a/include/libm2k/contextbuilder.hpp
+++ b/include/libm2k/contextbuilder.hpp
@@ -113,6 +113,11 @@ private:
 		bool ownsContext = false);
 	static bool m_disable_logging;
 
+	static std::map<std::string, int> reference_count;
+	static void incrementReferenceCount(std::string uri);
+	static void decrementReferenceCount(std::string uri);
+	static bool checkLastReference(std::string uri);
+	static Context* searchInConnectedDevices(std::string uri);
 };
 
 /**


### PR DESCRIPTION
- added reference count to ContextBuilder to keep track of how many external references to the M2k context are present. When the last reference is removed, the M2k context can be closed.
- contexts should be closed in the reverse order they were opened: contextClose() -> iio_context_destroy() to avoid pointer errors.
- based on context ownership, the user of the API is responsible of deinitalizing resources.