### PR TITLE
M2kAnalogIn: sync calibration state with device attributes

### DIFF
--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -181,11 +181,12 @@ void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int raw_offse
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
 	const int rawVertOffset = m_adc_hw_offset_raw.at(channel) - m_adc_calib_offset.at(channel);
-	if (m_calibbias_available) {
-		m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, raw_offset, "calibbias", false);
-	} else {
-		m_adc_calib_offset.at(channel) = raw_offset;
-	}
+	// if (m_calibbias_available) {
+	// 	m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, raw_offset, "calibbias", false);
+	// } else {
+	// 	m_adc_calib_offset.at(channel) = raw_offset;
+	// }
+	m_adc_calib_offset.at(channel) = raw_offset;
 
 	int hw_offset_raw = rawVertOffset + m_adc_calib_offset.at(channel);
 	m_adc_hw_offset_raw.at(channel) = m_ad5625_dev->setLongValue(channel + 2, hw_offset_raw, "raw", true);
@@ -249,7 +250,7 @@ double M2kAnalogInImpl::setCalibscale(unsigned int index, double calibscale)
 	if (firmware_version > "0.31") {
 		m_adc_calib_gain.at(index) = calibscale;
 	}
-	return m_m2k_adc->setDoubleValue(index, calibscale, "calibscale");
+	return calibscale;
 }
 
 libm2k::M2kHardwareTrigger *M2kAnalogInImpl::getTrigger()
@@ -906,11 +907,12 @@ void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_off
 	double vertOffset = convertRawToVoltsVerticalOffset(channel, vert_offset);
 	m_adc_hw_vert_offset.at(channel) = vertOffset;
 
-	if (m_calibbias_available) {
-                m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, calib_offset, "calibbias", false);
-        } else {
-                m_adc_calib_offset.at(channel) = calib_offset;
-	}
+	// if (m_calibbias_available) {
+    //             m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, calib_offset, "calibbias", false);
+    //     } else {
+    //             m_adc_calib_offset.at(channel) = calib_offset;
+	// }
+	m_adc_calib_offset.at(channel) = calib_offset;
 
 	const int hw_offset_raw = vert_offset + m_adc_calib_offset.at(channel);
 	m_adc_hw_offset_raw.at(channel) = m_ad5625_dev->setLongValue(channel + 2, hw_offset_raw, "raw", true);
@@ -925,11 +927,12 @@ void M2kAnalogInImpl::setAdcCalibOffset(ANALOG_IN_CHANNEL channel, int calib_off
     }
     m_adc_hw_vert_offset.at(channel) = vert_offset;
 
-    if (m_calibbias_available) {
-        m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, calib_offset, "calibbias", false);
-    } else {
-        m_adc_calib_offset.at(channel) = calib_offset;
-    }
+    // if (m_calibbias_available) {
+    //     m_adc_calib_offset.at(channel) = m_m2k_adc->setLongValue(channel, calib_offset, "calibbias", false);
+    // } else {
+    //     m_adc_calib_offset.at(channel) = calib_offset;
+    // }
+	m_adc_calib_offset.at(channel) = calib_offset;
 
     const int hw_offset_raw = convertVoltsToRaw(channel, vert_offset) + m_adc_calib_offset.at(channel);
     m_adc_hw_offset_raw.at(channel) = m_ad5625_dev->setLongValue(channel + 2, hw_offset_raw, "raw", true);

--- a/src/analog/m2kanalogin_impl.cpp
+++ b/src/analog/m2kanalogin_impl.cpp
@@ -49,7 +49,8 @@ M2kAnalogInImpl::M2kAnalogInImpl(iio_context * ctx, std::string adc_dev, bool sy
 	m_m2k_fabric = make_shared<DeviceGeneric>(ctx, "m2k-fabric");
 	m_ad5625_dev = make_shared<DeviceGeneric>(ctx, "ad5625");
 
-	if (firmware_version >= "v0.32") {
+	if (firmware_version >= "v0.31") {
+		std::cout << "Firmware version: " << firmware_version << std::endl;
 		setCalibrateHDL("true"); // NOTE: in new HDL we can control when the parameters are sent to HDL with this attribute
 	}
 
@@ -141,7 +142,7 @@ void M2kAnalogInImpl::syncDevice()
 		} else {
                         m_adc_calib_offset.at(i) = 2048;
 		}
-		if (firmware_version >= "v0.32") {
+		if (firmware_version >= "v0.31") {
 			m_adc_calib_gain.at(i) = getCalibscale(i);
 		}
 		m_adc_hw_offset_raw.at(i) = m_ad5625_dev->getLongValue(2 + i, "raw", true);
@@ -250,7 +251,7 @@ double M2kAnalogInImpl::setCalibscale(unsigned int index, double calibscale)
 	if (index >= getNbChannels()) {
 		THROW_M2K_EXCEPTION("M2kAnalogIn: no such channel", libm2k::EXC_OUT_OF_RANGE);
 	}
-	if (firmware_version >= "v0.32") {
+	if (firmware_version >= "v0.31") {
 		m_adc_calib_gain.at(index) = calibscale;
 	}
 	return m_m2k_adc->setDoubleValue(index, calibscale, "calibscale");

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -39,6 +39,7 @@ public:
 	~M2kAnalogInImpl() override;
 
 	void reset() override;
+	void syncDevice();
 	void startAcquisition(unsigned int nb_samples) override;
 	void stopAcquisition() override;
 
@@ -141,6 +142,7 @@ public:
 	bool hasCalibbias();
 	void loadNbKernelBuffers();
 private:
+	std::string firmware_version;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_ad5625_dev;
 	std::shared_ptr<libm2k::utils::DeviceGeneric> m_m2k_fabric;
 	std::shared_ptr<libm2k::utils::DeviceIn> m_m2k_adc;
@@ -160,8 +162,6 @@ private:
 	std::vector<bool> m_channels_enabled;
 	unsigned int m_nb_kernel_buffers;
 	bool m_data_available;
-
-	void syncDevice();
 
 	M2K_RANGE getRangeDevice(ANALOG_IN_CHANNEL channel);
 

--- a/src/analog/m2kanalogin_impl.hpp
+++ b/src/analog/m2kanalogin_impl.hpp
@@ -180,6 +180,9 @@ private:
 
 	int convertVoltsToRawVerticalOffset(ANALOG_IN_CHANNEL channel, double vertOffset);
 	double convertRawToVoltsVerticalOffset(ANALOG_IN_CHANNEL channel, int rawVertOffset);
+
+	void setCalibrateHDL(std::string calibrate_val);
+	std::string getCalibrateHDL();
 };
 }
 }


### PR DESCRIPTION
- Use device attributes in class instance for calibration at the SW level, samples should be sent uncalibrated. 
- Current firmware uses device attr to send calibrated samples by the HW. To simulate future firmware behaviour where samples are not calibrated we store the calibration result in the class instance, but don't write them to device attributes.
