### PR TITLE
ci/docs: delete dangling libiio build directory

### DIFF
--- a/CI/ubuntu/doxygen.sh
+++ b/CI/ubuntu/doxygen.sh
@@ -36,6 +36,7 @@ then
 
         sudo rm -rf ${TOP_DIR}/doc
         sudo rm -rf ${TOP_DIR}/glog
+        sudo rm -rf ${TOP_DIR}/libiio
         sudo rm -rf ${TOP_DIR}/build
 
 	# Need to create a .nojekyll file to allow filenames starting with an underscore

--- a/CI/ubuntu/make_linux
+++ b/CI/ubuntu/make_linux
@@ -32,7 +32,7 @@ handle_doxygen() {
 	make && sudo make install
 	make doc
 	cd ..
-	./CI/ubuntu/doxygen.sh
+	${TOP_DIR}/CI/ubuntu/doxygen.sh
 }
 
 handle_ubuntu_docker() {


### PR DESCRIPTION
- The build directory for libiio was left dangling, causing documentation generation to fail as it was recognized as a submodule.