### PR TITLE
buffer_v1: fix false RX dequeue errors over network contexts

### DIFF
--- a/src/utils/buffer_v1.cpp
+++ b/src/utils/buffer_v1.cpp
@@ -323,7 +323,7 @@ void Buffer::getSamples(std::vector<unsigned short> &data, unsigned int nb_sampl
 	}
 	struct iio_block *block = m_rx_blocks[m_rx_head];
 	int ret = iio_block_dequeue(block, false);
-	if (ret) {
+	if (ret < 0) {
 		destroy();
 		THROW_M2K_EXCEPTION("Buffer: Cannot dequeue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
 		return;
@@ -369,7 +369,7 @@ const unsigned short* Buffer::getSamplesP(unsigned int nb_samples)
 	}
 	struct iio_block *block = m_rx_blocks[m_rx_head];
 	int ret = iio_block_dequeue(block, false);
-	if (ret) {
+	if (ret < 0) {
 		destroy();
 		THROW_M2K_EXCEPTION("Buffer: Cannot dequeue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
 		return nullptr;
@@ -454,7 +454,7 @@ void* Buffer::getSamplesRawInterleavedVoid(unsigned int nb_samples)
 	}
 	struct iio_block *block = m_rx_blocks[m_rx_head];
 	int ret = iio_block_dequeue(block, false);
-	if (ret) {
+	if (ret < 0) {
 		destroy();
 		THROW_M2K_EXCEPTION("Buffer: Cannot dequeue RX block", libm2k::EXC_RUNTIME_ERROR, ret);
 		return nullptr;


### PR DESCRIPTION
iio_block_dequeue() only returns 0 on success for the local backend. Over the network/serial/USB iiod-client backend, a successful dequeue returns the number of bytes transferred, which is a positive, non-zero value.  

Checking `if (ret)` treated every successful network RX dequeue as an error, tearing down the buffer and throwing on the very first getSamples() call.

Check `ret < 0` instead, matching how iiod_client_dequeue_block() actually reports success/failure.