### PR TITLE
ci: replaced ubuntu-latest tag with specific ubuntu versions

### DIFF
--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -11,7 +11,7 @@ else
 fi
 
 $SUDO apt-get update
-$SUDO apt-get install -y build-essential cmake libiio-dev libunwind-dev libgoogle-glog-dev libserialport-dev swig python3 python3-dev python3-pip python3-setuptools dh-python mono-mcs cli-common-dev devscripts debhelper
+$SUDO apt-get install -y build-essential cmake libiio-dev libgoogle-glog-dev libserialport-dev swig python3 python3-dev python3-pip python3-setuptools dh-python mono-mcs cli-common-dev devscripts debhelper
 
 # Replace placeholders inside the debian template files
 sed -i "s/@VERSION@/$version-1/" packaging/debian/changelog

--- a/.github/scripts/create_debian.sh
+++ b/.github/scripts/create_debian.sh
@@ -11,7 +11,7 @@ else
 fi
 
 $SUDO apt-get update
-$SUDO apt-get install -y build-essential cmake libiio-dev libgoogle-glog-dev libserialport-dev swig python3 python3-dev python3-pip python3-setuptools dh-python mono-mcs cli-common-dev devscripts debhelper
+$SUDO apt-get install -y build-essential cmake libiio-dev libunwind-dev libgoogle-glog-dev libserialport-dev swig python3 python3-dev python3-pip python3-setuptools dh-python mono-mcs cli-common-dev devscripts debhelper
 
 # Replace placeholders inside the debian template files
 sed -i "s/@VERSION@/$version-1/" packaging/debian/changelog

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,8 +97,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: ubuntu-22.04
-            distro: ubuntu22
           - runs-on: ubuntu-24.04
             distro: ubuntu24
           - runs-on: ubuntu-26.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   identify_version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       app-version: ${{ steps.set_version.outputs.version }}
     steps:
@@ -92,8 +92,18 @@ jobs:
         if-no-files-found: error
 
   build_ubuntu:
-    runs-on: ubuntu-latest
     needs: identify_version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: ubuntu-22.04
+            distro: ubuntu22
+          - runs-on: ubuntu-24.04
+            distro: ubuntu24
+          - runs-on: ubuntu-26.04
+            distro: ubuntu26
+    runs-on: ${{matrix.runs-on}}
     env:
       architecture: amd64
     defaults:
@@ -118,7 +128,7 @@ jobs:
     - name: Upload debian artifacts to github
       uses: actions/upload-artifact@v7
       with:
-        name: ${{env.APP_NAME}}-ubuntu
+        name: ${{env.APP_NAME}}-${{matrix.distro}}-amd64
         path: |
           ${{env.APP_NAME}}/artifacts/*.deb
           ${{env.APP_NAME}}/artifacts/*.dsc

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -2,4 +2,4 @@ libm2k (@VERSION@) UNRELEASED; urgency=low
 
   * Automated package build.
 
- -- EngineerZone <https://ez.analog.com/sw-interface-tools/>  @DATE@
+ -- IonutMuthi <ionut.muthi@analog.com>  @DATE@

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,7 +1,7 @@
 Source: libm2k
 Section: libs
 Priority: optional
-Maintainer: EngineerZone <https://ez.analog.com/sw-interface-tools/>
+Maintainer: IonutMuthi <ionut.muthi@analog.com>
 Build-Depends: debhelper-compat (= 13),
                cmake,
                libiio-dev,


### PR DESCRIPTION
Instead of ubuntu-latest (currently ubuntu 24.04) now we cover:
* ubuntu 24.04
* ununtu 26.04