### PR TITLE
tests/analog: validate M2kAnalogOut features introduced in fw0.33

### DIFF
--- a/tests/analog_functions.py
+++ b/tests/analog_functions.py
@@ -13,6 +13,7 @@ import pandas
 import random
 import sys
 import reset_def_values as reset
+from helpers import get_result_files, save_data_to_csv, plot_to_file
 from open_context import ctx_timeout, ctx
 from create_files import results_file, results_dir, csv
 
@@ -133,16 +134,8 @@ def test_amplitude(out_data, ref_data, n, ain, aout, channel, trig):
     #    corr_amplitude_min -- correlation coefficient between the vector that holds the minimum amplitude values in the
     #    input signal and the vector that holds the maximum amplitude values in the reference signal
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
+
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -204,7 +197,7 @@ def test_amplitude(out_data, ref_data, n, ain, aout, channel, trig):
     data_string.append("Minimum amplitude computed:")
     data_string.append(str(min_in))
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
     aout.stop(channel)
     return corr_amplitude_max, corr_amplitude_min
 
@@ -229,16 +222,7 @@ def test_shape(channel, out_data, ref_data, ain, aout, trig, ch_ratio, shapename
     #    phase_diff_vect-- vector that holds the phase difference between the input data and the reference data for each
     #    signal shape
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -284,7 +268,7 @@ def test_shape(channel, out_data, ref_data, ain, aout, trig, ch_ratio, shapename
             "Correlation coefficient between " + shapename[i] + "signal and its reference:" + str(corr_shape))
         data_string.append("Phase difference between " + shapename[i] + "signal and its reference:" + str(phase_diff))
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
     aout.stop(channel)
 
     return corr_shape_vect, phase_diff_vect
@@ -304,16 +288,8 @@ def phase_diff_ch0_ch1(aout, ain, trig):
     # Returns:
     #    phase_diff_between_channels-- the phase difference between channels in degrees
     #  
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -359,7 +335,7 @@ def phase_diff_ch0_ch1(aout, ain, trig):
         phasediff_csv['Ch1, ADCsr=' + str(sr)] = input_data[libm2k.ANALOG_IN_CHANNEL_2]
     if gen_reports:
         channel = 0
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
         save_data_to_csv(phasediff_csv, csv_path + 'ph_diff_channels.csv')
     aout.stop()
 
@@ -380,16 +356,7 @@ def test_analog_trigger(channel, trig, aout, ain):
     #    trig_test -- Vector that holds 1 for each trigger condition fulfilled and 0 otherwise
     #    condition_name-- Vector that holds names of the trigger conditions
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -531,7 +498,7 @@ def test_analog_trigger(channel, trig, aout, ain):
             data_string.append("level set: " + str(high))
             data_string.append("\nlevel read: " + str(input_data[delay]))
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
     aout.stop(channel)
     return trig_test, condition_name
 
@@ -552,16 +519,7 @@ def test_offset(out_data, n, ain, aout, trig, channel):
     # Returns
     #    corr_offset -- Correlation coefficient between the computed offset vector and the defined offset vector
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -604,7 +562,7 @@ def test_offset(out_data, n, ain, aout, trig, channel):
 
     data_string.append(str(in_offset))
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
     corr_offset, _ = pearsonr(offset, in_offset)  # compare the original offset vector with the average values obtained
 
     aout.stop(channel)
@@ -623,16 +581,7 @@ def test_voltmeter_functionality(channel, ain, aout, ctx):
     # Returns:
     #    voltmeter_ -- Vector thet holds 1 if the read voltage is in specified range and 0 otherwise
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -666,7 +615,7 @@ def test_voltmeter_functionality(channel, ain, aout, ctx):
         else:
             voltmeter_ = np.append(voltmeter_, 0)  # the voltage is out of range
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
     aout.stop(channel)
 
     return voltmeter_
@@ -699,16 +648,7 @@ def cyclic_buffer_test(aout, ain, channel, trig):
     # Returns:
     #    cyclic_false -- Must be 1 if a single buffer was sent and succesfully recieved, 0 otherwise
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
     dac_sr = 75000
     adc_sr = 10000
     min_periods = 3
@@ -754,16 +694,7 @@ def noncyclic_buffer_test(aout, ain, channel, trig, ctx):
     # Returns:
     #    cyclic_false -- Must be 1 if a single buffer was sent and succesfully recieved, 0 otherwise
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -855,16 +786,7 @@ def compute_frequency(channel, ain, aout, trig):
     #    ofreqs-- Vector that holds the frequencies of the output buffers
     #    ifreqs-- Vector that holds the frequencies of the input buffers
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     test_name = "freq"
     data_string = []
@@ -924,7 +846,7 @@ def compute_frequency(channel, ain, aout, trig):
                 data_string.append("Out signal frequency:" + str(out_freq))
                 data_string.append("In singal frequency:" + str(in_freq))
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
 
     return ofreqs, ifreqs
 
@@ -987,16 +909,7 @@ def test_oversampling_ratio(channel, ain, aout, trig):
     #        test_osr -- Must be 1 if the computed oversampling ratio is equal with the set oversampling ratio
     #        and 0 otherwise
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
 
     reset.analog_in(ain)
     reset.analog_out(aout)
@@ -1044,51 +957,13 @@ def test_oversampling_ratio(channel, ain, aout, trig):
 
     data_string.append("Oversampling ratios computed: \n" + str(verify_osr))
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
     test_osr = 1
     for i in range(len(osr)):
         if osr[i] != verify_osr[i]:
             test_osr = 0
     aout.stop(channel)
     return test_osr
-
-
-def plot_to_file(title, data, dir_name, filename, xlabel=None, ylabel=None, data1=None, data_marked=None):
-    # Saves the plots in a separate folder
-    # Arguments:
-    #    title  -- Title of the plot
-    #    data  -- Data to be plotted
-    #    filename  -- Name of the file with the plot
-    # Keyword Arguments:
-    #    xlabel  -- Label of x-Axis (default: {None})
-    #    ylabel  -- Label of y-Axis(default: {None})
-    #    data1  --  Data that should be plotted on the same plot(default: {None})
-    #    data_marked -- Data that represents specific points on the plot(default: {None})
-    # plot the signals in a separate folder
-    plt.title(title)
-    if xlabel is not None:  # if xlabel and ylabel are not specified there will be default values
-        plt.xlabel(xlabel)
-    else:
-        plt.xlabel('Samples')
-    if ylabel is not None:
-        plt.ylabel(ylabel)
-    else:
-        plt.ylabel('Voltage [V]')
-    plt.grid(visible=True)
-    plt.plot(data)  # if a second set of data must be printed (for ch0 and ch1 phase difference in this case)
-    if data1 is not None:
-        plt.plot(data1)
-    if data_marked is not None:
-        plt.plot(data_marked, data[data_marked], 'xr')        
-    plt.savefig(dir_name + "/" + filename)
-    plt.close()
-    return
-
-
-def save_data_to_csv(csv_vals, csv_file):
-    df = DataFrame(csv_vals)
-    df.to_csv(csv_file)
-    return
 
 
 def channels_diff_in_samples(trig, channel, aout, ain):
@@ -1107,16 +982,7 @@ def channels_diff_in_samples(trig, channel, aout, ain):
     #    dac_osr-- oversampling ratios set for Aout
     #    freq -- frequency of the signals used for the test
 
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
     reset.analog_in(ain)
     reset.analog_out(aout)  # /len(samples_diff1[i])
     reset.trigger(trig)
@@ -1172,7 +1038,7 @@ def channels_diff_in_samples(trig, channel, aout, ain):
         data_string.append('Samples difference: ' + str(diff_osr))
 
     if gen_reports:
-        write_file(file, test_name, channel, data_string)
+        write_file(file_name, test_name, channel, data_string)
         save_data_to_csv(diff_in_samples0, csv_path + 'diffSamples_ch0_trigSrc_' + str(channel) + '.csv')
         save_data_to_csv(diff_in_samples1, csv_path + 'diffSamples_ch1_trigSrc_' + str(channel) + '.csv')
     aout.stop()
@@ -1317,16 +1183,7 @@ def is_spike(data, peak, threshold = 0.25):
     return percentage_dif > threshold
 
 def test_buffer_transition_glitch(channel, ain, aout, trig, waveform, amplitude=1):
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
     
     BUFFER_SIZE = 5_00_000
         
@@ -1401,7 +1258,7 @@ def test_buffer_transition_glitch(channel, ain, aout, trig, waveform, amplitude=
             "Number of glitch peaks found in " + waveform + " signal :" + str(num_peaks))
     
     if gen_reports:
-        write_file(file, test_name, channel, data_string)    
+        write_file(file_name, test_name, channel, data_string)    
         plot_to_file(f'Buffer Glitch , channel{channel}', 
                      data, 
                      dir_name, 

--- a/tests/bug_checks_functions.py
+++ b/tests/bug_checks_functions.py
@@ -2,6 +2,7 @@ from scipy.signal import find_peaks
 import matplotlib.pyplot as plt
 import libm2k
 
+from helpers import get_result_files, plot_to_file
 from open_context import ctx_timeout, ctx, ain, aout, trig
 
 gen_reports = True
@@ -9,16 +10,8 @@ gen_reports = True
 
 def test_dac_artifact(ain, aout, trig, chn):
     # check for DAC artifacts at slow sample rates
-    if gen_reports:
-        from create_files import results_file, results_dir, csv, open_files_and_dirs
-        if results_file is None:
-            file, dir_name, csv_path = open_files_and_dirs()
-        else:
-            file = results_file
-            dir_name = results_dir
-            csv_path = csv
-    else:
-        file = []
+    file_name, dir_name, csv_path = get_result_files(gen_reports)
+
     buffer_size = 4000
     sampling_frequency_in = 1000000
     sampling_frequency_out = 750000
@@ -64,32 +57,3 @@ def generate_clock_signal():
     for i in range(256):
         buffer.append(0)
     return buffer
-
-
-def plot_to_file(title, data, dir_name, filename, xlabel=None, ylabel=None, data1=None):
-    # Saves the plots in a separate folder
-    # Arguments:
-    #    title  -- Title of the plot
-    #    data  -- Data to be plotted
-    #    filename  -- Name of the file with the plot
-    # Keyword Arguments:
-    #    xlabel  -- Label of x-Axis (default: {None})
-    #    ylabel  -- Label of y-Axis(default: {None})
-    #    data1  --  Data that should be plotted on the same plot(default: {None})
-    # plot the signals in a separate folder
-    plt.title(title)
-    if xlabel is not None:  # if xlabel and ylabel are not specified there will be default values
-        plt.xlabel(xlabel)
-    else:
-        plt.xlabel('Samples')
-    if ylabel is not None:
-        plt.ylabel(ylabel)
-    else:
-        plt.ylabel('Voltage [V]')
-    plt.grid(visible=True)
-    plt.plot(data)  # if a second set of data must be printed (for ch0 and ch1 phase difference in this case)
-    if data1 is not None:
-        plt.plot(data1)
-    plt.savefig(dir_name + "/" + filename)
-    plt.close()
-    return

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -73,6 +73,40 @@ def plot_to_file(title, data, dir_name, filename, xlabel=None, x_lim = None, yla
     plt.close()
     return
 
+def plot_to_file_multiline(
+    title,
+    datasets,
+    dir_name,
+    filename,
+    xlabel="Samples", ylabel="Voltage [V]",
+    xlim = None,  ylim = None,
+):
+    plt.title(title)
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.grid(visible=True)
+
+    for data in datasets:
+        xdata, ydata, fmt = data
+        if xdata is not None:
+            if "marker" in fmt:
+                # Mark scattered points
+                plt.plot(xdata, ydata[xdata], linestyle="None", **fmt)
+            else:
+                plt.plot(xdata, ydata, **fmt)
+        else:
+            plt.plot(ydata, **fmt)
+    
+    if xlim is not None:
+        plt.xlim(*xlim)
+    if ylim is not None:
+        plt.ylim(*ylim)
+    plt.legend()
+
+    plt.savefig(f"{dir_name}/{filename}")
+    plt.close()
+    return
+
 
 def get_time_format(samples, sample_rate):
     x_time = np.linspace(0, samples/sample_rate, samples)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,5 @@
 
+import numpy as np
 from pandas import DataFrame
 import matplotlib.pyplot as plt
 
@@ -27,7 +28,7 @@ def save_data_to_csv(csv_vals, csv_file):
     return
 
 
-def plot_to_file(title, data, dir_name, filename, xlabel=None, ylabel=None, data1=None, data_marked=None):
+def plot_to_file(title, data, dir_name, filename, xlabel=None, x_lim = None, ylabel=None, y_lim = None, data1=None, x_data = None, data_marked=None):
     # Saves the plots in a separate folder
     # Arguments:
     #    title  -- Title of the plot
@@ -40,7 +41,8 @@ def plot_to_file(title, data, dir_name, filename, xlabel=None, ylabel=None, data
     #    data_marked -- Data that represents specific points on the plot(default: {None})
     # plot the signals in a separate folder
     plt.title(title)
-    if xlabel is not None:  # if xlabel and ylabel are not specified there will be default values
+    # if xlabel and ylabel are not specified there will be default values
+    if xlabel is not None:  
         plt.xlabel(xlabel)
     else:
         plt.xlabel('Samples')
@@ -49,11 +51,51 @@ def plot_to_file(title, data, dir_name, filename, xlabel=None, ylabel=None, data
     else:
         plt.ylabel('Voltage [V]')
     plt.grid(visible=True)
-    plt.plot(data)  # if a second set of data must be printed (for ch0 and ch1 phase difference in this case)
+    # if x_data is not None, the plot will be displayed with the specified x_data
+    if x_data is not None:
+        plt.plot(x_data, data)
+    else:
+        plt.plot(data)
+    # if a second set of data must be printed (for ch0 and ch1 phase difference in this case)
     if data1 is not None:
-        plt.plot(data1)
+        if x_data is not None:
+            plt.plot(x_data, data1)
+        else:
+            plt.plot(data1)
+    # Optional configurations
+    if x_lim is not None:
+        plt.xlim(*x_lim)
+    if y_lim is not None:
+        plt.ylim(*y_lim)
     if data_marked is not None:
         plt.plot(data_marked, data[data_marked], 'xr')        
     plt.savefig(dir_name + "/" + filename)
     plt.close()
     return
+
+
+def get_time_format(samples, sample_rate):
+    x_time = np.linspace(0, samples/sample_rate, samples)
+
+    if x_time[-1] < 1e-6:
+        x_time *= 1e9
+        x_label = "Time [ns]"
+    elif x_time[-1] < 1e-3:
+        x_time *= 1e6
+        x_label = "Time [us]"
+    elif x_time[-1] < 1:
+        x_time *= 1e3
+        x_label = "Time [ms]"
+    else:
+        x_label = "Time [s]"
+    return x_time, x_label
+
+
+def get_sample_rate_display_format(sample_rate):
+    if sample_rate < 1e3:
+        return f"{sample_rate:.2f} Hz"
+    if sample_rate < 1e6:
+        return f"{sample_rate/1e3:.2f} KHz"
+    if sample_rate < 1e9:
+        return f"{sample_rate/1e6:.2f} MHz"
+    return f"{sample_rate/1e9:.2f} GHz"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,59 @@
+
+from pandas import DataFrame
+import matplotlib.pyplot as plt
+
+
+
+def get_result_files(gen_reports):
+    if gen_reports:
+        from create_files import results_file, results_dir, csv, open_files_and_dirs
+        if results_file is None:
+            file, dir_name, csv_path = open_files_and_dirs()
+        else:
+            file = results_file
+            dir_name = results_dir
+            csv_path = csv
+    else:
+        file = []
+        dir_name = []
+        csv_path = []
+
+    return file, dir_name, csv_path
+
+
+def save_data_to_csv(csv_vals, csv_file):
+    df = DataFrame(csv_vals)
+    df.to_csv(csv_file)
+    return
+
+
+def plot_to_file(title, data, dir_name, filename, xlabel=None, ylabel=None, data1=None, data_marked=None):
+    # Saves the plots in a separate folder
+    # Arguments:
+    #    title  -- Title of the plot
+    #    data  -- Data to be plotted
+    #    filename  -- Name of the file with the plot
+    # Keyword Arguments:
+    #    xlabel  -- Label of x-Axis (default: {None})
+    #    ylabel  -- Label of y-Axis(default: {None})
+    #    data1  --  Data that should be plotted on the same plot(default: {None})
+    #    data_marked -- Data that represents specific points on the plot(default: {None})
+    # plot the signals in a separate folder
+    plt.title(title)
+    if xlabel is not None:  # if xlabel and ylabel are not specified there will be default values
+        plt.xlabel(xlabel)
+    else:
+        plt.xlabel('Samples')
+    if ylabel is not None:
+        plt.ylabel(ylabel)
+    else:
+        plt.ylabel('Voltage [V]')
+    plt.grid(visible=True)
+    plt.plot(data)  # if a second set of data must be printed (for ch0 and ch1 phase difference in this case)
+    if data1 is not None:
+        plt.plot(data1)
+    if data_marked is not None:
+        plt.plot(data_marked, data[data_marked], 'xr')        
+    plt.savefig(dir_name + "/" + filename)
+    plt.close()
+    return

--- a/tests/m2k_digital_test.py
+++ b/tests/m2k_digital_test.py
@@ -1,8 +1,9 @@
 import unittest
 import libm2k
-from digital_functions import dig_reset, set_digital_trigger, check_digital_channels_state, check_digital_output, \
-    check_digital_trigger, check_open_drain_mode, test_kernel_buffers, test_last_sample_hold, test_pattern_generator_pulse
+from digital_functions import set_digital_trigger, check_digital_channels_state, check_digital_output, \
+    check_digital_trigger, check_open_drain_mode, test_kernel_buffers, test_pattern_generator_pulse
 from digital_functions import test_digital_cyclic_buffer
+import reset_def_values as reset
 from open_context import ctx, dig, d_trig
 import logger
 from repeat_test import repeat

--- a/tests/main.py
+++ b/tests/main.py
@@ -75,7 +75,8 @@ if __name__ == "__main__":
               "test_shapes_ch1\n"
               "test_voltmeter\n"
               "test_buffer_transition_glitch\n"
-              "test_last_sample_hold\n")
+              "test_last_sample_hold\n"
+              "test_aout_triggering\n")
         print("\n ===== class B_TriggerTests ===== \n")
         print(" ===== tests ====== \n")
         print("test_1_trigger_object\n"

--- a/tests/main.py
+++ b/tests/main.py
@@ -74,7 +74,8 @@ if __name__ == "__main__":
               "test_shapes_ch0\n"
               "test_shapes_ch1\n"
               "test_voltmeter\n"
-              "test_buffer_transition_glitch\n")
+              "test_buffer_transition_glitch\n"
+              "test_last_sample_hold\n")
         print("\n ===== class B_TriggerTests ===== \n")
         print(" ===== tests ====== \n")
         print("test_1_trigger_object\n"

--- a/tests/reset_def_values.py
+++ b/tests/reset_def_values.py
@@ -56,3 +56,17 @@ def trigger(trig):
     trig.setAnalogDelay(0)
 
     return
+
+
+def digital(dig: libm2k.M2kDigital):
+    # Sets default values for digital parameters
+    # Arguments:
+    #    dig  -- Digital object
+
+    dig.setSampleRateIn(10000)
+    dig.setSampleRateOut(10000)
+    dig.setCyclic(True)
+    dig.setDirection(0b1111111111111111)
+    for i in range(16):
+        dig.setOutputMode(i, 1)
+    dig.enableAllOut(True)

--- a/tests/shapefile.py
+++ b/tests/shapefile.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import numpy as np
 import math
 
@@ -6,7 +7,7 @@ import math
 
 
 # signals that will be sent to output buffer
-def shape_gen(n):
+def shape_gen(n, amplitude: float = 1.0, offset: float = 0.0):
     # Generates different signal shapes that will be sent to the output
     # Arguments:
     #    n  -- Number of samples in the output buffer
@@ -15,18 +16,18 @@ def shape_gen(n):
 
     shape = [[]]
     # generate sine wave
-    sine = np.sin(np.linspace(-np.pi, np.pi, n))
+    sine = amplitude*(np.sin(np.linspace(-np.pi, np.pi, n))) + offset
     # generate square wave
-    square = np.append(np.linspace(-1, -1, int(n / 2)), np.linspace(1, 1, int(n / 2)))
+    square = amplitude * np.append(np.linspace(-1, -1, int(n / 2)), np.linspace(1, 1, int(n / 2))) + offset
 
     # generate triangle
-    triangle = np.append(np.linspace(-1, 1, int(n / 2)), np.linspace(1, -1, int(n / 2)))
+    triangle = amplitude * np.append(np.linspace(-1, 1, int(n / 2)), np.linspace(1, -1, int(n / 2))) + offset
 
     # generate rising ramp
-    rising_ramp = np.linspace(-1, 1, n)
+    rising_ramp = amplitude * np.linspace(-1, 1, n) + offset
 
     # generate falling ramp
-    falling_ramp = np.linspace(1, -1, n)
+    falling_ramp = amplitude * np.linspace(1, -1, n) + offset
 
     # shape and reference shape buffers
     shape = [sine, square, triangle, rising_ramp, falling_ramp]
@@ -58,3 +59,11 @@ def shape_name():
 
     shape_name = ['Sine', 'Square', 'Triangle', 'Rising_ramp', 'Falling_ramp']
     return shape_name
+
+
+class Shape(Enum):
+    SINE = 0
+    SQUARE = 1
+    TRIANGLE = 2
+    RISING_RAMP = 3
+    FALLING_RAMP = 4


### PR DESCRIPTION
- Validate last sample hold functionality.
- Validate DAC triggering.
- Validate that a reset to the M2kAnalogOut  brings the channel to 0V using the RAW attribute as source.

The tests cover the new features introduced, and detect bugs and issues encountered during development