### PR TITLE
doc omit build path

### DIFF
--- a/doc/Doxyfile_API.in
+++ b/doc/Doxyfile_API.in
@@ -150,7 +150,7 @@ INLINE_INHERITED_MEMB  = NO
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand
@@ -171,7 +171,8 @@ STRIP_FROM_PATH        =
 # specify the list of include paths that are normally passed to the compiler
 # using the -I flag.
 
-STRIP_FROM_INC_PATH    =
+STRIP_FROM_INC_PATH    = @PROJECT_SOURCE_DIR@ \
+		         @PROJECT_BINARY_DIR@
 
 # If the SHORT_NAMES tag is set to YES, doxygen will generate much shorter (but
 # less readable) file names. This can be useful is your file systems doesn't
@@ -992,7 +993,7 @@ REFERENCES_RELATION    = NO
 # link to the documentation.
 # The default value is: YES.
 
-REFERENCES_LINK_SOURCE = YES
+REFERENCES_LINK_SOURCE = NO
 
 # If SOURCE_TOOLTIPS is enabled (the default) then hovering a hyperlink in the
 # source code will show a tooltip with additional information such as prototype,

--- a/include/libm2k/analog/dmm.hpp
+++ b/include/libm2k/analog/dmm.hpp
@@ -39,7 +39,7 @@ namespace analog {
  * @defgroup dmm DMM
  * @brief Contains the representation of the digital multimeter
  * @{
- * @class DMM
+ * @class DMM dmm.hpp libm2k/analog/dmm.hpp
  * @brief Controls the digital multimeter
  */
 class LIBM2K_API DMM {

--- a/include/libm2k/analog/enums.hpp
+++ b/include/libm2k/analog/enums.hpp
@@ -36,7 +36,7 @@ namespace analog {
 
 
 	/**
-	* @struct DMM_READING
+	* @struct DMM_READING enums.hpp libm2k/analog/enums.hpp
 	* @brief The structure of a DMM
 	*
 	*/

--- a/include/libm2k/analog/m2kanalogin.hpp
+++ b/include/libm2k/analog/m2kanalogin.hpp
@@ -40,7 +40,7 @@ namespace analog {
  * @defgroup analogin AnalogIn
  * @brief Contains the representation of the analogical input segment
  * @{
- * @class M2kAnalogIn
+ * @class M2kAnalogIn m2kanalogin.hpp libm2k/analog/m2kanalogin.hpp
  * @brief Controls the analogical input compound
  */
 class LIBM2K_API M2kAnalogIn

--- a/include/libm2k/analog/m2kanalogout.hpp
+++ b/include/libm2k/analog/m2kanalogout.hpp
@@ -45,7 +45,7 @@ namespace analog {
  * @defgroup analogout AnalogOut
  * @brief Contains the representation of the analogical output segment
  * @{
- * @class M2kAnalogOut
+ * @class M2kAnalogOut m2kanalogout.hpp libm2k/analog/m2kanalogout.hpp
  * @brief Controls the analogical output compound
  */
 class LIBM2K_API M2kAnalogOut

--- a/include/libm2k/analog/m2kpowersupply.hpp
+++ b/include/libm2k/analog/m2kpowersupply.hpp
@@ -36,7 +36,7 @@ namespace analog {
  * @defgroup powersupply PowerSupply
  * @brief Contains the representation of the power supply
  * @{
- * @class M2kPowerSupply
+ * @class M2kPowerSupply m2kpowersupply.hpp libm2k/analog/m2kpowersupply.hpp
  * @brief Controls the power supply
  */
 class LIBM2K_API M2kPowerSupply {

--- a/include/libm2k/context.hpp
+++ b/include/libm2k/context.hpp
@@ -46,7 +46,7 @@ class Generic;
 /** @defgroup context Context
  * @brief Contains the representation of a generic IIO context
  * @{
- * @class Context
+ * @class Context context.hpp libm2k/context.hpp
  * @brief Controls the IIO context
  */
 class LIBM2K_API Context {

--- a/include/libm2k/digital/m2kdigital.hpp
+++ b/include/libm2k/digital/m2kdigital.hpp
@@ -38,7 +38,7 @@ namespace digital {
  * @defgroup digital Digital
  * @brief Contains the representation of the digital segment
  * @{
- * @class M2kDigital
+ * @class M2kDigital m2kdigital.hpp libm2k/digital/m2kdigital.hpp
  * @brief Controls the digital input and output segment
  */
 class LIBM2K_API M2kDigital

--- a/include/libm2k/enums.hpp
+++ b/include/libm2k/enums.hpp
@@ -51,7 +51,7 @@ namespace libm2k {
 
 
 	/**
-	* @struct CALIBRATION_PARAMETERS
+	* @struct CALIBRATION_PARAMETERS enums.hpp libm2k/enums.hpp
 	* @brief Calibration parameters of m2k
 	*/
 	struct CALIBRATION_PARAMETERS {
@@ -177,7 +177,7 @@ namespace libm2k {
 
 
 	/**
-	* @struct SETTINGS
+	* @struct SETTINGS enums.hpp libm2k/enums.hpp
 	* @brief Triggering system
 	*
 	*/
@@ -194,7 +194,7 @@ namespace libm2k {
 
 
 	/**
-	 * @struct CONTEXT_INFO
+	 * @struct CONTEXT_INFO enums.hpp libm2k/enums.hpp
 	 * @brief Additional information about the context
 	 */
 	struct CONTEXT_INFO {
@@ -220,7 +220,7 @@ namespace libm2k {
 	};
 
 	/**
-	 * @struct IIO_CONTEXT_VERSION
+	 * @struct IIO_CONTEXT_VERSION enums.hpp libm2k/enums.hpp
 	 * @brief The version of the backend
 	 */
 	struct IIO_CONTEXT_VERSION {

--- a/include/libm2k/m2k.hpp
+++ b/include/libm2k/m2k.hpp
@@ -48,7 +48,7 @@ namespace context {
 * @defgroup m2k M2k
 * @brief Contains the representation of the M2K
 * @{
-* @class M2k
+* @class M2k m2k.hpp libm2k/m2k.hpp
 * @brief Controls the ADALM2000
 */
 class LIBM2K_API M2k : public virtual Context

--- a/include/libm2k/m2khardwaretrigger.hpp
+++ b/include/libm2k/m2khardwaretrigger.hpp
@@ -35,7 +35,7 @@ namespace libm2k {
  * @defgroup m2ktrigger HardwareTrigger
  * @brief Contains the representation of the ADALM2000 trigger system
  * @{
- * @class M2kHardwareTrigger
+ * @class M2kHardwareTrigger m2khardwaretrigger.hpp libm2k/m2khardwaretrigger.hpp
  * @brief Controls the hardware trigger for ADALM2000
  */
 class LIBM2K_API M2kHardwareTrigger


### PR DESCRIPTION
In order to have reproducible builds with documentation, these Doxygen settings and markup changes are needed. (Previously the build path got put into HTML files.)