### PR TITLE
Fix v1 port for current libiio APIs

### DIFF
--- a/src/context_impl_v1.cpp
+++ b/src/context_impl_v1.cpp
@@ -76,44 +76,22 @@ void ContextImpl::deinitialize()
 
 bool ContextImpl::iioDevHasAttribute(iio_device* dev, std::string const& attr)
 {
-	unsigned int nb_attr = iio_device_get_attrs_count(dev);
-	for (unsigned int i = 0; i < nb_attr; i++) {
-		const struct iio_attr *attr_i = iio_device_get_attr(dev, i);
-		if (attr_i == NULL) {
-			continue;
-		}
-		const char *attr_name = iio_attr_get_name(attr_i);
-		std::size_t found = std::string(attr_name).find(attr);
-		if (found != std::string::npos) {
-			return true;
-		}
-	}
-	return false;
+	return iio_device_find_attr(dev, attr.c_str()) != NULL;
 }
 
 bool ContextImpl::iioDevBufferHasAttribute(iio_device *dev, const std::string &attr)
 {
-	// TBD buffers need to be created in order to check their attributes
-//	const char *attribute = iio_device_find_buffer_attr(dev, attr.c_str());
-//	return attribute != nullptr;
-	return true;
+	struct iio_buffer *buf = iio_device_get_buffer(dev, 0);
+	if (!buf)
+		return false;
+	if (iio_buffer_find_attr(buf, attr.c_str()))
+		return true;
+	return false;
 }
 
 bool ContextImpl::iioChannelHasAttribute(iio_channel* chn, std::string const& attr)
 {
-	unsigned int nb_attr = iio_channel_get_attrs_count(chn);
-	for (unsigned int i = 0; i < nb_attr; i++) {
-		const struct iio_attr *attr_i = iio_channel_get_attr(chn, i);
-		if (attr_i == NULL) {
-			continue;
-		}
-		const char *attr_name = iio_attr_get_name(attr_i);
-		std::size_t found = std::string(attr_name).find(attr);
-		if (found != std::string::npos) {
-			return true;
-		}
-	}
-	return false;
+	return iio_channel_find_attr(chn, attr.c_str()) != NULL;
 }
 
 DEVICE_DIRECTION ContextImpl::getIioDeviceDirection(std::string dev_name)

--- a/src/utils/buffer_v1.cpp
+++ b/src/utils/buffer_v1.cpp
@@ -45,7 +45,10 @@ Buffer::Buffer(struct iio_device *dev, struct iio_channels_mask *mask) {
 	m_buffer = nullptr;
 	m_block = nullptr;
 	m_block_enqueued = false;
-	m_stream = nullptr;
+	m_rx_blocks = {};
+	m_rx_head = 0;
+	m_current_rx_block = nullptr;
+	m_buf_stream = nullptr;
 	m_last_nb_samples = 0;
 	m_nb_kernel_buffers = 4;
 }
@@ -67,14 +70,9 @@ void Buffer::initializeBuffer(unsigned int size, bool cyclic, bool output, bool 
 	* old buffer must be destroyed and a new one must be created*/
 	if (!m_buffer) {
 		if (m_mask) {
-			m_buffer = iio_device_create_buffer(m_dev, 0, m_mask);
-			int buf_err = iio_err(m_buffer);
-			if (buf_err) {
-				m_buffer = nullptr;
-				if (buf_err == -ETIMEDOUT) {
-					THROW_M2K_EXCEPTION("Buffer: Cannot create the buffer", libm2k::EXC_TIMEOUT, -ETIMEDOUT);
-				}
-				THROW_M2K_EXCEPTION("Buffer: Cannot create the buffer", libm2k::EXC_RUNTIME_ERROR, buf_err);
+			m_buffer = iio_device_get_buffer(m_dev, 0);
+			if (!m_buffer) {
+				THROW_M2K_EXCEPTION("Buffer: Cannot get buffer from device", libm2k::EXC_RUNTIME_ERROR);
 			}
 		} else {
 			LIBM2K_LOG(INFO, "[FAIL] Buffer NOT created, no mask provided.");
@@ -92,29 +90,73 @@ void Buffer::initializeBuffer(unsigned int size, bool cyclic, bool output, bool 
 
 		m_last_nb_samples = size;
 		if (cyclic && output) {
-			ssize_t sample_size = iio_device_get_sample_size(m_dev, m_mask);
-			m_block = iio_buffer_create_block(m_buffer, sample_size * m_last_nb_samples);
-			int ret = iio_err(m_block);
+			m_buf_stream = iio_buffer_open(m_buffer, m_mask);
+			int ret = iio_err(m_buf_stream);
 			if (ret) {
+				m_buf_stream = nullptr;
+				THROW_M2K_EXCEPTION("Buffer: Cannot open cyclic buffer stream", libm2k::EXC_RUNTIME_ERROR, ret);
+				return;
+			}
+			ssize_t sample_size = iio_device_get_sample_size(m_dev, m_mask);
+			m_block = iio_buffer_stream_create_block(m_buf_stream, sample_size * m_last_nb_samples);
+			ret = iio_err(m_block);
+			if (ret) {
+				m_block = nullptr;
 				destroy();
-				THROW_M2K_EXCEPTION("Buffer: Cannot create block", libm2k::EXC_RUNTIME_ERROR, ret);
+				THROW_M2K_EXCEPTION("Buffer: Cannot create cyclic block", libm2k::EXC_RUNTIME_ERROR, ret);
 				return;
 			}
 		} else {
-			m_stream = iio_buffer_create_stream(m_buffer, m_nb_kernel_buffers, size);
-			int ret = iio_err(m_stream);
-			if (ret) {
-				destroy();
-				// timeout error code
-				THROW_M2K_EXCEPTION("Buffer: Cannot create stream", libm2k::EXC_RUNTIME_ERROR, ret);
-				return;
-			}
 			if (output) {
-				m_block = (struct iio_block*)iio_stream_get_next_block(m_stream);
+				m_buf_stream = iio_buffer_open(m_buffer, m_mask);
+				int ret = iio_err(m_buf_stream);
+				if (ret) {
+					m_buf_stream = nullptr;
+					destroy();
+					THROW_M2K_EXCEPTION("Buffer: Cannot open TX buffer stream", libm2k::EXC_RUNTIME_ERROR, ret);
+					return;
+				}
+				ssize_t sample_size = iio_device_get_sample_size(m_dev, m_mask);
+				m_block = iio_buffer_stream_create_block(m_buf_stream, sample_size * size);
 				ret = iio_err(m_block);
 				if (ret) {
+					m_block = nullptr;
 					destroy();
-					THROW_M2K_EXCEPTION("Buffer: Cannot get next block", libm2k::EXC_RUNTIME_ERROR, ret);
+					THROW_M2K_EXCEPTION("Buffer: Cannot create TX block", libm2k::EXC_RUNTIME_ERROR, ret);
+					return;
+				}
+			} else {
+				m_buf_stream = iio_buffer_open(m_buffer, m_mask);
+				int ret = iio_err(m_buf_stream);
+				if (ret) {
+					m_buf_stream = nullptr;
+					destroy();
+					THROW_M2K_EXCEPTION("Buffer: Cannot open RX buffer stream", libm2k::EXC_RUNTIME_ERROR, ret);
+					return;
+				}
+				ssize_t sample_size = iio_device_get_sample_size(m_dev, m_mask);
+				m_rx_blocks.resize(m_nb_kernel_buffers, nullptr);
+				for (unsigned int i = 0; i < m_nb_kernel_buffers; i++) {
+					m_rx_blocks[i] = iio_buffer_stream_create_block(m_buf_stream, sample_size * size);
+					ret = iio_err(m_rx_blocks[i]);
+					if (ret) {
+						m_rx_blocks[i] = nullptr;
+						destroy();
+						THROW_M2K_EXCEPTION("Buffer: Cannot create RX block", libm2k::EXC_RUNTIME_ERROR, ret);
+						return;
+					}
+					ret = iio_block_enqueue(m_rx_blocks[i], 0, false);
+					if (ret) {
+						destroy();
+						THROW_M2K_EXCEPTION("Buffer: Cannot enqueue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
+						return;
+					}
+				}
+				m_rx_head = 0;
+				ret = iio_buffer_stream_start(m_buf_stream);
+				if (ret) {
+					destroy();
+					THROW_M2K_EXCEPTION("Buffer: Cannot start RX stream", libm2k::EXC_RUNTIME_ERROR, ret);
 					return;
 				}
 			}
@@ -181,22 +223,37 @@ void Buffer::pushGeneric(void *data, ssize_t data_type_size, size_t data_size, u
 			m_channel_list.at(channel)->write(m_block, (void*)data, data_type_size, data_size, true);
 		}
 		if (!cyclic) {
-			m_block = (struct iio_block*)iio_stream_get_next_block(m_stream);
-			int ret = iio_err(m_block);
+			int ret = iio_block_enqueue(m_block, 0, false);
 			if (ret) {
 				destroy();
-				THROW_M2K_EXCEPTION("Buffer: Cannot get next block", libm2k::EXC_RUNTIME_ERROR, ret);
+				THROW_M2K_EXCEPTION("Buffer: Cannot enqueue TX block", libm2k::EXC_RUNTIME_ERROR, ret);
+				return;
+			}
+			m_block_enqueued = true;
+			ret = iio_buffer_stream_start(m_buf_stream);
+			if (ret) {
+				destroy();
+				THROW_M2K_EXCEPTION("Buffer: Cannot start TX stream", libm2k::EXC_RUNTIME_ERROR, ret);
+				return;
+			}
+			ret = iio_block_dequeue(m_block, false);
+			m_block_enqueued = false;
+			if (ret) {
+				destroy();
+				THROW_M2K_EXCEPTION("Buffer: Cannot dequeue TX block", libm2k::EXC_RUNTIME_ERROR, ret);
 				return;
 			}
 		} else {
-			int err = iio_block_enqueue(m_block, 0, cyclic);
+			int err = iio_block_enqueue(m_block, 0, true);
 			if (err) {
 				THROW_M2K_EXCEPTION("Buffer: Unable to enqueue block.", libm2k::EXC_INVALID_PARAMETER, err);
 			}
 			m_block_enqueued = true;
-			err = iio_buffer_enable(m_buffer);
-			if (err) {
-				THROW_M2K_EXCEPTION("Buffer: Unable to enable buffer.", libm2k::EXC_INVALID_PARAMETER, err);
+			int start_ret = iio_buffer_stream_start(m_buf_stream);
+			if (start_ret) {
+				destroy();
+				THROW_M2K_EXCEPTION("Buffer: Cannot start TX cyclic stream", libm2k::EXC_RUNTIME_ERROR, start_ret);
+				return;
 			}
 		}
 		LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer pushed"));
@@ -261,13 +318,18 @@ void Buffer::getSamples(std::vector<unsigned short> &data, unsigned int nb_sampl
 
 	initializeBuffer(nb_samples, false, false);
 
-	const struct iio_block *block = iio_stream_get_next_block(m_stream);
-	int ret = iio_err(block);
+	if (m_current_rx_block) {
+		iio_block_enqueue(m_current_rx_block, 0, false);
+	}
+	struct iio_block *block = m_rx_blocks[m_rx_head];
+	int ret = iio_block_dequeue(block, false);
 	if (ret) {
 		destroy();
-		THROW_M2K_EXCEPTION("Buffer: Cannot get next block", libm2k::EXC_RUNTIME_ERROR, ret);
+		THROW_M2K_EXCEPTION("Buffer: Cannot dequeue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
 		return;
 	}
+	m_current_rx_block = block;
+	m_rx_head = (m_rx_head + 1) % m_rx_blocks.size();
 	LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer refilled"));
 
 	unsigned short* d_ptr = (unsigned short*)iio_block_start(block);
@@ -302,13 +364,18 @@ const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 
 	initializeBuffer(nb_samples, false, false);
 
-	const struct iio_block *block = iio_stream_get_next_block(m_stream);
-	int ret = iio_err(block);
+	if (m_current_rx_block) {
+		iio_block_enqueue(m_current_rx_block, 0, false);
+	}
+	struct iio_block *block = m_rx_blocks[m_rx_head];
+	int ret = iio_block_dequeue(block, false);
 	if (ret) {
 		destroy();
-		THROW_M2K_EXCEPTION("Buffer: Cannot get next block", libm2k::EXC_RUNTIME_ERROR, ret);
+		THROW_M2K_EXCEPTION("Buffer: Cannot dequeue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
 		return nullptr;
 	}
+	m_current_rx_block = block;
+	m_rx_head = (m_rx_head + 1) % m_rx_blocks.size();
 
 	LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer refilled"));
 
@@ -379,16 +446,21 @@ void* Buffer::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 
 	initializeBuffer(nb_samples, false, false);
 
-	if (!m_stream) {
+	if (!m_buf_stream) {
 		return nullptr;
 	}
-	const struct iio_block *block = iio_stream_get_next_block(m_stream);
-	int ret = iio_err(block);
+	if (m_current_rx_block) {
+		iio_block_enqueue(m_current_rx_block, 0, false);
+	}
+	struct iio_block *block = m_rx_blocks[m_rx_head];
+	int ret = iio_block_dequeue(block, false);
 	if (ret) {
 		destroy();
-		THROW_M2K_EXCEPTION("Buffer: Cannot get next block", libm2k::EXC_RUNTIME_ERROR, ret);
+		THROW_M2K_EXCEPTION("Buffer: Cannot dequeue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
 		return nullptr;
 	}
+	m_current_rx_block = block;
+	m_rx_head = (m_rx_head + 1) % m_rx_blocks.size();
 	LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer refilled"));
 
 	return m_channel_list.at(0)->getFirstVoid(block);
@@ -429,9 +501,8 @@ void Buffer::stop()
 		return;
 	}
 
-	if (m_buffer) {
-		// TBD watchout for cancelling buffers
-		iio_buffer_cancel(m_buffer);
+	if (m_buf_stream) {
+		iio_buffer_stream_cancel(m_buf_stream);
 	}
 
 	destroy();
@@ -441,8 +512,7 @@ void Buffer::stop()
 void Buffer::destroyBuffer()
 {
 	if (m_buffer) {
-		iio_buffer_destroy(m_buffer);
-		LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer destroyed"));
+		LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer released"));
 		m_buffer = nullptr;
 		m_last_nb_samples = 0;
 	}
@@ -451,31 +521,45 @@ void Buffer::destroyBuffer()
 
 void Buffer::destroy()
 {
-	if (m_block && !m_stream) {
-		if (m_block_enqueued) {
-			iio_block_dequeue(m_block, false);
-			m_block_enqueued = false;
-		}
-		iio_block_destroy(m_block);
-		m_block = nullptr;
-		iio_buffer_disable(m_buffer);
+	if (m_buf_stream) {
+		iio_buffer_stream_cancel(m_buf_stream);
 	}
 
-	if (m_stream) {
-		iio_stream_destroy(m_stream);
-		m_block = nullptr;
+	if (m_block_enqueued) {
+		iio_block_dequeue(m_block, false);
+		m_block_enqueued = false;
 	}
+
+	if (m_buf_stream) {
+		if (m_block) {
+			iio_block_destroy(m_block);
+		}
+		for (auto &blk : m_rx_blocks) {
+			if (blk) {
+				if (blk != m_current_rx_block) {
+					iio_block_dequeue(blk, false);
+				}
+				iio_block_destroy(blk);
+				blk = nullptr;
+			}
+		}
+		m_rx_blocks.clear();
+		m_rx_head = 0;
+		m_current_rx_block = nullptr;
+		iio_buffer_close(m_buf_stream);
+		m_buf_stream = nullptr;
+	}
+	m_block = nullptr;
 
 	LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Stream destroyed"));
-	m_stream = nullptr;
 	m_last_nb_samples = 0;
 }
 
 void Buffer::cancelBuffer()
 {
-	if (m_buffer) {
-		iio_buffer_cancel(m_buffer);
-		LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Buffer canceled"));
+	if (m_buf_stream) {
+		iio_buffer_stream_cancel(m_buf_stream);
+		LIBM2K_LOG(INFO, libm2k::buildLoggingMessage({m_dev_name}, "Stream canceled"));
 	}
 }
 
@@ -580,6 +664,9 @@ struct iio_buffer* Buffer::getBuffer()
 
 struct iio_block* Buffer::getBlock()
 {
+	if (m_current_rx_block) {
+		return m_current_rx_block;
+	}
 	return m_block;
 }
 

--- a/src/utils/buffer_v1.hpp
+++ b/src/utils/buffer_v1.hpp
@@ -92,9 +92,12 @@ private:
 	struct iio_device* m_dev;
 	struct iio_buffer* m_buffer;
 	struct iio_channels_mask *m_mask;
-	struct iio_stream *m_stream;
+	struct iio_buffer_stream *m_buf_stream;
 	struct iio_block *m_block;
 	bool m_block_enqueued;
+	std::vector<struct iio_block*> m_rx_blocks;
+	unsigned int m_rx_head;
+	struct iio_block *m_current_rx_block;
 	const char *m_dev_name;
 	unsigned int m_last_nb_samples;
 	unsigned int m_nb_kernel_buffers;

--- a/src/utils/devicegeneric_v1.cpp
+++ b/src/utils/devicegeneric_v1.cpp
@@ -507,7 +507,7 @@ string DeviceGeneric::getStringValue(unsigned int chn_idx, string attr, bool out
 std::string DeviceGeneric::setBufferStringValue(std::string attr, std::string value)
 {
 	m_buffer->setStringValue(attr, value);
-
+	return getBufferStringValue(attr);
 }
 
 std::string DeviceGeneric::getBufferStringValue(string attr_name)

--- a/tests/analog_functions.py
+++ b/tests/analog_functions.py
@@ -1227,7 +1227,7 @@ def test_timeout(ctx, ain, aout, trig, channel, dir_name, file, csv_path):
 
     timeout_val = 2  # value of the timeout, small value so timeout occurrs during test
     t_occ = False
-    in_samples = 4096
+    in_samples = 8192
     out_samples = 4096
     offset = 0.5  # average value of the signal
     suma = 0
@@ -1236,10 +1236,9 @@ def test_timeout(ctx, ain, aout, trig, channel, dir_name, file, csv_path):
     x = offset + np.sin(np.linspace(-np.pi, np.pi, out_samples))
     out_data = [x, x]  # output buffer, same signal on both analog channels
     set_trig(trig, 0, 0, libm2k.FALLING_EDGE_ANALOG, 0)  # set trigger condition
-    ctx.setTimeout(timeout_val)  # set timeout
-    ain.stopAcquisition()  # flush buffer so previous values will not influence average
-    # send data
     aout.push(out_data)
+    ain.stopAcquisition() # flush buffer so previous values will not influence average
+    ctx.setTimeout(timeout_val) # set timeout
     try:
         input_data = ain.getSamples(in_samples)  # get data
     except:


### PR DESCRIPTION
## PR Description

Fix buffer, context, and test issues preventing the v1 port from working against current libiio v1 APIs. Several libiio functions used in the original port (`iio_device_create_buffer`, `iio_buffer_enable/disable`, `iio_stream` helper) have since been removed or reworked. These commits update the code to build and pass the full hardware test suite on ADALM2000.

### Benefits

- libm2k v1 port builds and runs correctly against current libiio v1
- Full test suite passes on hardware, and the examples work as expected
- Attribute lookups are correct and use the direct find functions provided by libiio v1

### Changes

- `buffer_v1.cpp`: replace removed APIs with `iio_buffer_stream` interfaces . RX uses a 4-block ring, TX uses a single block. Replace `iio_device_create_buffer` with `iio_device_get_buffer`.
- `buffer_v1.hpp`: replace `iio_stream *m_stream` with `iio_buffer_stream *m_buf_stream` and add ring buffer state (`m_rx_blocks`, `m_rx_head`, `m_current_rx_block`)
- `context_impl_v1.cpp`: use `iio_device_find_attr` / `iio_channel_find_attr` directly instead of manual enumeration with substring matching. Fix `iioDevBufferHasAttribute` which was unconditionally returning `true`, now actually checks buffer attributes.
- `tests/analog_functions.py`: move `aout.push()` before `ctx.setTimeout()` in `test_timeout` , v1 backend doesn't complete stream_start within the short test timeout. Increase `in_samples` from 4096 to 8192 (15 full periods instead of 7.5) to stabilize the average.

### How it works

1. `initializeBuffer` retrieves the device buffer with `iio_device_get_buffer` (replaces the removed `iio_device_create_buffer`).
2. For RX: opens a stream with `iio_buffer_open`, creates 4 blocks via `iio_buffer_stream_create_block`, enqueues all of them, and starts the stream. Each `getSamples` re-enqueues the previously-read block and dequeues the next one.
3. For TX: opens stream, creates a single block, writes data, enqueues, and starts the stream. Non-cyclic dequeues synchronously before returning; cyclic enqueues with cyclic=true and repeats until destroyed.
4. `destroy()` cancels the stream, dequeues blocks, destroys all blocks, and closes the stream.

These changes only affect the v1 backend files (`*_v1.cpp`). The v0 backend is untouched.
